### PR TITLE
Recreate k8s client on auth failure

### DIFF
--- a/py/kubeflow/testing/argo_client.py
+++ b/py/kubeflow/testing/argo_client.py
@@ -29,6 +29,18 @@ def log_status(workflow):
     logging.exception('KeyError: %s', e)
 
 
+def handle_retriable_exception(exception):
+  if isinstance(exception, rest.ApiException)
+    and (exception.status == 401 or exception.status == 403):
+    # Due to https://github.com/kubernetes-client/python-base/issues/59,
+    # we need to reload the kube config (which refreshes the GCP token).
+    # TODO(richardsliu): Remove this workaround when the k8s client issue
+    # is resolved.
+    util.load_kube_config()
+    return True
+  return not isinstance(exception, util.TimeoutError)
+
+
 # Wait 2^x * 1 second between retries up to a max of 10 seconds between
 # retries.
 # Retry for a maximum of 5 minutes.
@@ -39,38 +51,32 @@ def log_status(workflow):
 # https://github.com/kubeflow/testing/issues/171
 @retry(wait_exponential_multiplier=1000, wait_exponential_max=10000,
        stop_max_delay=5*60*1000,
-       retry_on_exception=lambda e: not isinstance(e, util.TimeoutError))
-def get_namespaced_custom_object_with_retries(client, namespace, name):
+       retry_on_exception=handle_retriable_exception)
+def get_namespaced_custom_object_with_retries(namespace, name):
   """Call get_namespaced_customer_object API with retries.
 
   Args:
-    client: K8s api client.
     namespace: namespace for the workflow.
     name: name of the workflow.
   """
