### PR TITLE
Add argo UI urls to gubernator metadata

### DIFF
--- a/py/kubeflow/testing/prow_artifacts.py
+++ b/py/kubeflow/testing/prow_artifacts.py
@@ -46,7 +46,7 @@ def create_started():
 # TODO(jlewi): Replace create_finished in tensorflow/k8s/py/prow.py with this
 # version. We should do that when we switch tensorflow/k8s to use Argo instead
 # of Airflow.
-def create_finished(success):
+def create_finished(success, ui_urls):
   """Create a string containing the contents for finished.json.
 
   Args:
@@ -62,7 +62,9 @@ def create_finished(success):
       # Dictionary of extra key value pairs to display to the user.
       # TODO(jlewi): Perhaps we should add the GCR path of the Docker image
       # we are running in. We'd have to plumb this in from bootstrap.
-      "metadata": {},
+      "metadata": {
+        "ui-urls": ui_urls
+      },
   }
 
   return json.dumps(finished)

--- a/py/kubeflow/testing/prow_artifacts_test.py
+++ b/py/kubeflow/testing/prow_artifacts_test.py
@@ -31,14 +31,16 @@ class TestProw(unittest.TestCase):
   def testCreateFinished(self, mock_time):  # pylint: disable=no-self-use
     """Test create finished job."""
     mock_time.return_value = 1000
-
+    test_urls = "https://example.com"
     expected = {
         "timestamp": 1000,
         "result": "FAILED",
-        "metadata": {},
+        "metadata": {
+          "ui-urls": "https://example.com"
+        },
     }
 
-    actual = prow_artifacts.create_finished(False)
+    actual = prow_artifacts.create_finished(False, test_urls)
 
     self.assertEquals(expected, json.loads(actual))
 


### PR DESCRIPTION
Would like to provide a link to workflow URLs in gubernator.

Changes made:
- Pass ui_urls into create_finished to use in the metadata.

@jlewi Does this address https://github.com/kubeflow/testing/issues/10