### PR TITLE
Cleanup the ${SRC_DIR}

### DIFF
--- a/images/checkout.sh
+++ b/images/checkout.sh
@@ -21,8 +21,6 @@ SRC_DIR=$1
 # ${SRC_DIR} to start from a clean directory
 rm -rf ${SRC_DIR}/*
 
-mkdir -p ${SRC_DIR}/${REPO_OWNER}
-
 # TODO(jlewi): We should eventually move the code for running the workflow from
 # kubeflow/kubeflow into kubeflow/testing
 git clone https://github.com/${REPO_OWNER}/${REPO_NAME}.git ${SRC_DIR}/${REPO_OWNER}/${REPO_NAME}

--- a/images/checkout.sh
+++ b/images/checkout.sh
@@ -19,7 +19,9 @@ SRC_DIR=$1
 # Since we use a shared mount, during re-runs of release
 # git clone will fail. So clean up everything under the
 # ${SRC_DIR} to start from a clean directory
-rm -rm ${SRC_DIR}/*
+rm -rf ${SRC_DIR}/*
+
+mkdir -p ${SRC_DIR}/${REPO_OWNER}
 
 # TODO(jlewi): We should eventually move the code for running the workflow from
 # kubeflow/kubeflow into kubeflow/testing


### PR DESCRIPTION
Since we use a shared mount, during re-runs of release,
git clone will fail. So clean up everything under the
${SRC_DIR} to start from a clean directory

Also cleanup trailing whitespaces