### PR TITLE
checkout.sh should support checking out extra repositories.

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -24,7 +24,6 @@ all: build
 # To build without the cache set the environment variable
 # export DOCKER_BUILD_OPTS=--no-cache
 build:
-	@echo {\"image\": \"$(IMG):$(TAG)\"} > version.json
 	docker build ${DOCKER_BUILD_OPTS} -t $(IMG):$(TAG) .
 	docker tag $(IMG):$(TAG) $(IMG):latest
 	@echo Built $(IMG):$(TAG) and tagged with latest

--- a/images/checkout.sh
+++ b/images/checkout.sh
@@ -9,7 +9,9 @@
 # extra GitHub repositories to checkout.
 # EXTRA_REPOS should be a ; delimited list of the form
 # {REPO_ORG}/{REPO_NAME}@{SHA}
-
+#
+# For a pull request do
+# {REPO_ORG}/{REPO_NAME}@{SHA}:{PULL_NUMBER}
 set -xe
 
 SRC_DIR=$1
@@ -23,7 +25,8 @@ git clone https://github.com/${REPO_OWNER}/${REPO_NAME}.git ${SRC_DIR}/${REPO_OW
 echo Job Name = ${JOB_NAME}
 
 # See https://github.com/kubernetes/test-infra/tree/master/prow#job-evironment-variables
-cd ${SRC_DIR}/${REPO_OWNER}/${REPO_NAME}
+REPO_DIR=${SRC_DIR}/${REPO_OWNER}/${REPO_NAME}
+cd ${REPO_DIR}
 if [ ! -z ${PULL_NUMBER} ]; then
  git fetch origin  pull/${PULL_NUMBER}/head:pr
  if [ ! -z ${PULL_PULL_SHA} ]; then
@@ -44,24 +47,38 @@ git submodule init
 git submodule update
 
 # Print out the commit so we can tell from logs what we checked out.
-echo Repo is at `git describe --tags --always --dirty`
+echo ${REPO_DIR} is at `git describe --tags --always --dirty`
 git submodule
 git status
 
 # Check out any extra repos.
-IFS=';' read -ra EXTRA_REPOS <<< "${EXTRA_REPOS}"
+IFS=';' read -ra REPOS <<< "${EXTRA_REPOS}"
+echo REPOS=${REPOS}
 for r in "${REPOS[@]}"; do
-  echo "Repo ${r}" 
+  echo "Processing ${r}" 
   ORG_NAME="$(cut -d'@' -f1 <<< "$r")"
   EXTRA_ORG="$(cut -d'/' -f1 <<< "$ORG_NAME")"
   EXTRA_NAME="$(cut -d'/' -f2<<< "$ORG_NAME")"
-  SHA="$(cut -d'@' -f2 <<< "$r")"  
+  SHA_AND_PR="$(cut -d'@' -f2 <<< "$r")"  
+  SHA="$(cut -d':' -f1 <<< "$SHA_AND_PR")"  
+  EXTRA_PR="$(cut -d':' -s -f2 <<< "$SHA_AND_PR")"
   URL=https://github.com/${EXTRA_ORG}/${EXTRA_NAME}.git
   TARGET=${SRC_DIR}/${EXTRA_ORG}/${EXTRA_NAME}
   if [ ! -d ${TARGET} ]; then
   	git clone  ${URL} ${TARGET}
   	cd ${TARGET}
-  	git checkout ${SHA}
+
+  	if [ ! -z ${EXTRA_PR} ]; then
+  		git fetch origin  pull/${EXTRA_PR}/head:pr
+  		git checkout pr
+
+	  	if [ "$SHA" -ne "HEAD" ]; then
+	  		git checkout ${SHA}
+		fi  		
+  	else  	
+  		git checkout ${SHA}
+	fi  
+	echo ${TARGET} is at `git describe --tags --always --dirty`
   else
   	echo Error ${TARGET} already exists not cloning ${URL}
   fi
@@ -69,7 +86,8 @@ done
 
 # Check out the kubeflow/testing repo (unless that's the repo being tested)
 # since it contains common utilities.
-# TODO(jlewi): We might want to eventually pin to a particular version that is known to be good.
-if [ ! -d /src/kubeflow/testing ]; then
+# TODO(jlewi): We should get rid of this and just treat kubeflow/testing as
+# an EXTRA_REPOS.
+if [ ! -d ${SRC_DIR}/kubeflow/testing ]; then
 	git clone https://github.com/kubeflow/testing.git ${SRC_DIR}/kubeflow/testing
 fi	

--- a/images/checkout.sh
+++ b/images/checkout.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 #
 # This script is used to bootstrap our prow jobs.
-# The point of this script is to check out the kubeflow/kubeflow repo
-# at the commit corresponding to the Prow job. We can then
-# invoke the launcher script at that commit to submit and
-# monitor an Argo workflow
+# The point of this script is to check out repositories
+# at the commit corresponding to the Prow job. 
+#
+# In addition to understanding the prow environment variables.
+# the environment variable EXTRA_REPOS can be used to specify
+# extra GitHub repositories to checkout.
+# EXTRA_REPOS should be a ; delimited list of the form
+# {REPO_ORG}/{REPO_NAME}@{SHA}
+
 set -xe
 
 SRC_DIR=$1
@@ -37,6 +42,25 @@ git submodule update
 echo Repo is at `git describe --tags --always --dirty`
 git submodule
 git status
+
+# Check out any extra repos.
+IFS=';' read -ra EXTRA_REPOS <<< "${EXTRA_REPOS}"
+for r in "${REPOS[@]}"; do
+  echo "Repo ${r}" 
+  ORG_NAME="$(cut -d'@' -f1 <<< "$r")"
+  EXTRA_ORG="$(cut -d'/' -f1 <<< "$ORG_NAME")"
+  EXTRA_NAME="$(cut -d'/' -f2<<< "$ORG_NAME")"
+  SHA="$(cut -d'@' -f2 <<< "$r")"  
+  URL=https://github.com/${EXTRA_ORG}/${EXTRA_NAME}.git
+  TARGET=${SRC_DIR}/${EXTRA_ORG}/${EXTRA_NAME}
+  if [ ! -d ${TARGET} ]; then
+  	git clone  ${URL} ${TARGET}
+  	cd ${TARGET}
+  	git checkout ${SHA}
+  else
+  	echo Error ${TARGET} already exists not cloning ${URL}
+  fi
+done	
 
 # Check out the kubeflow/testing repo (unless that's the repo being tested)
 # since it contains common utilities.

--- a/images/checkout.sh
+++ b/images/checkout.sh
@@ -26,7 +26,12 @@ echo Job Name = ${JOB_NAME}
 cd ${SRC_DIR}/${REPO_OWNER}/${REPO_NAME}
 if [ ! -z ${PULL_NUMBER} ]; then
  git fetch origin  pull/${PULL_NUMBER}/head:pr
- git checkout ${PULL_PULL_SHA}
+ if [ ! -z ${PULL_PULL_SHA} ]; then
+ 	git checkout ${PULL_PULL_SHA}
+ else
+ 	git checkout pr
+ fi
+ 
 else
  if [ ! -z ${PULL_BASE_SHA} ]; then
  	# Its a post submit; checkout the commit to test.

--- a/images/version.json
+++ b/images/version.json
@@ -1,1 +1,0 @@
-{"image": "gcr.io/mlkube-testing/test-worker:v20180205-91039c2-dirty-529dd8"}

--- a/py/kubeflow/testing/test_util.py
+++ b/py/kubeflow/testing/test_util.py
@@ -1,0 +1,180 @@
+import errno
+import logging
+import os
+import subprocess
+import time
+from xml.etree import ElementTree
+
+import six
+
+from py import util
+
+class TestCase(object):
+  def __init__(self, class_name="", name=""):
+    self.class_name = class_name
+    self.name = name
+    # Time in seconds of the test.
+    self.time = None
+    # String describing the failure.
+    self.failure = None
+
+class TestSuite(object):
+  """A suite of test cases."""
+
+  def __init__(self, class_name):
+    self._cases = {}
+    self._class_name = class_name
+
+  def create(self, name):
+    """Create a new TestCase with the specified name.
+
+    Args:
+      name: Name for the newly created TestCase.
+
+    Returns:
+      TestCase: The newly created test case.
+
+    Raises:
+      ValueError: If a test case with the specified name already exists.
+    """
+    if name in self._cases:
+      raise ValueError("TestSuite already has a test named %s" % name)
+    self._cases[name] = TestCase()
+    self._cases[name].class_name = self._class_name
+    self._cases[name].name = name
+    return self._cases[name]
+
+  def get(self, name):
+    """Get the specified test case.
+
+    Args:
+      name: Name of the test case to return.
+
+    Returns:
+      TestCase: The requested test case.
+
+    Raises:
+      KeyError: If no test with that name exists.
+    """
+    if not name in self._cases:
+      raise KeyError("No TestCase named %s" % name)
+    return self._cases[name]
+
+  def __iter__(self):
+    """Return an iterator of TestCases."""
+    return six.itervalues(self._cases)
+
+def wrap_test(test_func, test_case):
+  """Wrap a test func.
+
+  Test_func is a callable that contains the commands to perform a particular
+  test.
+
+  Args:
+    test_func: The callable to invoke.
+    test_case: A TestCase to be populated.
+
+  Raises:
+    Exceptions are reraised to indicate test failure.
+  """
+  start = time.time()
+  try:
+    test_func()
+  except subprocess.CalledProcessError as e:
+    test_case.failure = (
+       "Subprocess failed;\n{0}".format(e.output))
+    raise
+  except Exception as e:
+    test_case.failure = "Test failed; " + e.message
+    raise
+  finally:
+    test_case.time = time.time() - start
+
+def create_xml(test_cases):
+  """Create an Element tree representing the test cases.
+
+  Args:
+    test_cases: TestSuite or List of test case objects.
+
+  Returns:
+    ElementTree: representing the elements.
+  """
+  total_time = 0
+  failures = 0
+  for c in test_cases:
+    if c.time:
+      total_time += c.time
+
+    if c.failure:
+      failures += 1
+  attrib = {"failures": "{0}".format(failures), "tests": "{0}".format(len(test_cases)),
+            "time": "{0}".format(total_time)}
+  root = ElementTree.Element("testsuite", attrib)
+
+  for c in test_cases:
+    attrib = {
+      "classname": c.class_name,
+      "name": c.name,
+    }
+    if c.time:
+      attrib["time"] = "{0}".format(c.time)
+
+    # If the time isn't set and no message is set we interpret that as
+    # the test not being run.
+    if not c.time and not c.failure:
+      c.failure = "Test was not run."
+
+    e = ElementTree.Element("testcase", attrib)
+
+    root.append(e)
+
+    if c.failure:
+      f = ElementTree.Element("failure")
+      f.text = c.failure
+      e.append(f)
+
+  t = ElementTree.ElementTree(root)
+  return t
+
+def create_junit_xml_file(test_cases, output_path, gcs_client=None):
+  """Create a JUnit XML file.
+
+  The junit schema is specified here:
+  https://www.ibm.com/support/knowledgecenter/en/SSQ2R2_9.5.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html
+
+  Args:
+    test_cases: TestSuite or List of test case objects.
+    output_path: Path to write the XML
+    gcs_client: GCS client to use if output is GCS.
+  """
+  t = create_xml(test_cases)
+  logging.info("Creating %s", output_path)
+  if output_path.startswith("gs://"):
+    b = six.StringIO()
+    t.write(b)
+
+    bucket_name, path = util.split_gcs_uri(output_path)
+    bucket = gcs_client.get_bucket(bucket_name)
+    blob = bucket.blob(path)
+    blob.upload_from_string(b.getvalue())
+  else:
+    dir_name = os.path.dirname(output_path)
+    if not os.path.exists(dir_name):
+      logging.info("Creating directory %s", dir_name)
+      try:
+        os.makedirs(dir_name)
+      except OSError as e:
+        if e.errno == errno.EEXIST:
+          # The path already exists. This is probably a race condition
+          # with some other test creating the directory.
+          # We should just be able to continue
+          pass
+        else:
+          raise
+    t.write(output_path)
+
+def get_num_failures(xml_string):
+  """Return the number of failures based on the XML string."""
+
+  e = ElementTree.fromstring(xml_string)
+  return int(e.attrib.get("failures", 0))

--- a/py/kubeflow/testing/test_util.py
+++ b/py/kubeflow/testing/test_util.py
@@ -7,7 +7,7 @@ from xml.etree import ElementTree
 
 import six
 
-from py import util
+from kubeflow.testing import util
 
 class TestCase(object):
   def __init__(self, class_name="", name=""):

--- a/py/kubeflow/testing/test_util_test.py
+++ b/py/kubeflow/testing/test_util_test.py
@@ -1,0 +1,117 @@
+from __future__ import print_function
+
+import subprocess
+import StringIO
+import tempfile
+import time
+import unittest
+
+from kubeflow.testing import test_util
+
+class XMLTest(unittest.TestCase):
+  def test_write_xml(self):
+    with tempfile.NamedTemporaryFile(delete=False) as hf:
+      pass
+
+    success = test_util.TestCase()
+    success.class_name = "some_test"
+    success.name = "first"
+    success.time = 10
+
+    failure = test_util.TestCase()
+    failure.class_name = "some_test"
+    failure.name = "first"
+    failure.time = 10
+    failure.failure = "failed for some reason."
+
+    test_util.create_junit_xml_file([success, failure], hf.name)
+    with open(hf.name) as hf:
+      output = hf.read()
+      print(output)
+    expected = ("""<testsuite failures="1" tests="2" time="20">"""
+                """<testcase classname="some_test" name="first" time="10" />"""
+                """<testcase classname="some_test" name="first" """
+                """time="10"><failure>failed for some reason.</failure>"""
+                """</testcase></testsuite>""")
+
+    self.assertEquals(expected, output)
+
+  def test_get_num_failures(self):
+    failure = test_util.TestCase()
+    failure.class_name = "some_test"
+    failure.name = "first"
+    failure.time = 10
+    failure.failure = "failed for some reason."
+
+    e = test_util.create_xml([failure])
+    s = StringIO.StringIO()
+    e.write(s)
+    xml_value = s.getvalue()
+    self.assertEquals(1, test_util.get_num_failures(xml_value))
+
+  def test_get_num_failures_success(self):
+    success = test_util.TestCase()
+    success.class_name = "some_test"
+    success.name = "first"
+    success.time = 10
+
+    e = test_util.create_xml([success])
+    s = StringIO.StringIO()
+    e.write(s)
+    xml_value = s.getvalue()
+    self.assertEquals(0, test_util.get_num_failures(xml_value))
+
+class TestSuiteTest(unittest.TestCase):
+  def testSuite(self):
+    """Test TestSuite."""
+    s = test_util.TestSuite("test_class")
+    c1 = s.create("c1")
+    c1.time = 100
+
+    c2 = s.create("c2")
+    c2.time = 200
+
+    c1_get = s.get("c1")
+    self.assertEquals(100, c1_get.time)
+
+    c2_get = s.get("c2")
+    self.assertEquals(200, c2_get.time)
+
+    names = set()
+
+    for c in s:
+      names.add(c.name)
+
+    self.assertItemsEqual(["c1", "c2"], names)
+
+class TestWrapTest(unittest.TestCase):
+  def testOk(self):
+    def ok():
+      time.sleep(1)
+
+    t = test_util.TestCase()
+    test_util.wrap_test(ok, t)
+    self.assertGreater(t.time, 0)
+    self.assertEquals(None, t.failure)
+
+  def testSubprocessError(self):
+    def run():
+      raise subprocess.CalledProcessError(10, "some command", output="some output")
+
+    t = test_util.TestCase()
+    self.assertRaises(subprocess.CalledProcessError, test_util.wrap_test, run, t)
+    self.assertGreater(t.time, 0)
+    self.assertEquals("Subprocess failed;\nsome output", t.failure)
+
+  def testGeneralError(self):
+    def run():
+      time.sleep(1)
+      raise ValueError("some error")
+
+    t = test_util.TestCase()
+    self.assertRaises(ValueError, test_util.wrap_test, run, t)
+    self.assertGreater(t.time, 0)
+    self.assertEquals("Test failed; some error", t.failure)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -28,10 +28,6 @@ MASTER_REPO_NAME = "k8s"
 
 # TODO(jlewi): Should we stream the output by polling the subprocess?
 # look at run_and_stream in build_and_push.
-#
-# TODO(jlewi): I think we can delete use_print after updating callers. that
-# was a hack to make output show up in Airflow; I think writing subprocess
-# to a file and then logging it works better.
 def run(command, cwd=None, env=None, dryrun=False):
   """Run a subprocess.
 


### PR DESCRIPTION
* We need this for E2E testing because we will need to check out multiple
  repositories. For example, to test our ksonnet configs we want to checkout
  tensorflow/k8s so that we can run the tests defined within it.

* Move test_util from kubeflow/kubeflow to this repository so we can reuse it.