### PR TITLE
Grant permissions to test service account to push to our public registry

### DIFF
--- a/release-infra/kubeflow-images-public.iam.policy.yaml
+++ b/release-infra/kubeflow-images-public.iam.policy.yaml
@@ -22,6 +22,7 @@ bindings:
   - serviceAccount:67369850431@cloudbuild.gserviceaccount.com
   - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com   
   - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  - serviceAccount:593963025935@cloudbuild.gserviceaccount.com
   role: roles/storage.admin
-etag: BwVvQG9zuiE=
+etag: BwV2XFYyoKs=
 version: 1

--- a/release-infra/kubeflow-images-public.iam.policy.yaml
+++ b/release-infra/kubeflow-images-public.iam.policy.yaml
@@ -20,7 +20,8 @@ bindings:
   role: roles/sourcerepo.serviceAgent
 - members:
   - serviceAccount:67369850431@cloudbuild.gserviceaccount.com
-  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com   
+  - serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
   role: roles/storage.admin
 etag: BwVvQG9zuiE=
 version: 1


### PR DESCRIPTION

* This is a temporary solution to improve automation around releasing our
  images by pushing them on postsubmit.

* See
    kubeflow/kubeflow#1574 use prow to auto release images
    kubeflow/kubeflow#816 trigger image pushes on postsubmit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/211)
<!-- Reviewable:end -->
