### PR TITLE
fix argo uri

### DIFF
--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -143,8 +143,8 @@ def run(args, file_handler): # pylint: disable=too-many-statements
     util.run(["ks", "show", env, "-c", w.component], cwd=w.app_dir)
     util.run(["ks", "apply", env, "-c", w.component], cwd=w.app_dir)
 
-    ui_url = ("http://testing-argo.kubeflow.org/timeline/kubeflow-test-infra/{0}"
-              ";tab=workflow".format(workflow_name))
+    ui_url = ("http://testing-argo.kubeflow.org/workflows/kubeflow-test-infra/{0}"
+              "?tab=workflow".format(workflow_name))
     ui_urls.append(ui_url)
     logging.info("URL for workflow: %s", ui_url)
 


### PR DESCRIPTION
for now the `timeline` url path gave me a blank line everytime i want to access the build job. using `workflows` renders the correct result.

also the `tab` is a query (i.e. follows a `?`)