### PR TITLE
Increase the timeout waiting for workflows to finish.

### DIFF
--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -193,6 +193,7 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   try:
     results = argo_client.wait_for_workflows(api_client, get_namespace(args),
                                              workflow_names,
+                                             timeout=datetime.timedelta(minutes=60),
                                              status_callback=argo_client.log_status)
     for r in results:
       phase = r.get("status", {}).get("phase")


### PR DESCRIPTION
* In kubeflow/kubeflow#1109 We are seeing lots of timeouts waiting for the
  test workflows too complete.

* Bump the timeout to 1 hour.

* Related to #166

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/167)
<!-- Reviewable:end -->
