### PR TITLE
Properly compute the changed files in presubmits.

### DIFF
--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -136,7 +136,7 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   if job_type == "presubmit":
     # We need to get a common ancestor for the PR and the master branch
     common_ancestor = util.run(
-      ["git", "merge-base", "--fork-point", "master"],
+      ["git", "merge-base", "HEAD", "master"],
       cwd=os.path.join(args.repos_dir, repo_owner, repo_name))
     diff_command = ["git", "diff", "--name-only", common_ancestor]
   elif job_type == "postsubmit":

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -134,8 +134,13 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   # For presubmit/postsubmit jobs, find the list of files changed by the PR.
   diff_command = []
   if job_type == "presubmit":
-    diff_command = ["git", "diff", "--name-only", "master"]
+    # We need to get a common ancestor for the PR and the master branch
+    common_ancestor = util.run(["git", "merge-base", "--fork-point", "master"])
+    diff_command = ["git", "diff", "--name-only", common_ancestor]
   elif job_type == "postsubmit":
+    # See: https://git-scm.com/docs/git-diff
+    # This syntax compares the commit before pull_base_sha with the commit
+    # at pull_base_sha
     diff_command = ["git", "diff", "--name-only", pull_base_sha + "^", pull_base_sha]
 
   changed_files = []

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -135,7 +135,9 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   diff_command = []
   if job_type == "presubmit":
     # We need to get a common ancestor for the PR and the master branch
-    common_ancestor = util.run(["git", "merge-base", "--fork-point", "master"])
+    common_ancestor = util.run(
+      ["git", "merge-base", "--fork-point", "master"],
+      cwd=os.path.join(args.repos_dir, repo_owner, repo_name))
     diff_command = ["git", "diff", "--name-only", common_ancestor]
   elif job_type == "postsubmit":
     # See: https://git-scm.com/docs/git-diff

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -76,7 +76,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
-      ["git", "merge-base", "--fork-point", "master"]
+      ["git", "merge-base", "--fork-point", "master"],
       ["git", "diff", "--name-only", ".*"],
       ["ks", "version"],
       ["ks", "env", "add", "kubeflow-presubmit-wf-77-123abc-1234-.*"],

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -80,7 +80,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
-      ["git", "merge-base", "--fork-point", "master"],
+      ["git", "merge-base", "HEAD", "master"],
       ["git", "diff", "--name-only", "ab1234"],
       ["ks", "version"],
       ["ks", "env", "add", "kubeflow-presubmit-wf-77-123abc-1234-.*"],

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -35,10 +35,18 @@ class TestRunE2eWorkflow(unittest.TestCase):
   @mock.patch("kubeflow.testing.run_e2e_workflow.util.run")
   def testWithConfig(self, mock_run, mock_configure, *unused_mocks):  # pylint: disable=no-self-use,unused-argument
     """Test creating a workflow from a config file."""
-
+    # We need to set cwd and the app_dir in the config file consistenly.
+    # The app_dir will be relative to the working dir.
+    # We set cwd to the root of the repo and then app dir relative to that.
+    this_dir = os.path.basename(__file__)
+    cwd = os.path.abspath(os.path.join(this_dir, "..", "..", "..", ".."))
+    # Current directory is in the format:
+    # "/mnt/test-data-volume/kubeflow-testing-12345/src/kubeflow/testing"
+    # We need to parse the actual repo root here.
+    repo_dir = cwd
     config = {
       "workflows": [
-        {"app_dir": "kubeflow/testing/workflows",
+        {"app_dir": "workflows",
          "component": "workflows",
          "name": "wf",
          "params": {
@@ -60,11 +68,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
     os.environ["BUILD_NUMBER"] = "1234"
     os.environ["BUILD_ID"] = "11"
 
-    cwd = os.getcwd()
-    # Current directory is in the format:
-    # "/mnt/test-data-volume/kubeflow-testing-12345/src/kubeflow/testing"
-    # We need to parse the actual repo root here.
-    repo_dir = cwd[:cwd.index("/kubeflow/testing")]
+    mock_run.return_value = "ab1234"
 
     args = ["--project=some-project", "--cluster=some-cluster",
             "--zone=us-east1-d", "--bucket=some-bucket",
@@ -77,7 +81,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
 
     expected_calls = [
       ["git", "merge-base", "--fork-point", "master"],
-      ["git", "diff", "--name-only", ".*"],
+      ["git", "diff", "--name-only", "ab1234"],
       ["ks", "version"],
       ["ks", "env", "add", "kubeflow-presubmit-wf-77-123abc-1234-.*"],
       ["ks", "param", "set", "--env=.*", "workflows", "name",
@@ -109,9 +113,9 @@ class TestRunE2eWorkflow(unittest.TestCase):
       self.assertItemsMatchRegex(
         expected,
         mock_run.call_args_list[i][0][0])
-      if i > 1:
+      if i > 2:
         self.assertEqual(
-           repo_dir + "/kubeflow/testing/workflows",
+           os.path.join(cwd, "workflows"),
            mock_run.call_args_list[i][1]["cwd"])
 
 if __name__ == "__main__":

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -76,7 +76,8 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
-      ["git", "diff", "--name-only", "master"],
+      ["git", "merge-base", "--fork-point", "master"]
+      ["git", "diff", "--name-only", ".*"],
       ["ks", "version"],
       ["ks", "env", "add", "kubeflow-presubmit-wf-77-123abc-1234-.*"],
       ["ks", "param", "set", "--env=.*", "workflows", "name",


### PR DESCRIPTION
* We need to find the common ancestor between the pull request and the master
  branch.

* We only want to consider files changed in the PR branch relative to the
  common ancestor. If we just compare to the master branch we end up
  including files that were changed on the master branch since the commit
  on which the PR was based. This is undesirable because we will end up
  triggering tests unrelated to the PR.

Related to kubeflow/testing#229

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/255)
<!-- Reviewable:end -->
