### PR TITLE
Enable workflow scoping for postsubmit jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ configured for the repository (see these [instructions](#prow-setup) for info on
        ```
        This configures the `unittests` workflow to only run during presubmit jobs, and only if there are changes under directories `foo` or `bar`.
 
-     * **include_dirs** is only considered for presubmit jobs
-
 1. Create a prow job for that repository
    * The command for the prow job should be set via the entrypoint baked into the Docker image
    * This way we can change the Prow job just by pushing a docker image and we don't need to update the prow config.


### PR DESCRIPTION
Previously the "include_dirs" parameter in prow_config for scoping workflows is only considered for presubmit jobs. Recently we've added postsubmit jobs that build/push Docker images, and these can be time/resource-consuming. This change adds scoping abilities to postsubmit jobs, using the command
`git diff --name-only HEAD^ HEAD` to compare against the last commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/218)
<!-- Reviewable:end -->
