### PR TITLE
upgrade ksonnet to 0.10.2 in e2e Docker image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -91,9 +91,9 @@ RUN cd /tmp && \
 # Install ksonnet
 RUN cd /tmp && \
     wget -O ks.tar.gz \
-    https://github.com/ksonnet/ksonnet/releases/download/v0.9.1/ks_0.9.1_linux_amd64.tar.gz  && \
+    https://github.com/ksonnet/ksonnet/releases/download/v0.10.2/ks_0.10.2_linux_amd64.tar.gz && \
     tar -xvf ks.tar.gz && \
-    mv ks_0.9.1_linux_amd64/ks /usr/local/bin && \
+    mv ks_0.10.2_linux_amd64/ks /usr/local/bin && \
     chmod a+x /usr/local/bin/ks
 
 RUN cd /tmp && \


### PR DESCRIPTION
ref: https://github.com/kubeflow/kubeflow/pull/837#issuecomment-390719872

I updated ksonnet version to 0.10.2 in Docker image used by our E2E tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/134)
<!-- Reviewable:end -->
