### PR TITLE
Add the ability to specify arbitrary parameters in prow_config.yaml

### DIFF
--- a/py/kubeflow/testing/prow_artifacts.py
+++ b/py/kubeflow/testing/prow_artifacts.py
@@ -53,7 +53,8 @@ def create_finished(success, workflow_phase, ui_urls):
   Args:
     success: Bool indicating whether the workflow succeeded or not.
     workflow_phase: Dictionary of workflow name to phase.
-    ui_urls: Dictionary of workflow name to URL corresponding to the Argo UI for the workflows launched.
+    ui_urls: Dictionary of workflow name to URL corresponding to the Argo UI
+      for the workflows launched.
   """
   if success:
     result = "SUCCESS"
@@ -65,7 +66,7 @@ def create_finished(success, workflow_phase, ui_urls):
       # Dictionary of extra key value pairs to display to the user.
       # TODO(jlewi): Perhaps we should add the GCR path of the Docker image
       # we are running in. We'd have to plumb this in from bootstrap.
-      "metadata": {        
+      "metadata": {
       },
   }
 
@@ -206,7 +207,8 @@ def finalize_prow_job(bucket, workflow_success, workflow_phase, ui_urls):
     bucket: The bucket where results are stored.
     workflow_success: Bool indicating whether the job should be considered succeeded or failed.
     workflow_phase: Dictionary of workflow name to phase the workflow is in.
-    ui_urls: Dictionary of workflow name to URL corresponding to the Argo UI for the workflows launched.
+    ui_urls: Dictionary of workflow name to URL corresponding to the Argo UI
+      for the workflows launched.
   """
   gcs_client = storage.Client()
 

--- a/py/kubeflow/testing/prow_artifacts_test.py
+++ b/py/kubeflow/testing/prow_artifacts_test.py
@@ -29,16 +29,22 @@ class TestProw(unittest.TestCase):
   def testCreateFinished(self, mock_time):  # pylint: disable=no-self-use
     """Test create finished job."""
     mock_time.return_value = 1000
-    test_urls = "https://example.com"
+    workflow_phase = {
+      "wfA": "Succeeded"
+    }
+    test_urls = {
+      "wfA": "https://example.com",
+    }
     expected = {
         "timestamp": 1000,
         "result": "FAILED",
         "metadata": {
-          "ui-urls": "https://example.com"
+          "wfA-phase": "Succeeded",
+          "wfA-ui": "https://example.com",
         },
     }
 
-    actual = prow_artifacts.create_finished(False, test_urls)
+    actual = prow_artifacts.create_finished(False, workflow_phase, test_urls)
 
     self.assertEquals(expected, json.loads(actual))
 

--- a/py/kubeflow/testing/prow_artifacts_test.py
+++ b/py/kubeflow/testing/prow_artifacts_test.py
@@ -23,7 +23,7 @@ class TestProw(unittest.TestCase):
 
     actual = prow_artifacts.create_started()
 
-    self.assertEquals(expected, json.loads(actual))
+    self.assertEqual(expected, json.loads(actual))
 
   @mock.patch("kubeflow.testing.prow_artifacts.time.time")
   def testCreateFinished(self, mock_time):  # pylint: disable=no-self-use
@@ -46,7 +46,7 @@ class TestProw(unittest.TestCase):
 
     actual = prow_artifacts.create_finished(False, workflow_phase, test_urls)
 
-    self.assertEquals(expected, json.loads(actual))
+    self.assertEqual(expected, json.loads(actual))
 
   @mock.patch("kubeflow.testing.prow_artifacts.util.run")
   def testCopyArtifactsPresubmit(self, mock_run):  # pylint: disable=no-self-use

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -72,7 +72,7 @@ def parse_config_file(config_file, root_dir):
       i["name"], os.path.join(root_dir, i["app_dir"]), i["component"], i.get("params", {})))
   return components
 
-def run(args, file_handler): # pylint: disable=too-many-statements
+def run(args, file_handler): # pylint: disable=too-many-statements,too-many-branches
   # Print ksonnet version
   util.run(["ks", "version"])
   workflows = []
@@ -143,7 +143,8 @@ def run(args, file_handler): # pylint: disable=too-many-statements
     util.run(["ks", "param", "set", "--env=" + env, w.component, "bucket", args.bucket],
              cwd=w.app_dir)
 
-    # Set any extra params. We do this in alphabetical order to make it easier to verify in the unittest.
+    # Set any extra params. We do this in alphabetical order to make it easier to verify in
+    # the unittest.
     param_names = w.params.keys()
     param_names.sort()
     for k in param_names:

