### PR TITLE
Fix gcs directory path for periodic Prow jobs

### DIFF
--- a/deployment/kubeflow-latest_ks_app/vendor/kubeflow/katib@177377f154475e797ebf2c9bb7d156862f8e1231/prototypes/all.jsonnet
+++ b/deployment/kubeflow-latest_ks_app/vendor/kubeflow/katib@177377f154475e797ebf2c9bb7d156862f8e1231/prototypes/all.jsonnet
@@ -13,9 +13,9 @@
 
 local k = import "k.libsonnet";
 
-local vizier = import "kubeflow/katib/vizier.libsonnet";
 local modeldb = import "kubeflow/katib/modeldb.libsonnet";
 local suggestion = import "kubeflow/katib/suggestion.libsonnet";
+local vizier = import "kubeflow/katib/vizier.libsonnet";
 
 local namespace = env.namespace;
 

--- a/py/kubeflow/testing/prow_artifacts.py
+++ b/py/kubeflow/testing/prow_artifacts.py
@@ -87,22 +87,15 @@ def create_finished_file(bucket, success, workflow_phase, ui_urls):
 
 def get_gcs_dir(bucket):
   """Return the GCS directory for this job."""
-  pull_number = os.getenv("PULL_NUMBER")
-
-  repo_owner = os.getenv("REPO_OWNER")
-  repo_name = os.getenv("REPO_NAME")
-
-
-  job_name = os.getenv("JOB_NAME")
-
   # GCS layout is defined here:
   # https://github.com/kubernetes/test-infra/tree/master/gubernator#job-artifact-gcs-layout
   pull_number = os.getenv("PULL_NUMBER")
-
   repo_owner = os.getenv("REPO_OWNER")
   repo_name = os.getenv("REPO_NAME")
+  job_name = os.getenv("JOB_NAME")
+  job_type = os.getenv("JOB_TYPE")
 
-  if pull_number:
+  if job_type == "presubmit":
     output = ("gs://{bucket}/pr-logs/pull/{owner}_{repo}/"
               "{pull_number}/{job}/{build}").format(
               bucket=bucket,
@@ -110,8 +103,7 @@ def get_gcs_dir(bucket):
               pull_number=pull_number,
               job=os.getenv("JOB_NAME"),
               build=os.getenv("BUILD_NUMBER"))
-
-  elif repo_owner:
+  elif job_type == "postsubmit":
     # It is a postsubmit job
     output = ("gs://{bucket}/logs/{owner}_{repo}/"
               "{job}/{build}").format(

--- a/py/kubeflow/tests/prow_artifacts_test.py
+++ b/py/kubeflow/tests/prow_artifacts_test.py
@@ -59,6 +59,7 @@ class TestProw(unittest.TestCase):
     os.environ["BUILD_NUMBER"] = "100"
     os.environ["PULL_PULL_SHA"] = "123abc"
     os.environ["JOB_NAME"] = "kubeflow-presubmit"
+    os.environ["JOB_TYPE"] = "presubmit"
 
     args = ["--artifacts_dir=/tmp/some/dir", "copy_artifacts",
             "--bucket=some_bucket"]
@@ -89,6 +90,7 @@ class TestProw(unittest.TestCase):
       os.environ["BUILD_NUMBER"] = "100"
       os.environ["PULL_PULL_SHA"] = "123abc"
       os.environ["JOB_NAME"] = "kubeflow-presubmit"
+      os.environ["JOB_TYPE"] = "presubmit"
 
       args = ["--artifacts_dir=/tmp/some/dir", "create_pr_symlink",
               "--bucket=some-bucket"]


### PR DESCRIPTION
Prow artifacts were not being uploaded to GCS correctly. This is because we recently added environment variables for repo name and owner. The fix is to determine the GCS path based on job_type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/230)
<!-- Reviewable:end -->
