### PR TITLE
Check junit files for test status

### DIFF
--- a/py/kubeflow/testing/prow_artifacts.py
+++ b/py/kubeflow/testing/prow_artifacts.py
@@ -199,6 +199,8 @@ def finalize_prow_job(bucket, workflow_success, ui_urls):
     bucket: The bucket where results are stored.
     workflow_success: Bool indicating whether the workflow succeeded or not.
     ui_urls: String corresponding to the Argo UI for the workflows launched.
+  Returns:
+    test_success: Bool indicating whether all tests succeeded.
   """
   gcs_client = storage.Client()
 
@@ -209,10 +211,14 @@ def finalize_prow_job(bucket, workflow_success, ui_urls):
   # We don't need to check the junit files for test failures because we
   # already know it failed; furthermore we can't rely on the junit files
   # if the workflow didn't succeed because not all junit files might be there.
+  test_success = True
   if workflow_success:
-    workflow_success = check_no_errors(gcs_client, artifacts_dir)
+    test_success = check_no_errors(gcs_client, artifacts_dir)
+  else:
+    test_success = False
 
   create_finished_file(bucket, workflow_success, ui_urls)
+  return test_success
 
 def main(unparsed_args=None):  # pylint: disable=too-many-locals
   logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals

--- a/py/kubeflow/testing/prow_artifacts.py
+++ b/py/kubeflow/testing/prow_artifacts.py
@@ -204,6 +204,7 @@ def finalize_prow_job(bucket, workflow_success, workflow_phase, ui_urls):
   prow job by looking at the junit files and then creating finished.json.
 
   Args
+    bucket: The bucket where results are stored.
     workflow_success: Bool indicating whether the job should be considered succeeded or failed.
     workflow_phase: Dictionary of workflow name to phase the workflow is in.
     ui_urls: Dictionary of workflow name to URL corresponding to the Argo UI
@@ -226,7 +227,7 @@ def finalize_prow_job(bucket, workflow_success, workflow_phase, ui_urls):
   else:
     test_success = False
 
-  create_finished_file(bucket, workflow_success, workflow_phase, ui_urls)
+  create_finished_file(bucket, test_success, workflow_phase, ui_urls)
   return test_success
 
 def main(unparsed_args=None):  # pylint: disable=too-many-locals

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -165,7 +165,7 @@ def run(args, file_handler): # pylint: disable=too-many-statements
     success = False
     logging.error("Time out waiting for Workflows %s to finish", ",".join(workflow_names))
   finally:
-    prow_artifacts.finalize_prow_job(args.bucket, success, ",".join(ui_urls))
+    success = prow_artifacts.finalize_prow_job(args.bucket, success, ",".join(ui_urls))
 
     # Upload logs to GCS. No logs after this point will appear in the
     # file in gcs


### PR DESCRIPTION
finalize_prow_job returns the test result.
run_e2e_workflow.run returns False if there is failure. 
run_e2e_workflow will then exit(1) if there is failure.

/cc @jlewi 

Fix https://github.com/kubeflow/kubeflow/issues/436