### PR TITLE
Increase timeout in E2E workflow from 1 to 3 hours

### DIFF
--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -237,7 +237,7 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   try:
     results = argo_client.wait_for_workflows(get_namespace(args),
                                              workflow_names,
-                                             timeout=datetime.timedelta(minutes=60),
+                                             timeout=datetime.timedelta(minutes=180),
                                              status_callback=argo_client.log_status)
     for r in results:
       phase = r.get("status", {}).get("phase")


### PR DESCRIPTION
Recently we added presubmit and postsubmit workflows to build Docker images. Some of them can take over 2 hours to build, so we need to increase the timeout in our e2e workflows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/216)
<!-- Reviewable:end -->
