### PR TITLE
Fix the stackdriver link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The argo UI is publicly accessible at http://testing-argo.kubeflow.org/timeline.
 
 ### Stackdriver logs
 
-Since we run our E2E tests on GKE, all logs are persisted in [Stackdriver logging](https://console.cloud.google.com/logs/viewer?project=kubeflow-ci&resource=k8s_cluster%2Flocation%2Fus-east1-d%2Fcluster_name%2Fkubeflow-testing).
+Since we run our E2E tests on GKE, all logs are persisted in [Stackdriver logging](https://console.cloud.google.com/logs/viewer?project=kubeflow-ci&resource=container%2Fcluster_name%2Fkubeflow-testing&advancedFilter=resource.type%3D"container"%0Aresource.labels.cluster_name%3D"kubeflow-testing"%0A).
 
 Viewer access to Stackdriver logs is available by joining one of the following groups
 


### PR DESCRIPTION
* We want to set the resource type to container because we are interested in
  container logs.

/assign @richardsliu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/178)
<!-- Reviewable:end -->
