### PR TITLE
Poll for subprocess output while the process is running.

### DIFF
--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -57,18 +57,22 @@ def run(command, cwd=None, env=None, dryrun=False):
     command, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
   logging.info("Subprocess output:\n")
+  output = []
   while process.poll() is None:
     process.stdout.flush()
     for line in iter(process.stdout.readline, ''):
+      output.append(line.strip())
       logging.info(line.strip())
 
   process.stdout.flush()
   for line in iter(process.stdout.readline, ''):
+    output.append(line.strip())
     logging.info(line.strip())
 
   if process.returncode != 0:
-    raise subprocess.CalledProcessError("cmd: {0} exited with code {1}".format(
-      " ".join(cmd), process.returncode))
+    raise subprocess.CalledProcessError(process.returncode,
+                                        "cmd: {0} exited with code {1}".format(
+                                        " ".join(command), process.returncode), "\n".join(output))
 
 def run_and_output(command, cwd=None, env=None):
   logging.info("Running: %s \ncwd=%s", " ".join(command), cwd)

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -47,26 +47,28 @@ def run(command, cwd=None, env=None, dryrun=False):
     logging.info("Running: Environment:\n%s", "\n".join(lines))
 
   log_file = None
-  try:
-    if dryrun:
-      command_str = ("Dryrun: Command:\n{0}\nCWD:\n{1}\n"
-                     "Environment:\n{2}").format(" ".join(command), cwd, env)
-      logging.info(command_str)
+  
+  if dryrun:
+    command_str = ("Dryrun: Command:\n{0}\nCWD:\n{1}\n"
+                   "Environment:\n{2}").format(" ".join(command), cwd, env)
+    logging.info(command_str)
 
-    # We write stderr/stdout to a file and then read it and process it.
-    # We do this because if just inherit the handles from the parent the
-    # subprocess output doesn't show up in Airflow. This might be because
-    # we had multiple levels of processes invoking python processes.
-    with tempfile.NamedTemporaryFile(prefix="tmpRunLogs", delete=False,
-                                     mode="w") as hf:
-      log_file = hf.name
-      subprocess.check_call(command, cwd=cwd, env=env,
-                            stdout=hf,
-                            stderr=hf)
-  finally:
-    with open(log_file, "r") as hf:
-      output = hf.read()
-    logging.info("Subprocess output:\n%s", output)
+  process = subprocess.Popen(
+    command, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+  logging.info("Subprocess output:\n")
+  while process.poll() is None:
+    process.stdout.flush()
+    for line in iter(process.stdout.readline, ''):
+      logging.info(line.strip())
+
+  process.stdout.flush()
+  for line in iter(process.stdout.readline, ''):
+    logging.info(line.strip())
+
+  if process.returncode != 0:
+    raise subprocess.CalledProcessError("cmd: {0} exited with code {1}".format(
+      " ".join(cmd), process.returncode))
 
 def run_and_output(command, cwd=None, env=None):
   logging.info("Running: %s \ncwd=%s", " ".join(command), cwd)


### PR DESCRIPTION
* Don't wait for the process to finish to log the output.
* This is more convenient for streaming the output of long running commands.
* We no longer use Airflow so redirecting to a file and then reading that
  file should no longer be necessary.
* Change run to also return output and have run_and_output should be a wrapper around run
   * We can delete run_and_output after updating the callers.