### PR TITLE
Fix bytes literals in run() command

### DIFF
--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -60,7 +60,7 @@ def run(command, cwd=None, env=None, polling_interval=datetime.timedelta(seconds
     time.sleep(polling_interval.total_seconds())
 
   process.stdout.flush()
-  for line in iter(process.stdout.readline, ''):
+  for line in iter(process.stdout.readline, b''):
     output.append(line.strip())
     logging.info(line.strip())
 


### PR DESCRIPTION
Currently this does not work with python3

/cc @inc0

Similar to https://github.com/kubeflow/kubeflow/pull/759#pullrequestreview-117579486