### PR TITLE
Fix label 0.4.0

### DIFF
--- a/label_sync/README.md
+++ b/label_sync/README.md
@@ -22,6 +22,6 @@ After making changes to `kubeflow_label.yml`, we need to update the configmap
 ```
 # Setup kubectl to point to kubeflow-testing cluster in kubeflow-ci
 kubectl delete configmap label-config-v2
-kubectl create configmap --from-file=kubeflow_label.yml
+kubectl create configmap label-config-v2 --from-file=kubeflow_label.yml
 ```
 

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: label-sync
+  name: label-sync-1008-002
 spec:
   template:
     spec:

--- a/label_sync/kubeflow_label.yml
+++ b/label_sync/kubeflow_label.yml
@@ -2,12 +2,25 @@ default:
   labels:
   - color: d28caa
     name: addition/feature
-  - color: d2b48c
-    name: area/api
-  - color: d2b48c
+  - color: ef1ad6
+    name: area/0.2.0
+    previously:
+    - name: release/0.2.0
+  - color: ef1ad6
+    name: area/0.3.0
+    previously:
+    - name: release/0.3.0
+  - color: ef1ad6
     name: area/0.4.0
     previously:
     - name: release/0.4.0
+  - color: ef1ad6
+    name: area/1.0.0
+    previously:
+    - name: release/1.0.0
+  - color: d2b48c
+    name: area/api
+  - color: d2b48c
     name: area/build-release
     previously:
     - name: area/release-eng
@@ -29,7 +42,7 @@ default:
   - color: d2b48c
     name: area/inference
     previously:
-    - name: inference
+    - name: inference  
   - color: d2b48c
     name: area/usage
   - color: ecfc15
@@ -109,18 +122,6 @@ default:
     name: approved
     previously:
     - name: status/approved
-  - color: ef1ad6
-    name: area/0.2.0
-    previously:
-    - name: release/0.2.0
-  - color: ef1ad6
-    name: area/0.3.0
-    previously:
-    - name: release/0.3.0
-  - color: ef1ad6
-    name: area/1.0.0
-    previously:
-    - name: release/1.0.0
   - color: bc9090
     name: status/backlog
   - color: fca42e


### PR DESCRIPTION
* The indentation in kubeflow_label.yml was messed up so the 0.4.0
  tag wasn't being included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/232)
<!-- Reviewable:end -->
