### PR TITLE
Use userinfo.email scope with kube API Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,16 @@ kubectl create clusterrolebinding  ${SERVICE_ACCOUNT}-admin --clusterrole=cluste
 ```
 * The service account is used to deploye Kubeflow which entails creating various roles; so it needs sufficient RBAC permission to do so.
 
+Add a clusterrolebinding that uses the numeric id of the service account as a work around for
+[ksonnet/ksonnet#396](https://github.com/ksonnet/ksonnet/issues/396)
+
+
+```
+NUMERIC_ID=`gcloud --project=kubeflow-ci iam service-accounts describe ${SERVICE_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com --format="value(oauth2ClientId)"`
+kubectl create clusterrolebinding  ${SERVICE_ACCOUNT}-numeric-id-admin --clusterrole=cluster-admin  \
+    --user=${NUMERIC_ID}
+```
+
 ### Create a GitHub Token
 
 You need to use a GitHub token with ksonnet otherwise the test quickly runs into GitHub API limits.

--- a/images/checkout.sh
+++ b/images/checkout.sh
@@ -12,6 +12,8 @@
 #
 # For a pull request do
 # {REPO_ORG}/{REPO_NAME}@{SHA}:{PULL_NUMBER}
+#
+# You can use HEAD as the sha to get the latest for a pull request.
 set -xe
 
 SRC_DIR=$1

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -431,15 +431,23 @@ def split_gcs_uri(gcs_uri):
 
 def _refresh_credentials():
   # userinfo.email scope was insufficient for authorizing requests to K8s.
+  # We need userinfo.email because role bindings can be expressed in terms
+  # of email and these won't work without email scope.
   credentials, _ = google.auth.default(
-    scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    scopes=["https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/userinfo.email"])
   request = google.auth.transport.requests.Request()
   credentials.refresh(request)
   return credentials
 
-# TODO(jlewi): This is a work around for
+# TODO(jlewi): This was originally a work around for
 # https://github.com/kubernetes-incubator/client-python/issues/339.
-# Consider getting rid of this and adopting the solution to that issue.
+#
+# There was a fix (see issue) that sets the scope but userinfo.email scope
+# wasn't included. Which I think will cause problems see
+# https://github.com/kubernetes-client/python-base/issues/54
+#
+# So as a work around we use this function to allow us to specify the scopes.
 #
 # This function is based on
 # https://github.com/kubernetes-client/python-base/blob/master/config/kube_config.py#L331

--- a/test-infra/components/debug-worker.jsonnet
+++ b/test-infra/components/debug-worker.jsonnet
@@ -41,7 +41,7 @@ local ss = {
                     "value": "/secret/gcp-credentials/key.json"
                   }
                 ], 
-                "image": "gcr.io/mlkube-testing/test-worker:latest", 
+                "image": "gcr.io/kubeflow-ci/test-worker:latest", 
                 "name": "test-container", 
                 "volumeMounts": [
                   {


### PR DESCRIPTION
* See kubernetes-client/python-base#54
* We need to provide userinfo.email scope to service accounts when with the K8s python client library.
   * K8s server needs to know the email of the service account because RBAC role bindings can be expressed in terms of the email but without the userinfo.email scope it will end up using the numeric id
    and we will get RBAC roles because of missing bindings.
* Update the debug worker to use the image in kubeflow-ci.