### PR TITLE
Use daemonset-preloaded yaml

### DIFF
--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -345,7 +345,7 @@ def install_gpu_drivers(api_client):
   """
   logging.info("Install GPU Drivers.")
   # Fetch the daemonset to install the drivers.
-  link = "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/k8s-1.9/daemonset.yaml"  # pylint: disable=line-too-long
+  link = "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/stable/nvidia-driver-installer/cos/daemonset-preloaded.yaml"  # pylint: disable=line-too-long
   logging.info("Using daemonset file: %s", link)
   f = urllib.urlopen(link)
   daemonset_spec = yaml.load(f)


### PR DESCRIPTION
Use this version of the driver installer daemonset: https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers

Tried this on a test cluster manually and it seems to fix the GPU pool problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/246)
<!-- Reviewable:end -->
