### PR TITLE
Add the filelock module.

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -111,10 +111,10 @@ COPY ./Pipfile ./Pipfile.lock /tmp/
 # Don't upgrade pip for now because it seems to be broken
 # https://github.com/pypa/pip/issues/5240
 RUN cd /tmp/ && \
-    pip2 install -U wheel && \
+    pip2 install -U wheel filelock && \
     pip2 install pipenv && \
     pipenv install --system --two && \
-    pip3 install -U wheel && \
+    pip3 install -U wheel filelock && \
     pip3 install pipenv && \
     pipenv install --system --three
 


### PR DESCRIPTION
* We run multiple tests in parallel that are modifying the ksonnet app directory
  I think this is leading to conflicts. So we want to use the filelock
  as a simple inter process communication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/164)
<!-- Reviewable:end -->
