### PR TITLE
Ignore KeyError exception in argo_client.log_status

### DIFF
--- a/py/kubeflow/testing/argo_client.py
+++ b/py/kubeflow/testing/argo_client.py
@@ -16,10 +16,16 @@ KIND = "Workflow"
 
 def log_status(workflow):
   """A callback to use with wait_for_workflow."""
-  logging.info("Workflow %s in namespace %s; phase=%s",
-           workflow["metadata"]["name"],
-           workflow["metadata"]["namespace"],
-           workflow["status"]["phase"])
+  try:
+    logging.info("Workflow %s in namespace %s; phase=%s",
+                 workflow["metadata"]["name"],
+                 workflow["metadata"]["namespace"],
+                 workflow["status"]["phase"])
+  except KeyError as e:
+    # Ignore the error and just log the stacktrace
+    # as sometimes the workflow object does not have all the fields
+    logging.exception('')
+
 
 @retry(stop_max_attempt_number=3, wait_fixed=2000,
        retry_on_exception=lambda e: not isinstance(e, util.TimeoutError))

--- a/py/kubeflow/testing/argo_client.py
+++ b/py/kubeflow/testing/argo_client.py
@@ -24,6 +24,7 @@ def log_status(workflow):
   except KeyError as e:
     # Ignore the error and just log the stacktrace
     # as sometimes the workflow object does not have all the fields
+    # https://github.com/kubeflow/testing/issues/147
     logging.exception('KeyError: %s', e)
 
 

--- a/py/kubeflow/testing/argo_client.py
+++ b/py/kubeflow/testing/argo_client.py
@@ -24,7 +24,7 @@ def log_status(workflow):
   except KeyError as e:
     # Ignore the error and just log the stacktrace
     # as sometimes the workflow object does not have all the fields
-    logging.exception('')
+    logging.exception('KeyError: %s', e)
 
 
 @retry(stop_max_attempt_number=3, wait_fixed=2000,


### PR DESCRIPTION
A lot of workflows have been flaky because of this exception.
```
ERROR|2018-06-06T21:31:19|/src/kubeflow/testing/py/kubeflow/testing/run_e2e_workflow.py|210| Exception occurred: 'status'
Traceback (most recent call last):
  File "/src/kubeflow/testing/py/kubeflow/testing/run_e2e_workflow.py", line 196, in run
    status_callback=argo_client.log_status)
  File "/usr/local/lib/python2.7/dist-packages/retrying.py", line 49, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
  File "/usr/local/lib/python2.7/dist-packages/retrying.py", line 212, in call
    raise attempt.get()
  File "/usr/local/lib/python2.7/dist-packages/retrying.py", line 247, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/usr/local/lib/python2.7/dist-packages/retrying.py", line 200, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/src/kubeflow/testing/py/kubeflow/testing/argo_client.py", line 58, in wait_for_workflows
    status_callback(results)
  File "/src/kubeflow/testing/py/kubeflow/testing/argo_client.py", line 22, in log_status
    workflow["status"]["phase"])
KeyError: 'status'
```

Fixes https://github.com/kubeflow/testing/issues/147

/assign @lluunn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/152)
<!-- Reviewable:end -->
