### PR TITLE
Taking junit results into account when computing prow job status.

### DIFF
--- a/py/kubeflow/testing/prow_artifacts_test.py
+++ b/py/kubeflow/testing/prow_artifacts_test.py
@@ -92,5 +92,29 @@ class TestProw(unittest.TestCase):
         "gs://some-bucket/pr-logs/pull/fake_org_fake_name/72"
         "/kubeflow-presubmit/100")
 
+  @mock.patch("kubeflow.testing.test_util.get_num_failures")
+  @mock.patch("kubeflow.testing.prow_artifacts._get_actual_junit_files")
+  def testCheckNoErrorsSuccess(self, mock_get_junit, mock_get_failures):
+    # Verify that check no errors returns true when there are no errors
+    gcs_client = mock.MagicMock(spec=storage.Client)
+    artifacts_dir = "gs://some_dir"
+    mock_get_junit.return_value = set(["junit_1.xml"])
+    mock_get_failures.return_value = 0
+    junit_files = ["junit_1.xml"]
+    self.assertTrue(prow_artifacts.check_no_errors(gcs_client, artifacts_dir,
+                                                   junit_files))
+
+  @mock.patch("kubeflow.testing.test_util.get_num_failures")
+  @mock.patch("kubeflow.testing.prow_artifacts._get_actual_junit_files")
+  def testCheckNoErrorsFailure(self, mock_get_junit, mock_get_failures):
+    # Verify that check no errors returns false when a junit
+    # file reports an error.
+    gcs_client = mock.MagicMock(spec=storage.Client)
+    artifacts_dir = "gs://some_dir"
+    mock_get_junit.return_value = set(["junit_1.xml"])
+    mock_get_failures.return_value = 1
+    junit_files = ["junit_1.xml"]
+    self.assertFalse(prow_artifacts.check_no_errors(gcs_client, artifacts_dir,
+                                                    junit_files))
 if __name__ == "__main__":
   unittest.main()

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -82,12 +82,13 @@ def create_started_file(bucket):
   target = os.path.join(prow_artifacts.get_gcs_dir(bucket), "started.json")
   upload_to_gcs(contents, target)
 
-def create_finished_file(bucket, success, ui_urls):
-  """Create the started file in gcs for gubernator."""
-  contents = prow_artifacts.create_finished(success, ui_urls)
+# DO NOT SUBMIT delete this.
+#def create_finished_file(bucket, success, ui_urls):
+  #"""Create the started file in gcs for gubernator."""
+  #contents = prow_artifacts.create_finished(success, ui_urls)
 
-  target = os.path.join(prow_artifacts.get_gcs_dir(bucket), "finished.json")
-  upload_to_gcs(contents, target)
+  #target = os.path.join(prow_artifacts.get_gcs_dir(bucket), "finished.json")
+  #upload_to_gcs(contents, target)
 
 def parse_config_file(config_file, root_dir):
   with open(config_file) as hf:
@@ -191,7 +192,7 @@ def run(args, file_handler): # pylint: disable=too-many-statements
     success = False
     logging.error("Time out waiting for Workflows %s to finish", ",".join(workflow_names))
   finally:
-    create_finished_file(args.bucket, success, ",".join(ui_urls))
+    prow_artifacts.finalize_prow_job(args.bucket, success, ",".join(ui_urls))
 
     # Upload logs to GCS. No logs after this point will appear in the
     # file in gcs


### PR DESCRIPTION
* When decided whether to mark a prow job as failed or succeded we need
  to explicitly look at the junit files and determine that.

* Prow won't do this automatically.

* Fix #27