-  try:
-    crd_api = k8s_client.CustomObjectsApi(client)
-    return crd_api.get_namespaced_custom_object(
-      GROUP, VERSION, namespace, PLURAL, name)
-  except rest.ApiException as e:
-    logging.exception("ApiException: %s", e)
-    if e.status == 401 or e.status == 403:
-      # Due to https://github.com/kubernetes-client/python-base/issues/59,
-      # we need to manually refresh the GCP token and recreate the k8s client.
-      util.load_kube_config()
-      client = k8s_client.ApiClient()
-    # Raise the same exception since it will be retried.
-    raise
+  # Due to https://github.com/kubernetes-client/python-base/issues/59,
+  # we need to recreate the API client since it may contain stale auth
+  # tokens.
+  # TODO(richardsliu): Remove this workaround when the k8s client issue
+  # is resolved.
+  client = k8s_client.ApiClient()
+  crd_api = k8s_client.CustomObjectsApi(client)
+  return crd_api.get_namespaced_custom_object(
+    GROUP, VERSION, namespace, PLURAL, name)
 
 
-def wait_for_workflows(client, namespace, names,
+def wait_for_workflows(namespace, names,
                       timeout=datetime.timedelta(minutes=30),
                       polling_interval=datetime.timedelta(seconds=30),
                       status_callback=None):
   """Wait for multiple workflows to finish.
 
   Args:
-    client: K8s api client.
     namespace: namespace for the workflow.
     names: Names of the workflows to wait for.
     timeout: How long to wait for the workflow.
@@ -89,7 +95,7 @@ def wait_for_workflows(client, namespace, names,
     all_results = []
 
     for n in names:
-      results = get_namespaced_custom_object_with_retries(client, namespace, n)
+      results = get_namespaced_custom_object_with_retries(namespace, n)
       all_results.append(results)
       if status_callback:
         status_callback(results)
@@ -112,14 +118,13 @@ def wait_for_workflows(client, namespace, names,
 
   return []
 
-def wait_for_workflow(client, namespace, name,
+def wait_for_workflow(namespace, name,
                       timeout=datetime.timedelta(minutes=30),
                       polling_interval=datetime.timedelta(seconds=30),
                       status_callback=None):
   """Wait for the specified workflow to finish.
 
   Args:
-    client: K8s api client.
     namespace: namespace for the workflow.
     name: Name of the workflow
     timeout: How long to wait for the workflow.
@@ -131,6 +136,6 @@ def wait_for_workflow(client, namespace, name,
   Raises:
     TimeoutError: If timeout waiting for the job to finish.
   """
-  results = wait_for_workflows(client, namespace, [name],
+  results = wait_for_workflows(namespace, [name],
                                timeout, polling_interval, status_callback)
   return results[0]

--- a/py/kubeflow/testing/argo_client.py
+++ b/py/kubeflow/testing/argo_client.py
@@ -29,15 +29,6 @@ def log_status(workflow):
     logging.exception('KeyError: %s', e)
 
 
-def handle_retriable_exception(exception):
-  if isinstance(exception, rest.ApiException) and exception.status == 401:
-    # See https://github.com/kubeflow/testing/issues/207.
-    # If we get an unauthorized response, just reload the kubeconfig and retry.
-    util.load_kube_config()
-    return True
-  return not isinstance(exception, util.TimeoutError)
-
-
 # Wait 2^x * 1 second between retries up to a max of 10 seconds between
 # retries.
 # Retry for a maximum of 5 minutes.
@@ -48,7 +39,7 @@ def handle_retriable_exception(exception):
 # https://github.com/kubeflow/testing/issues/171
 @retry(wait_exponential_multiplier=1000, wait_exponential_max=10000,
        stop_max_delay=5*60*1000,
-       retry_on_exception=handle_retriable_exception)
+       retry_on_exception=lambda e: not isinstance(e, util.TimeoutError))
 def get_namespaced_custom_object_with_retries(client, namespace, name):
   """Call get_namespaced_customer_object API with retries.
 
@@ -57,9 +48,19 @@ def get_namespaced_custom_object_with_retries(client, namespace, name):
     namespace: namespace for the workflow.
     name: name of the workflow.
   """
-  crd_api = k8s_client.CustomObjectsApi(client)
-  return crd_api.get_namespaced_custom_object(
-    GROUP, VERSION, namespace, PLURAL, name)
+  try:
+    crd_api = k8s_client.CustomObjectsApi(client)
+    return crd_api.get_namespaced_custom_object(
+      GROUP, VERSION, namespace, PLURAL, name)
+  except rest.ApiException as e:
+    logging.exception("ApiException: %s", e)
+    if e.status == 401 or e.status == 403:
+      # Due to https://github.com/kubernetes-client/python-base/issues/59,
+      # we need to manually refresh the GCP token and recreate the k8s client.
+      util.load_kube_config()
+      client = k8s_client.ApiClient()
+    # Raise the same exception since it will be retried.
+    raise
 
 
 def wait_for_workflows(client, namespace, names,

--- a/py/kubeflow/testing/argo_client.py
+++ b/py/kubeflow/testing/argo_client.py
@@ -30,8 +30,8 @@ def log_status(workflow):
 
 
 def handle_retriable_exception(exception):
-  if isinstance(exception, rest.ApiException)
-    and (exception.status == 401 or exception.status == 403):
+  if (isinstance(exception, rest.ApiException) and
+    (exception.status == 401 or exception.status == 403)):
     # Due to https://github.com/kubernetes-client/python-base/issues/59,
     # we need to reload the kube config (which refreshes the GCP token).
     # TODO(richardsliu): Remove this workaround when the k8s client issue

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -51,6 +51,7 @@ from kubeflow.testing import util
 import uuid
 import sys
 import yaml
+import time
 
 # The namespace to launch the Argo workflow in.
 def get_namespace(args):
@@ -161,6 +162,9 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
             break
         if dir_modified:
           break
+
+    logging.info("Sleeping...")
+    time.sleep(3660)
 
     # Only consider modified files on presubmit. On postsubmit we run
     # all tests.

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -50,7 +50,6 @@ from kubeflow.testing import util
 import uuid
 import sys
 import yaml
-import time
 
 # The namespace to launch the Argo workflow in.
 def get_namespace(args):
@@ -160,9 +159,6 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
             break
         if dir_modified:
           break
-
-    logging.info("Sleeping...")
-    time.sleep(3660)
 
     # Only consider modified files on presubmit. On postsubmit we run
     # all tests.

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -42,7 +42,6 @@ import argparse
 import datetime
 import fnmatch
 import logging
-from kubernetes import client as k8s_client
 import os
 import tempfile
 from kubeflow.testing import argo_client
@@ -133,7 +132,6 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   util.configure_kubectl(args.project, args.zone, args.cluster)
   util.load_kube_config()
 
-  api_client = k8s_client.ApiClient()
   workflow_names = []
   ui_urls = {}
 
@@ -241,7 +239,7 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   success = True
   workflow_phase = {}
   try:
-    results = argo_client.wait_for_workflows(api_client, get_namespace(args),
+    results = argo_client.wait_for_workflows(get_namespace(args),
                                              workflow_names,
                                              timeout=datetime.timedelta(minutes=60),
                                              status_callback=argo_client.log_status)

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -497,6 +497,8 @@ def load_kube_config(config_file=None,
     kubernetes_configuration.Configuration.set_default(config)
   else:
     loader.load_and_set(client_configuration) # pylint: disable=too-many-function-args
+  # Dump the loaded config.
+  run(["kubectl", "config", "view"])
 
 
 def maybe_activate_service_account():

--- a/py/kubeflow/tests/argo_client_test.py
+++ b/py/kubeflow/tests/argo_client_test.py
@@ -12,13 +12,14 @@ class ArgoClientTest(unittest.TestCase):
     self.test_dir = os.path.join(os.path.dirname(__file__), "test-data")
 
   def test_wait_for_workflow(self):
-    with mock.patch("kubeflow.testing.argo_client.k8s_client.ApiClient") as api_client:
+    with mock.patch("kubeflow.testing.argo_client.k8s_client.ApiClient") as mock_client:
       with open(os.path.join(self.test_dir, "successful_workflow.yaml")) as hf:
         response = yaml.load(hf)
 
-      api_client.call_api.return_value = response
-      result = argo_client.wait_for_workflow("some-namespace", "some-set")
-      self.assertIsNotNone(result)
+        client = mock_client.return_value
+        client.call_api.return_value = response
+        result = argo_client.wait_for_workflow("some-namespace", "some-set")
+        self.assertIsNotNone(result)
 
 if __name__ == "__main__":
   unittest.main()

--- a/py/kubeflow/tests/argo_client_test.py
+++ b/py/kubeflow/tests/argo_client_test.py
@@ -12,8 +12,7 @@ class ArgoClientTest(unittest.TestCase):
     self.test_dir = os.path.join(os.path.dirname(__file__), "test-data")
 
   def test_wait_for_workflow(self):
-    with mock.patch("kubeflow.testing.argo_client.k8s_client.ApiClient")
-      as api_client:
+    with mock.patch("kubeflow.testing.argo_client.k8s_client.ApiClient") as api_client:
       with open(os.path.join(self.test_dir, "successful_workflow.yaml")) as hf:
         response = yaml.load(hf)
 

--- a/py/kubeflow/tests/argo_client_test.py
+++ b/py/kubeflow/tests/argo_client_test.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import unittest
 
 from kubeflow.testing import argo_client
-from kubernetes import client as k8s_client
 import mock
 import os
 import yaml
@@ -13,14 +12,14 @@ class ArgoClientTest(unittest.TestCase):
     self.test_dir = os.path.join(os.path.dirname(__file__), "test-data")
 
   def test_wait_for_workflow(self):
-    api_client = mock.MagicMock(spec=k8s_client.ApiClient)
+    with mock.patch("kubeflow.testing.argo_client.k8s_client.ApiClient")
+      as api_client:
+      with open(os.path.join(self.test_dir, "successful_workflow.yaml")) as hf:
+        response = yaml.load(hf)
 
-    with open(os.path.join(self.test_dir, "successful_workflow.yaml")) as hf:
-      response = yaml.load(hf)
-
-    api_client.call_api.return_value = response
-    result = argo_client.wait_for_workflow(api_client, "some-namespace", "some-set")
-    self.assertIsNotNone(result)
+      api_client.call_api.return_value = response
+      result = argo_client.wait_for_workflow("some-namespace", "some-set")
+      self.assertIsNotNone(result)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
This is a work around for kubernetes-client/python-base#59

There is a bug in the python K8s client preventing GCP auth tokens from being refreshed when they expire.

* As a result our E2E tests fail waiting for workflows that take more than an hour. In this case, the OAuth token expires so the requests to get workspace status fail with unauthorized 

see
    #207  - Argo client should refresh credentials if OAuth token expires
   #204 - argo_client doesn't handle retries correctly.
   


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/215)
<!-- Reviewable:end -->
