### PR TITLE
Compute postsubmit file diffs by PULL_BASE_SHA

### DIFF
--- a/images/checkout.sh
+++ b/images/checkout.sh
@@ -14,6 +14,9 @@
 # {REPO_ORG}/{REPO_NAME}@{SHA}:{PULL_NUMBER}
 #
 # You can use HEAD as the sha to get the latest for a pull request.
+#
+# To checkout a specific branch (e.g. "v0.3-branch"), set the
+# {BRANCH_NAME} environment variable.
 set -xe
 
 SRC_DIR=$1
@@ -36,6 +39,12 @@ if [ ! -z ${PULL_NUMBER} ]; then
  else
  	git checkout pr
  fi
+
+elif [ ! -z ${BRANCH_NAME} ]; then
+  # Periodic jobs don't have pull numbers or commit SHAs, so we pass in the
+  # branch name from the config yaml file.
+  git fetch origin
+  git checkout ${BRANCH_NAME}
  
 else
  if [ ! -z ${PULL_BASE_SHA} ]; then

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -114,6 +114,8 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   # Print ksonnet version
   util.run(["ks", "version"])
   job_type = os.getenv("JOB_TYPE")
+  repo_owner = os.getenv("REPO_OWNER")
+  repo_name = os.getenv("REPO_NAME")
   pull_base_sha = os.getenv("PULL_BASE_SHA")
 
   # For presubmit/postsubmit jobs, find the list of files changed by the PR.
@@ -126,7 +128,7 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   changed_files = []
   if job_type == "presubmit" or job_type == "postsubmit":
     changed_files = util.run(diff_command,
-      cwd=os.path.join(args.repos_dir, os.getenv("REPO_OWNER"), os.getenv("REPO_NAME"))).splitlines()
+      cwd=os.path.join(args.repos_dir, repo_owner, repo_name)).splitlines()
 
   for f in changed_files:
     logging.info("File %s is modified.", f)

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -114,16 +114,22 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   # Print ksonnet version
   util.run(["ks", "version"])
   job_type = os.getenv("JOB_TYPE")
+  pull_base_sha = os.getenv("PULL_BASE_SHA")
 
-  # Compare with master branch and get changed files.
+  # For presubmit/postsubmit jobs, find the list of files changed by the PR.
   diff_command = []
   if job_type == "presubmit":
     diff_command = ["git", "diff", "--name-only", "master"]
-  else:
-    diff_command = ["git", "diff", "--name-only", "HEAD^", "HEAD"]
+  elif job_type == "postsubmit":
+    diff_command = ["git", "diff", "--name-only", pull_base_sha + "^", pull_base_sha]
 
-  changed_files = util.run(diff_command,
-    cwd=os.path.join(args.repos_dir, os.getenv("REPO_OWNER"), os.getenv("REPO_NAME"))).splitlines()
+  changed_files = []
+  if job_type == "presubmit" or job_type == "postsubmit":
+    changed_files = util.run(diff_command,
+      cwd=os.path.join(args.repos_dir, os.getenv("REPO_OWNER"), os.getenv("REPO_NAME"))).splitlines()
+
+  for f in changed_files:
+    logging.info("File %s is modified.", f)
 
   if args.release:
     generate_env_from_head(args)


### PR DESCRIPTION
For postsubmit jobs, we can detect the list of changed files by doing
```
git diff --name-only PULL_BASE_SHA^ PULL_BASE_SHA
```
Where PULL_BASE_SHA is set by the Prow environment.

Also added more logging for debugging purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/223)
<!-- Reviewable:end -->
