### PR TITLE
Added optional param replicas

### DIFF
--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -242,7 +242,7 @@ def wait_for_deployment(api_client, namespace, name, timeout_minutes=2, replicas
     namespace: The name space for the deployment.
     name: The name of the deployment.
     timeout_minutes: Timeout interval in minutes.
-    replicas: number of replicas that must be running.
+    replicas: Number of replicas that must be running.
 
   Returns:
     deploy: The deploy object describing the deployment.

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -234,7 +234,7 @@ def configure_kubectl(project, zone, cluster_name):
   run(["gcloud", "--project=" + project, "container",
        "clusters", "--zone=" + zone, "get-credentials", cluster_name])
 
-def wait_for_deployment(api_client, namespace, name, timeout_minutes=2):
+def wait_for_deployment(api_client, namespace, name, timeout_minutes=2, replicas=1):
   """Wait for deployment to be ready.
 
   Args:
@@ -242,6 +242,7 @@ def wait_for_deployment(api_client, namespace, name, timeout_minutes=2):
     namespace: The name space for the deployment.
     name: The name of the deployment.
     timeout_minutes: Timeout interval in minutes.
+    replicas: number of replicas that must be running.
 
   Returns:
     deploy: The deploy object describing the deployment.
@@ -256,7 +257,7 @@ def wait_for_deployment(api_client, namespace, name, timeout_minutes=2):
 
   while datetime.datetime.now() < end_time:
     deploy = ext_client.read_namespaced_deployment(name, namespace)
-    if deploy.status.ready_replicas >= 1:
+    if deploy.status.ready_replicas >= replicas:
       logging.info("Deployment %s in namespace %s is ready", name, namespace)
       return deploy
     logging.info("Waiting for deployment %s in namespace %s", name, namespace)
@@ -275,6 +276,7 @@ def wait_for_statefulset(api_client, namespace, name):
     api_client: K8s api client to use.
     namespace: The name space for the deployment.
     name: The name of the stateful set.
+    replicas: number of replicas that must be running.
 
   Returns:
     deploy: The deploy object describing the deployment.

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -276,7 +276,6 @@ def wait_for_statefulset(api_client, namespace, name):
     api_client: K8s api client to use.
     namespace: The name space for the deployment.
     name: The name of the stateful set.
-    replicas: number of replicas that must be running.
 
   Returns:
     deploy: The deploy object describing the deployment.


### PR DESCRIPTION
function wait_for_deployment may now check custom number of replicas running


Needed for https://github.com/kubeflow/kubeflow/issues/346 , as we may want to verify that all 3 replicas are Running