### PR TITLE
Fix gh-demo.kubeflow.org

### DIFF
--- a/dev-kubeflow-org/ks-app/components/issue-summarization-ui.jsonnet
+++ b/dev-kubeflow-org/ks-app/components/issue-summarization-ui.jsonnet
@@ -10,22 +10,98 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 local targetPort = params.containerPort;
 local labels = { app: params.name };
 
-local appService = service
-                   .new(
-  params.name,
-  labels,
-  servicePort.new(params.servicePort, targetPort)
-)
-                   .withType(params.type);
+local appService = {
+  apiVersion: "v1",
+  kind: "Service",
+  metadata: {
+    name: "issue-summarization-ui",
+    namespace: env.namespace,
+    annotations: {
+      "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind:  Mapping\nname:  issue_summarization_ui\nprefix: /issue-summarization/\nrewrite: /\nservice: issue-summarization-ui:80\n",
+    },
+  },
+  spec: {
+    ports: [
+      {
+        port: 80,
+        targetPort: 80,
+      },
+    ],
+    selector: {
+      app: "issue-summarization-ui",
+    },
+    type: params.type,
+  },
+};
 
-local appDeployment = deployment
-                      .new(
-  params.name,
-  params.replicas,
-  container
-  .new(params.name, params.image)
-  .withPorts(containerPort.new(targetPort)),
-  labels
-);
+local appDeployment = {
+  apiVersion: "apps/v1beta1",
+  kind: "Deployment",
+  metadata: {
+    name: "issue-summarization-ui",
+    namespace: env.namespace,
+  },
+  spec: {
+    replicas: 1,
+    template: {
+      metadata: {
+        labels: {
+          app: "issue-summarization-ui",
+        },
+      },
+      spec: {
+        containers: [
+          {
+            image: "gcr.io/kubeflow-images-public/issue-summarization-ui:latest",
+            env: [
+              {
+                name: "GITHUB_TOKEN",
+                valueFrom: {
+                  secretKeyRef: {
+                    name: "github-token",
+                    key: "github-token",
+                  },
+                },
+              },
+            ],
+            name: "issue-summarization-ui",
+            ports: [
+              {
+                containerPort: 80,
+              },
+            ],
+          },
+        ],
+        volumes: [
+          {
+            name: "github-token",
+            secret: {
+              secretName: "github-token",
+            },
+          },
+        ],  // volumes
+      },
+    },
+  },
+};
 
-k.core.v1.list.new([appService, appDeployment])
+// Ingress to expose the demo at gh-demo.kubeflow.org
+local uiIngress = {
+  apiVersion: "extensions/v1beta1",
+  kind: "Ingress",
+  metadata: {
+    name: params.name,
+    namespace: env.namespace,
+    annotations: {
+      "kubernetes.io/ingress.global-static-ip-name": "gh-demo-kubeflow-org",
+    },
+  },
+  spec: {
+    backend: {
+      serviceName: params.name,
+      servicePort: targetPort,
+    },
+  },
+};  // uiIngress
+
+k.core.v1.list.new([appService, appDeployment, uiIngress])

--- a/dev-kubeflow-org/ks-app/components/params.libsonnet
+++ b/dev-kubeflow-org/ks-app/components/params.libsonnet
@@ -65,7 +65,8 @@
       namespace: "kubeflow",
       replicas: 1,
       servicePort: 80,
-      type: "ClusterIP",
+      // Need node port to expose it via ingress.
+      type: "NodePort",
     },
   },
 }


### PR DESCRIPTION
* Issue Summarization UI service should be of type node port
* UI should also get GITHUB_TOKEN from a secret

* It looks like isssue-summarization-ui.jsonnet might have been signficantly
  out of date
    * There was no ingress to expose it publicly
    * Doesn't look like namespace was set correctly

Fix kubeflow/examples#118 gh-demo.kubeflow.org down
Fix kubeflow/kubeflow#871 envoy crash looping because ingress not created

/assign @ankushagarwal 
/assign @pdmack

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/140)
<!-- Reviewable:end -->