--- a/py/kubeflow/testing/run_e2e_workflow_test.py
+++ b/py/kubeflow/testing/run_e2e_workflow_test.py
@@ -21,7 +21,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
       # assertRegexpMatches uses re.search so we automatically append
       # ^ and $ so we match the beginning and end of the string.
       pattern = "^" + e + "$"
-      six.assertRegex(actual[index], pattern)
+      six.assertRegex(self, actual[index], pattern)
 
   @mock.patch("kubeflow.testing.run_e2e_workflow.prow_artifacts"
               ".finalize_prow_job")

--- a/py/kubeflow/testing/run_e2e_workflow_test.py
+++ b/py/kubeflow/testing/run_e2e_workflow_test.py
@@ -55,6 +55,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
+      ["ks", "version"],
       ["ks", "env", "add", "kubeflow-presubmit-legacy-77-123abc-1234-.*"],
       ["ks", "param", "set", "--env=.*", "workflows", "name",
            "kubeflow-presubmit-legacy-77-123abc-1234-[0-9a-z]{4}"],
@@ -79,9 +80,10 @@ class TestRunE2eWorkflow(unittest.TestCase):
       self.assertItemsMatchRegex(
         expected,
         mock_run.call_args_list[i][0][0])
-      self.assertEquals(
-         "/some/dir",
-         mock_run.call_args_list[i][1]["cwd"])
+      if i > 0:
+        self.assertEquals(
+           "/some/dir",
+           mock_run.call_args_list[i][1]["cwd"])
 
   @mock.patch("kubeflow.testing.run_e2e_workflow.prow_artifacts"
               ".finalize_prow_job")
@@ -101,6 +103,10 @@ class TestRunE2eWorkflow(unittest.TestCase):
         {"app_dir": "kubeflow/testing/workflows",
          "component": "workflows",
          "name": "wf",
+         "params": {
+           "param1": "valuea",
+           "param2": 10,
+         },
         },]
     }
     with tempfile.NamedTemporaryFile(delete=False) as hf:
@@ -126,6 +132,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
+      ["ks", "version"],
       ["ks", "env", "add", "kubeflow-presubmit-wf-77-123abc-1234-.*"],
       ["ks", "param", "set", "--env=.*", "workflows", "name",
            "kubeflow-presubmit-wf-77-123abc-1234-[0-9a-z]{4}"],
@@ -142,6 +149,12 @@ class TestRunE2eWorkflow(unittest.TestCase):
       ["ks", "param", "set",
            "--env=.*",
            "workflows", "bucket", "some-bucket"],
+      ["ks", "param", "set",
+           "--env=.*",
+           "workflows", "param1", "valuea"],
+      ["ks", "param", "set",
+           "--env=.*",
+           "workflows", "param2", "10"],
       ["ks", "show", "kubeflow-presubmit.*", "-c", "workflows"],
       ["ks", "apply", "kubeflow-presubmit.*", "-c", "workflows"],
     ]
@@ -150,9 +163,10 @@ class TestRunE2eWorkflow(unittest.TestCase):
       self.assertItemsMatchRegex(
         expected,
         mock_run.call_args_list[i][0][0])
-      self.assertEquals(
-         "/src/kubeflow/testing/workflows",
-         mock_run.call_args_list[i][1]["cwd"])
+      if i > 0:
+        self.assertEquals(
+           "/src/kubeflow/testing/workflows",
+           mock_run.call_args_list[i][1]["cwd"])
 
 if __name__ == "__main__":
   unittest.main()

--- a/py/kubeflow/testing/run_e2e_workflow_test.py
+++ b/py/kubeflow/testing/run_e2e_workflow_test.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import mock
 from kubeflow.testing import run_e2e_workflow
+import six
 import tempfile
 import yaml
 
@@ -20,7 +21,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
       # assertRegexpMatches uses re.search so we automatically append
       # ^ and $ so we match the beginning and end of the string.
       pattern = "^" + e + "$"
-      self.assertRegexpMatches(actual[index], pattern)
+      six.assertRegex(actual[index], pattern)
 
   @mock.patch("kubeflow.testing.run_e2e_workflow.prow_artifacts"
               ".finalize_prow_job")
@@ -81,7 +82,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
         expected,
         mock_run.call_args_list[i][0][0])
       if i > 0:
-        self.assertEquals(
+        self.assertEqual(
            "/some/dir",
            mock_run.call_args_list[i][1]["cwd"])
 
@@ -164,7 +165,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
         expected,
         mock_run.call_args_list[i][0][0])
       if i > 0:
