### PR TITLE
Add exclusion for dko vendor dir

### DIFF
--- a/py/kubeflow/testing/test_py_lint.py
+++ b/py/kubeflow/testing/test_py_lint.py
@@ -38,7 +38,7 @@ def test_lint(test_case): # pylint: disable=redefined-outer-name
   dir_excludes = [
     "dashboard/frontend/node_modules",
     "kubeflow_testing",
-    "vendor",
+    "dev-kubeflow-org/ks-app/vendor",
   ]
   full_dir_excludes = [
     os.path.join(os.path.abspath(args.src_dir), f) for f in dir_excludes


### PR DESCRIPTION
Closes kubeflow/kubeflow#881

/cc @jlewi 

Where exactly are these dirs?
```
"dashboard/frontend/node_modules",
"kubeflow_testing",
```