### PR TITLE
Add ssh to test-worker

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex \
     zip \
     unzip \
     gcc \
+    ssh \
     python-dev \
     python-setuptools \
     python-pip \


### PR DESCRIPTION
It was removed in https://github.com/kubeflow/testing/pull/36/files

Related https://github.com/kubeflow/testing/issues/112

/cc @pdmack 
/cc @lluunn 