-        self.assertEquals(
+        self.assertEqual(
            "/src/kubeflow/testing/workflows",
            mock_run.call_args_list[i][1]["cwd"])
 

--- a/py/kubeflow/testing/test_util_test.py
+++ b/py/kubeflow/testing/test_util_test.py
@@ -34,7 +34,7 @@ class XMLTest(unittest.TestCase):
                 """time="10"><failure>failed for some reason.</failure>"""
                 """</testcase></testsuite>""")
 
-    self.assertEquals(expected, output)
+    self.assertEqual(expected, output)
 
   def test_get_num_failures(self):
     failure = test_util.TestCase()
@@ -47,7 +47,7 @@ class XMLTest(unittest.TestCase):
     s = StringIO.StringIO()
     e.write(s)
     xml_value = s.getvalue()
-    self.assertEquals(1, test_util.get_num_failures(xml_value))
+    self.assertEqual(1, test_util.get_num_failures(xml_value))
 
   def test_get_num_failures_success(self):
     success = test_util.TestCase()
@@ -59,7 +59,7 @@ class XMLTest(unittest.TestCase):
     s = StringIO.StringIO()
     e.write(s)
     xml_value = s.getvalue()
-    self.assertEquals(0, test_util.get_num_failures(xml_value))
+    self.assertEqual(0, test_util.get_num_failures(xml_value))
 
 class TestSuiteTest(unittest.TestCase):
   def testSuite(self):
@@ -72,10 +72,10 @@ class TestSuiteTest(unittest.TestCase):
     c2.time = 200
 
     c1_get = s.get("c1")
-    self.assertEquals(100, c1_get.time)
+    self.assertEqual(100, c1_get.time)
 
     c2_get = s.get("c2")
-    self.assertEquals(200, c2_get.time)
+    self.assertEqual(200, c2_get.time)
 
     names = set()
 
@@ -92,7 +92,7 @@ class TestWrapTest(unittest.TestCase):
     t = test_util.TestCase()
     test_util.wrap_test(ok, t)
     self.assertGreater(t.time, 0)
-    self.assertEquals(None, t.failure)
+    self.assertEqual(None, t.failure)
 
   def testSubprocessError(self):
     def run():
@@ -101,7 +101,7 @@ class TestWrapTest(unittest.TestCase):
     t = test_util.TestCase()
     self.assertRaises(subprocess.CalledProcessError, test_util.wrap_test, run, t)
     self.assertGreater(t.time, 0)
-    self.assertEquals("Subprocess failed;\nsome output", t.failure)
+    self.assertEqual("Subprocess failed;\nsome output", t.failure)
 
   def testGeneralError(self):
     def run():
@@ -111,7 +111,7 @@ class TestWrapTest(unittest.TestCase):
     t = test_util.TestCase()
     self.assertRaises(ValueError, test_util.wrap_test, run, t)
     self.assertGreater(t.time, 0)
-    self.assertEquals("Test failed; some error", t.failure)
+    self.assertEqual("Test failed; some error", t.failure)
 
 if __name__ == "__main__":
   unittest.main()

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -422,7 +422,9 @@ def setup_cluster(api_client):
   if use_gpus:
     wait_for_gpu_driver_install(api_client)
 
-class TimeoutError(Exception):
+# TODO(jlewi): TimeoutError should be built in in python3 so once
+# we migrate to Python3 we should be able to get rid of this.
+class TimeoutError(Exception):  # pylint: disable=redefined-builtin
   """An error indicating an operation timed out."""
 
 GCS_REGEX = re.compile("gs://([^/]*)(/.*)?")

--- a/py/kubeflow/testing/util_test.py
+++ b/py/kubeflow/testing/util_test.py
@@ -29,12 +29,12 @@ class UtilTest(unittest.TestCase):
 
   def testSplitGcsUri(self):
     bucket, path = util.split_gcs_uri("gs://some-bucket/some/path")
-    self.assertEquals("some-bucket", bucket)
-    self.assertEquals("some/path", path)
+    self.assertEqual("some-bucket", bucket)
+    self.assertEqual("some/path", path)
 
     bucket, path = util.split_gcs_uri("gs://some-bucket")
-    self.assertEquals("some-bucket", bucket)
-    self.assertEquals("", path)
+    self.assertEqual("some-bucket", bucket)
+    self.assertEqual("", path)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
* We want to be able to parameterize our E2E workflows and invoke them
  with different parameters. For example, we want to use parameters to control
  whether a test runs on minikube or GKE.

* To support this we need to add the ability to specify parameters to pass
  to ksonnet as part of prow_config.yaml

* Improve metadata reported in Gubernator to make it easier to see results
  for multiple workflows
  * Have separate fields containing the UI URL for each workflow
  * Also report the phase of each workflow in the metadata.