### PR TITLE
Allow run_e2e_workflow to select which version of ks to use

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -89,13 +89,21 @@ RUN cd /tmp && \
     tar -xvf glide-v0.13.0-linux-amd64.tar.gz && \
     mv ./linux-amd64/glide /usr/local/bin/
 
-# Install ksonnet
+# Install ksonnet. We install both 0.11.0 and 0.12.0 due to compatibility issues
+# (see https://github.com/kubeflow/testing/issues/220).
 RUN cd /tmp && \
     wget -O ks.tar.gz \
-    https://github.com/ksonnet/ksonnet/releases/download/v0.12.0/ks_0.12.0_linux_amd64.tar.gz && \
+    https://github.com/ksonnet/ksonnet/releases/download/v0.11.0/ks_0.11.0_linux_amd64.tar.gz && \
     tar -xvf ks.tar.gz && \
-    mv ks_0.12.0_linux_amd64/ks /usr/local/bin && \
+    mv ks_0.11.0_linux_amd64/ks /usr/local/bin && \
     chmod a+x /usr/local/bin/ks
+
+RUN cd /tmp && \
+    wget -O ks-12.tar.gz \
+    https://github.com/ksonnet/ksonnet/releases/download/v0.12.0/ks_0.12.0_linux_amd64.tar.gz && \
+    tar -xvf ks-12.tar.gz && \
+    mv ks_0.12.0_linux_amd64/ks /usr/local/bin/ks-12 && \
+    chmod a+x /usr/local/bin/ks-12
 
 RUN cd /tmp && \
     wget https://github.com/google/jsonnet/archive/v0.11.2.tar.gz && \

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -67,9 +67,8 @@ def get_namespace(args):
 class WorkflowComponent(object):
   """Datastructure to represent a ksonnet component to submit a workflow."""
 
-  def __init__(self, name, app_dir, component,
-               job_types, include_dirs, ks_version,
-               params):  # pylint: disable=too-many-arguments
+  def __init__(self, name, app_dir, component, # pylint: disable=too-many-arguments
+               job_types, include_dirs, ks_version, params):
     self.name = name
     self.app_dir = app_dir
     self.component = component

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -16,6 +16,7 @@ workflows:
       presubmit
     include_dirs:
       tensorflow/*
+    ks_version: 0.11.0
 
   - name: lint
     app_dir: kubeflow/kubeflow/testing/workflows
@@ -32,6 +33,9 @@ that should run this workflow.
 
 include_dirs (optional) is an array of strings that specify which directories, if modified,
 should run this workflow.
+
+ks_version (optional) is a string representing the version of Ksonnet. Current supported versions
+are 0.11.0 and 0.12.0.
 
 The script expects that the directories
 {repos_dir}/{app_dir} exists. Where repos_dir is provided
@@ -63,7 +67,9 @@ def get_namespace(args):
 class WorkflowComponent(object):
   """Datastructure to represent a ksonnet component to submit a workflow."""
 
-  def __init__(self, name, app_dir, component, job_types, include_dirs, ks_version, params):
+  def __init__(self, name, app_dir, component,
+               job_types, include_dirs, ks_version,
+               params):  # pylint: disable=too-many-arguments
     self.name = name
     self.app_dir = app_dir
     self.component = component

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import unittest
 import mock
@@ -60,10 +61,13 @@ class TestRunE2eWorkflow(unittest.TestCase):
     os.environ["BUILD_NUMBER"] = "1234"
     os.environ["BUILD_ID"] = "11"
 
+    cwd = os.getcwd()
+    logging.info("Current working directory: %s", cwd)
+
     args = ["--project=some-project", "--cluster=some-cluster",
             "--zone=us-east1-d", "--bucket=some-bucket",
             "--config_file=" + name,
-            "--repos_dir=/src"]
+            "--repos_dir=" + cwd + "/../../../../.."]
     run_e2e_workflow.main(args)
 
     mock_configure.assert_called_once_with("some-project", "us-east1-d",

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -70,8 +70,8 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
-      ["ks", "version"],
       ["git", "diff", "--name-only", "master"],
+      ["ks", "version"],
       ["ks", "env", "add", "kubeflow-presubmit-wf-77-123abc-1234-.*"],
       ["ks", "param", "set", "--env=.*", "workflows", "name",
            "kubeflow-presubmit-wf-77-123abc-1234-[0-9a-z]{4}"],

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import unittest
 import mock
@@ -62,12 +61,15 @@ class TestRunE2eWorkflow(unittest.TestCase):
     os.environ["BUILD_ID"] = "11"
 
     cwd = os.getcwd()
-    logging.info("Current working directory: %s", cwd)
+    # Current directory is in the format:
+    # "/mnt/test-data-volume/kubeflow-testing-12345/src/kubeflow/testing"
+    # We need to parse the actual repo root here.
+    repo_dir = cwd[:cwd.index("/kubeflow/testing")]
 
     args = ["--project=some-project", "--cluster=some-cluster",
             "--zone=us-east1-d", "--bucket=some-bucket",
             "--config_file=" + name,
-            "--repos_dir=" + cwd + "/../../../../.."]
+            "--repos_dir=" + repo_dir]
     run_e2e_workflow.main(args)
 
     mock_configure.assert_called_once_with("some-project", "us-east1-d",
@@ -108,7 +110,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
         mock_run.call_args_list[i][0][0])
       if i > 1:
         self.assertEqual(
-           "/src/kubeflow/testing/workflows",
+           repo_dir + "/kubeflow/testing/workflows",
            mock_run.call_args_list[i][1]["cwd"])
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Install both ks 0.11 and 0.12 in the docker image for test-worker
- "ks" points to 0.11, "ks-12" points to 0.12
- By default, test-worker uses ks 0.11
- Run_e2e_workflow determines which version of ks to use by examining app_dir/app.yaml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/228)
<!-- Reviewable:end -->
