### PR TITLE
Improve readability of priority/p1 and status/icebox labels

### DIFF
--- a/label_sync/kubeflow_label.yml
+++ b/label_sync/kubeflow_label.yml
@@ -101,7 +101,7 @@ default:
     name: platform/other
   - color: db1203
     name: priority/p0
-  - color: db03cc
+  - color: cb03cc
     name: priority/p1
   - color: fc9915
     name: priority/p2
@@ -126,7 +126,7 @@ default:
     name: status/backlog
   - color: fca42e
     name: status/done
-  - color: '808080'
+  - color: '707070'
     name: status/icebox
   # Don't remove, this label is being used by prow
   - color: ffa500


### PR DESCRIPTION
The mentioned labels are very close to the threshold that github uses to determine whether to use black or white foreground text.

By darkening them slightly, the foreground switches to white, and the labels become more readable.

Before:
![image](https://user-images.githubusercontent.com/34456002/48088632-5704d780-e1b7-11e8-95f7-e2bf3867e0a9.png)
After:
![image](https://user-images.githubusercontent.com/34456002/48088650-5f5d1280-e1b7-11e8-9b3d-fd497c345965.png)

Before:
![image](https://user-images.githubusercontent.com/34456002/48088655-65eb8a00-e1b7-11e8-950f-182bffae6101.png)

After:
![image](https://user-images.githubusercontent.com/34456002/48088662-697f1100-e1b7-11e8-83b8-eda5add5497e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/241)
<!-- Reviewable:end -->
