### PR TITLE
Require name to be set for TestSuite.

### DIFF
--- a/py/kubeflow/testing/test_helper.py
+++ b/py/kubeflow/testing/test_helper.py
@@ -39,6 +39,8 @@ class TestSuite(junit_xml.TestSuite):
   """A suite of test cases."""
 
   def __init__(self, name, test_dir, artifacts_dir, logs_dir, **kwargs):
+    if not name:
+      raise ValueError("name must be set.")
     self.test_dir = test_dir
     self.artifacts_dir = artifacts_dir
     self.logs_dir = logs_dir


### PR DESCRIPTION
* name is used in the XMl file containing the test results. If name
  isn't set the XML file won't be created correctly and therefore
  not surfaced in gubernator correctly; see kubeflow/kubeflow#1426

* Related to kubeflow/kubeflow#1426

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/198)
<!-- Reviewable:end -->
