### PR TITLE
Add ssh for minikube testing.

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex \
         zip \
         unzip \
         gcc \
+        ssh \
         python-dev \
         python-setuptools \
         python-pip \

--- a/images/Makefile
+++ b/images/Makefile
@@ -26,16 +26,21 @@ all: build
 # To build without the cache set the environment variable
 # export DOCKER_BUILD_OPTS=--no-cache
 build:
-	docker build ${DOCKER_BUILD_OPTS} -t $(IMG):$(TAG) .
-	docker tag $(IMG):$(TAG) $(IMG):latest
-	@echo Built $(IMG):$(TAG) and tagged with latest
+	docker build ${DOCKER_BUILD_OPTS} -t $(IMG):$(TAG) .	
+	@echo Built $(IMG):$(TAG)
 
+# Build but don't attach the latest tag. This allows manual testing/inspection of the image
+# first.
 push: build
-	gcloud docker -- push $(IMG):$(TAG)
-	gcloud docker -- push $(IMG):latest
-	@echo Pushed $(IMG) with :latest and :$(TAG) tags
+	gcloud docker -- push $(IMG):$(TAG)	
+	@echo Pushed $(IMG) with  :$(TAG) tags
 	# Tagging into a new project can be very slow but it appears to work.
 	gcloud container images add-tag --quiet $(IMG):$(TAG) $(RELEASE_WORKER):$(TAG) --verbosity=info
 	echo created $(RELEASE_WORKER):$(TAG)
+	
+push-latest: push
+	gcloud container images add-tag --quiet $(IMG):$(TAG) $(IMG):latest --verbosity=info
+	echo created $(IMG):latest
+	# Tagging into a new project can be very slow but it appears to work.	
 	gcloud container images add-tag --quiet $(RELEASE_WORKER):$(TAG) $(RELEASE_WORKER):latest --verbosity=info
 	echo created $(RELEASE_WORKER):latest

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -470,6 +470,7 @@ def load_kube_config(config_file=None, context=None,
 
   if config_file is None:
     config_file = os.path.expanduser(kube_config.KUBE_CONFIG_DEFAULT_LOCATION)
+  logging.info("Using Kubernetes config file: %s", config_file)
 
   config_persister = None
   if persist_config:


### PR DESCRIPTION
* We use ssh to execute code on the VM used for minikube.

* Modify the makefile to build the image so we can build without adding the latest tag. Gives us an
  opportunity to debug it.

* Related to #6 