### PR TITLE
Don't consider modified_dirs for periodic jobs

### DIFF
--- a/images/checkout.sh
+++ b/images/checkout.sh
@@ -14,6 +14,9 @@
 # {REPO_ORG}/{REPO_NAME}@{SHA}:{PULL_NUMBER}
 #
 # You can use HEAD as the sha to get the latest for a pull request.
+#
+# To checkout a specific branch (e.g. "v0.3-branch"), set the
+# {BRANCH_NAME} environment variable.
 set -xe
 
 SRC_DIR=$1
@@ -36,6 +39,12 @@ if [ ! -z ${PULL_NUMBER} ]; then
  else
  	git checkout pr
  fi
+
+elif [ ! -z ${BRANCH_NAME} ]; then
+  # Periodic jobs don't have pull numbers or commit SHAs, so we pass in the
+  # branch name from the config yaml file.
+  git fetch origin
+  git checkout ${BRANCH_NAME}
  
 else
  if [ ! -z ${PULL_BASE_SHA} ]; then

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -176,7 +176,9 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
         if dir_modified:
           break
 
-    if w.include_dirs and not dir_modified:
+    # Only consider modified files when the job is pre or post submit, and if
+    # the include_dirs stanza is defined.
+    if job_type != "periodic" and w.include_dirs and not dir_modified:
       logging.info("Skipping workflow %s because no code modified in %s.",
                    w.name, w.include_dirs)
       continue


### PR DESCRIPTION
For periodic Prow jobs, we should run all the test workflows whose job_type includes "periodic". We should not consider modified_dirs since there is no last commit hash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/226)
<!-- Reviewable:end -->
