### PR TITLE
Add labels for CUJs and cleanup some labels.

### DIFF
--- a/label_sync/kubeflow_label.yml
+++ b/label_sync/kubeflow_label.yml
@@ -1,7 +1,5 @@
 default:
   labels:
-  - color: d28caa
-    name: addition/feature
   - color: ef1ad6
     name: area/0.2.0
     previously:
@@ -48,37 +46,19 @@ default:
   - color: ecfc15
     name: community/discussion
   - color: ecfc15
+    name: community/maintenance
+  - color: 2515fc
     name: community/question
     previously:
     - name: question
+  - color: ecfc15
+    name: cuj/build-train-deploy
+  - color: 00daff
+    name: cuj/multi-user
   - color: 00daff
     name: do-not-merge
   - color: 00daff
     name: duplicate
-  - color: 00daff
-    name: high-impact
-  - color: 00daff
-    name: improvement/enhancement
-    previously:
-    - name: enhancement
-  - color: 00daff
-    name: improvement/optimization
-  - color: 8cd2b4
-    name: os/centos
-    previously:
-    - name: area/os/centos
-  - color: 8cd2b4
-    name: os/macos
-    previously:
-    - name: area/os/macos
-  - color: 8cd2b4
-    name: os/ubuntu
-    previously:
-    - name: area/os/ubuntu
-  - color: 8cd2b4
-    name: os/windows
-    previously:
-    - name: area/os/windows
   - color: 2515fc
     name: platform/aws
     previously:
@@ -110,12 +90,6 @@ default:
     previously:
     - name: bug
     - name: problem/bug
-  - color: fc2515
-    name: problems/refactor
-    previously:
-    - name: bug  
-  - color: fc2515
-    name: problems/security
   - color: 00daff
     name: starter
   - color: 03db12


### PR DESCRIPTION
* Define some CUJ labels to begin grouping issues by CUJ. This will
  be a good way to group issues across repos and relate them to releases.

* kubernetes/test-infra#10515 will allow the prow bot to set labels
  /community, /platform, /cuj so all members will be able to begin
  setting those labels.

* Add a label for community mainenance.

* Remove os labels we aren't using them
* Remove problems label these aren't using them.
* Remove improvemnt labels these aren't using them

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/253)
<!-- Reviewable:end -->
