### PR TITLE
Adding label for 0.4.0 as area/0.4.0

### DIFF
--- a/label_sync/kubeflow_label.yml
+++ b/label_sync/kubeflow_label.yml
@@ -5,7 +5,8 @@ labels:
   name: area/api
 - color: d2b48c
   name: area/0.4.0
-- color: d2b48c
+  previously:
+  - name: release/0.4.0
   name: area/build-release
   previously:
   - name: area/release-eng

--- a/label_sync/kubeflow_label.yml
+++ b/label_sync/kubeflow_label.yml
@@ -4,6 +4,8 @@ labels:
 - color: d2b48c
   name: area/api
 - color: d2b48c
+  name: area/0.4.0
+- color: d2b48c
   name: area/build-release
   previously:
   - name: area/release-eng


### PR DESCRIPTION
adding ability for new users to add label to open issues to an area for release 0.4.0

Related to: kubeflow/community#173
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/200)
<!-- Reviewable:end -->
