### PR TITLE
Allow checkout.sh to process branch name

### DIFF
--- a/images/checkout.sh
+++ b/images/checkout.sh
@@ -14,6 +14,9 @@
 # {REPO_ORG}/{REPO_NAME}@{SHA}:{PULL_NUMBER}
 #
 # You can use HEAD as the sha to get the latest for a pull request.
+#
+# To checkout a specific branch (e.g. "v0.3-branch"), set the
+# {BRANCH_NAME} environment variable.
 set -xe
 
 SRC_DIR=$1
@@ -36,6 +39,12 @@ if [ ! -z ${PULL_NUMBER} ]; then
  else
  	git checkout pr
  fi
+
+elif [ ! -z ${BRANCH_NAME} ]; then
+  # Periodic jobs don't have pull numbers or commit SHAs, so we pass in the
+  # branch name from the config yaml file.
+  git fetch origin
+  git checkout ${BRANCH_NAME}
  
 else
  if [ ! -z ${PULL_BASE_SHA} ]; then


### PR DESCRIPTION
This change allows checkout.sh to checkout a branch (e.g. v0.3-branch) on a repository. This is to allow periodic Prow jobs to run against specific release branches.

A separate PR will be made to pass in the environment variables for periodic jobs.

Related to #214

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/219)
<!-- Reviewable:end -->
