### PR TITLE
Update instructions about adding a repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,13 +333,16 @@ kubectl create clusterrolebinding default-admin --clusterrole=cluster-admin --us
     * Add prow jobs to [prow/config.yaml](https://github.com/kubernetes/test-infra/pull/4951/files#diff-406185368ba7839d1459d3d51424f104)
     * Add trigger plugin to [prow/plugins.yaml](https://github.com/kubernetes/test-infra/pull/4951/files#diff-ae83e55ccb05896d5229df577d34255d)
     * Add test dashboards to [testgrid/config/config.yaml](https://github.com/kubernetes/test-infra/pull/4951/files#diff-49f154cd90facc43fda49a99885e6d17)
-    * Modify [testgrid/jenkins_verify/jenkins_validat.go](https://github.com/kubernetes/test-infra/pull/4951/files#diff-7fb4731a02dd681bbd0daada8dd2f908)
+    * Modify testgrid/cmd/config/config_test.go
        to allow presubmits for the new repo.
-1. For tensorflow/k8s configure webhooks by following these [instructions](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started.md#add-the-webhook-to-github)
-    * Use https://prow.k8s.io/hook as the target
-    * Get HMAC token from k8s test team
 1. Add the k8s bot account, k8s-ci-robot, as an admin on the repository
     * Admin privileges are needed to update status (but not comment)
     * Someone with access to the bot will need to accept the request.
 1. Follow [instructions](https://github.com/kubernetes/test-infra/tree/master/gubernator#adding-a-repository-to-the-pr-dashboard) for adding a repository to the PR
    dashboard.
+
+
+Webhooks for prow should already be configured according to these [instructions](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started.md#add-the-webhook-to-github) for the org so you shouldn't
+need to set hooks per repository.
+    * Use https://prow.k8s.io/hook as the target
+    * Get HMAC token from k8s test team


### PR DESCRIPTION
* Looks like some files moved in the kubeflow/test-infra repository
* Update instructions to reflect the fact that we now have our own org and webhooks can be set at the org level.