### PR TITLE
Allow run_e2e_workflow to select which version of ks to use

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -89,13 +89,21 @@ RUN cd /tmp && \
     tar -xvf glide-v0.13.0-linux-amd64.tar.gz && \
     mv ./linux-amd64/glide /usr/local/bin/
 
-# Install ksonnet
+# Install ksonnet. We install both 0.11.0 and 0.12.0 due to compatibility issues
+# (see https://github.com/kubeflow/testing/issues/220).
 RUN cd /tmp && \
     wget -O ks.tar.gz \
-    https://github.com/ksonnet/ksonnet/releases/download/v0.12.0/ks_0.12.0_linux_amd64.tar.gz && \
+    https://github.com/ksonnet/ksonnet/releases/download/v0.11.0/ks_0.11.0_linux_amd64.tar.gz && \
     tar -xvf ks.tar.gz && \
-    mv ks_0.12.0_linux_amd64/ks /usr/local/bin && \
+    mv ks_0.11.0_linux_amd64/ks /usr/local/bin && \
     chmod a+x /usr/local/bin/ks
+
+RUN cd /tmp && \
+    wget -O ks-12.tar.gz \
+    https://github.com/ksonnet/ksonnet/releases/download/v0.12.0/ks_0.12.0_linux_amd64.tar.gz && \
+    tar -xvf ks-12.tar.gz && \
+    mv ks_0.12.0_linux_amd64/ks /usr/local/bin/ks-12 && \
+    chmod a+x /usr/local/bin/ks-12
 
 RUN cd /tmp && \
     wget https://github.com/google/jsonnet/archive/v0.11.2.tar.gz && \

--- a/images/checkout.sh
+++ b/images/checkout.sh
@@ -14,6 +14,9 @@
 # {REPO_ORG}/{REPO_NAME}@{SHA}:{PULL_NUMBER}
 #
 # You can use HEAD as the sha to get the latest for a pull request.
+#
+# To checkout a specific branch (e.g. "v0.3-branch"), set the
+# {BRANCH_NAME} environment variable.
 set -xe
 
 SRC_DIR=$1
@@ -36,6 +39,12 @@ if [ ! -z ${PULL_NUMBER} ]; then
  else
  	git checkout pr
  fi
+
+elif [ ! -z ${BRANCH_NAME} ]; then
+  # Periodic jobs don't have pull numbers or commit SHAs, so we pass in the
+  # branch name from the config yaml file.
+  git fetch origin
+  git checkout ${BRANCH_NAME}
  
 else
  if [ ! -z ${PULL_BASE_SHA} ]; then


### PR DESCRIPTION
- Install both ks 0.11 and 0.12 in the docker image for test-worker
- "ks" points to 0.11, "ks-12" points to 0.12
- By default, test-worker uses ks 0.11
- Each workflow can additionally specify "ks_version" in the prow_config, which overrides the default cmd