### PR TITLE
Check in YAML files with current IAM policy for test and release infra projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,33 +437,6 @@ Create the PVs corresponding to external NFS
 ks apply ${ENV} -c nfs-external
 ```
 
-### Release infrastructure
-
-Our release infrastructure is largely identical to our test infrastructure
-except its more locked down.
-
-In particular, we don't expose the Argo UI publicly.
-
-Additionally we need to grant the service account access to the GCR
-registry used to host our images.
-
-```
-GCR_PROJECT=kubeflow-images-public
-gcloud projects add-iam-policy-binding ${GCR_PROJECT} \
-      --member serviceAccount:${SERVICE_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com
-      --role=roles/storage.admin
-```
-
-We also need to give access to the GCB service account to the registry
-
-```
-GCR_PROJECT=kubeflow-images-public
-GCB_SERVICE_ACCOUNT=${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com
-gcloud projects add-iam-policy-binding ${GCR_PROJECT} \
-      --member serviceAccount:${GCB_SERVICE_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com
-      --role=roles/storage.admin
-```
-
 #### Troubleshooting
 
 User or service account deploying the test infrastructure needs sufficient permissions to create the roles that are created as part deploying the test infrastructure. So you may need to run the following command before using ksonnet to deploy the test infrastructure.

--- a/release-infra/README.md
+++ b/release-infra/README.md
@@ -1,0 +1,60 @@
+
+# Release Infrastructure
+
+This page describes our release infrastructure.
+
+It also contains various config files for our release infrastruce.
+
+## IAM Policies
+
+We manage IAM policies declaratively to create a versioned history of any changes.
+Changes are not automatically applied; an appropriate owner needs to apply the changes.
+
+To get the latest changes
+
+```
+gcloud projects get-iam-policy ${PROJECT} > ${PROJECT}.iam.policy.yaml
+```
+
+To change the IAM policy
+
+1. Get the current etag by running
+
+   ```
+   gcloud projects get-iam-policy ${PROJECT} > ${PROJECT}.iam.policy.yaml
+   ```
+
+1. Create and submit a PR with the desired changes
+
+1. Ask an admin to apply changes using 
+
+   ```
+   gcloud projects set-iam-policy ${PROJECT} ${PROJECT}.iam.policy.yaml
+   ```
+
+## Release infrastructure
+
+Our release infrastructure is largely identical to our [test infrastructure](https://github.com/kubeflow/testing/blob/master/README.md)
+except its more locked down.
+
+In particular, we don't expose the Argo UI publicly.
+
+Additionally we need to grant the service account access to the GCR
+registry used to host our images.
+
+```
+GCR_PROJECT=kubeflow-images-public
+gcloud projects add-iam-policy-binding ${GCR_PROJECT} \
+      --member serviceAccount:${SERVICE_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com
+      --role=roles/storage.admin
+```
+
+We also need to give access to the GCB service account to the registry
+
+```
+GCR_PROJECT=kubeflow-images-public
+GCB_SERVICE_ACCOUNT=${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com
+gcloud projects add-iam-policy-binding ${GCR_PROJECT} \
+      --member serviceAccount:${GCB_SERVICE_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com
+      --role=roles/storage.admin
+```

--- a/release-infra/kubeflow-images-public.iam.policy.yaml
+++ b/release-infra/kubeflow-images-public.iam.policy.yaml
@@ -1,0 +1,26 @@
+bindings:
+- members:
+  - serviceAccount:service-760823423706@compute-system.iam.gserviceaccount.com
+  role: roles/compute.serviceAgent
+- members:
+  - serviceAccount:service-760823423706@container-engine-robot.iam.gserviceaccount.com
+  role: roles/container.serviceAgent
+- members:
+  - group:release-team@kubeflow.org
+  - serviceAccount:760823423706-compute@developer.gserviceaccount.com
+  - serviceAccount:760823423706@cloudservices.gserviceaccount.com
+  - serviceAccount:service-760823423706@containerregistry.iam.gserviceaccount.com
+  role: roles/editor
+- members:
+  - user:jlewi@kubeflow.org
+  role: roles/owner
+- members:
+  - serviceAccount:service-760823423706@sourcerepo-service-accounts.iam.gserviceaccount.com
+  - serviceAccount:service-760823423706@sourcerepo-service-accounts.iam.gserviceaccount.com
+  role: roles/sourcerepo.serviceAgent
+- members:
+  - serviceAccount:67369850431@cloudbuild.gserviceaccount.com
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  role: roles/storage.admin
+etag: BwVvQG9zuiE=
+version: 1

--- a/release-infra/kubeflow-releasing.iam.policy.yaml
+++ b/release-infra/kubeflow-releasing.iam.policy.yaml
@@ -1,0 +1,42 @@
+bindings:
+- members:
+  - serviceAccount:67369850431@cloudbuild.gserviceaccount.com
+  role: roles/cloudbuild.builds.builder
+- members:
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  role: roles/cloudbuild.builds.editor
+- members:
+  - serviceAccount:service-67369850431@compute-system.iam.gserviceaccount.com
+  role: roles/compute.serviceAgent
+- members:
+  - group:release-team@kubeflow.org
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  role: roles/container.admin
+- members:
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  role: roles/container.developer
+- members:
+  - serviceAccount:service-67369850431@container-engine-robot.iam.gserviceaccount.com
+  role: roles/container.serviceAgent
+- members:
+  - group:release-team@kubeflow.org
+  - serviceAccount:67369850431-compute@developer.gserviceaccount.com
+  - serviceAccount:67369850431@cloudservices.gserviceaccount.com
+  - serviceAccount:service-67369850431@containerregistry.iam.gserviceaccount.com
+  - serviceAccount:67369850431-compute@developer.gserviceaccount.com
+  - serviceAccount:67369850431@cloudservices.gserviceaccount.com
+  role: roles/editor
+- members:
+  - serviceAccount:service-67369850431@cloud-ml.google.com.iam.gserviceaccount.com
+  role: roles/ml.serviceAgent
+- members:
+  - user:jlewi@kubeflow.org
+  role: roles/owner
+- members:
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  role: roles/storage.admin
+- members:
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  role: roles/viewer
+etag: BwVvUQ9A2Hg=
+version: 1

--- a/test-infra/kubeflow-ci.iam.policy.yaml
+++ b/test-infra/kubeflow-ci.iam.policy.yaml
@@ -1,0 +1,282 @@
+bindings:
+- members:
+  - serviceAccount:e2e-2f35-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-user@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/bigquery.admin
+- members:
+  - serviceAccount:593963025935@cloudbuild.gserviceaccount.com
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  role: roles/cloudbuild.builds.builder
+- members:
+  - serviceAccount:e2e-2f35-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-user@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/cloudbuild.builds.editor
+- members:
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  role: roles/cloudbuild.builds.viewer
+- members:
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/compute.instanceAdmin.v1
+- members:
+  - serviceAccount:e2e-2f35-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-admin@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/compute.networkAdmin
+- members:
+  - serviceAccount:service-593963025935@compute-system.iam.gserviceaccount.com
+  role: roles/compute.serviceAgent
+- members:
+  - serviceAccount:593963025935@cloudservices.gserviceaccount.com
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/container.admin
+- members:
+  - serviceAccount:688881552167-compute@developer.gserviceaccount.com
+  - serviceAccount:pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
+  role: roles/container.developer
+- members:
+  - serviceAccount:service-593963025935@container-engine-robot.iam.gserviceaccount.com
+  role: roles/container.serviceAgent
+- members:
+  - serviceAccount:e2e-2f35-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-user@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/dataflow.admin
+- members:
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/deploymentmanager.editor
+- members:
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/deploymentmanager.typeEditor
+- members:
+  - serviceAccount:593963025935-compute@developer.gserviceaccount.com
+  - serviceAccount:593963025935@cloudservices.gserviceaccount.com
+  - serviceAccount:service-593963025935@containerregistry.iam.gserviceaccount.com
+  role: roles/editor
+- members:
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/file.editor
+- members:
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:service-593963025935@cloud-filer.iam.gserviceaccount.com
+  role: roles/file.serviceAgent
+- members:
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/iam.serviceAccountAdmin
+- members:
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/iam.serviceAccountKeyAdmin
+- members:
+  - serviceAccount:e2e-2f35-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-vm@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/logging.logWriter
+- members:
+  - group:ci-viewer@kubeflow.org
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/logging.viewer
+- members:
+  - serviceAccount:service-593963025935@cloud-ml.google.com.iam.gserviceaccount.com
+  role: roles/ml.serviceAgent
+- members:
+  - serviceAccount:e2e-2f35-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-vm@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/monitoring.metricWriter
+- members:
+  - group:ci-team@kubeflow.org
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  - user:jlewi@kubeflow.org
+  role: roles/owner
+- members:
+  - serviceAccount:593963025935@cloudservices.gserviceaccount.com
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/resourcemanager.projectIamAdmin
+- members:
+  - serviceAccount:e2e-2f35-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-admin@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/servicemanagement.admin
+- members:
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/serviceusage.serviceUsageAdmin
+- members:
+  - serviceAccount:e2e-2f35-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-2f35-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-admin@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-user@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/source.admin
+- members:
+  - serviceAccount:e2e-2f35-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-user@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/storage.admin
+- members:
+  - serviceAccount:67369850431-compute@developer.gserviceaccount.com
+  - serviceAccount:688881552167-compute@developer.gserviceaccount.com
+  - serviceAccount:e2e-2f35-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-vm@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-vm@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/storage.objectViewer
+- members:
+  - serviceAccount:e2e-2f35-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-3dc8-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-5260-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-8c33-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-a3e9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dcf0-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:e2e-dee9-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-7132-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-8337-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-dc2f-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-e5f4-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kfctl-f23e-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-19-3580caf-26-1324-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-2ed7199-67-0a05-user@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:z-26-ed2fa0e-70-e265-user@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/viewer
+etag: BwV2V1Zf0qA=
+version: 1


### PR DESCRIPTION
* This is the first step in modifying the current permissoins to grant
  our CI infrastructure permissions to push images to gcr.io/kubeflow-images-public

Related to:
kubeflow/testing#816 trigger docker build imagees on post-submit
kubeflow/kubeflow#1574 use prow to auto push images.