### PR TITLE
Add log for why triggering a workflow

### DIFF
--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -156,6 +156,8 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
         for d in w.include_dirs:
           if fnmatch.fnmatch(f, d):
             dir_modified = True
+            logging.info("Triggering workflow %s because %s in dir %s is modified.",
+                         w.name, f, d)
             break
         if dir_modified:
           break

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -294,6 +294,7 @@ def wait_for_deployment(api_client,
 
   logging.error("Timeout waiting for deployment %s in namespace %s to be "
                 "ready", name, namespace)
+  run(["kubectl", "describe", "deployment", "-n", namespace, name])
   raise TimeoutError(
     "Timeout waiting for deployment {0} in namespace {1}".format(
       name, namespace))


### PR DESCRIPTION
For https://github.com/kubeflow/kubeflow/issues/1617

Also add logs to describe the deployment when timeout waiting for it.

/cc @richardsliu @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/217)
<!-- Reviewable:end -->
