### PR TITLE
Support ksonnet apps using 0.3.0 spec in our tests.

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -90,7 +90,9 @@ RUN cd /tmp && \
     tar -xvf glide-v0.13.0-linux-amd64.tar.gz && \
     mv ./linux-amd64/glide /usr/local/bin/
 
-# Install ksonnet. We install both 0.11.0 and 0.12.0 due to compatibility issues
+# Install ksonnet. We install multiple versions of ks to support different versions
+# of ksonnet applications. Newer versions of ksonnet are backwards compatible but
+# that can require upgrading the app which isn't something we want to be forced to.
 # (see https://github.com/kubeflow/testing/issues/220).
 RUN cd /tmp && \
     wget -O ks.tar.gz \
@@ -105,6 +107,13 @@ RUN cd /tmp && \
     tar -xvf ks-12.tar.gz && \
     mv ks_0.12.0_linux_amd64/ks /usr/local/bin/ks-12 && \
     chmod a+x /usr/local/bin/ks-12
+
+RUN cd /tmp && \
+    wget -O ks-13.tar.gz \
+    https://github.com/ksonnet/ksonnet/releases/download/v0.13.1/ks_0.13.1_linux_amd64.tar.gz && \
+    tar -xvf ks-13.tar.gz && \
+    mv ks_0.12.0_linux_amd64/ks /usr/local/bin/ks-13 && \
+    chmod a+x /usr/local/bin/ks-13
 
 RUN cd /tmp && \
     wget https://github.com/google/jsonnet/archive/v0.11.2.tar.gz && \

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -112,7 +112,7 @@ RUN cd /tmp && \
     wget -O ks-13.tar.gz \
     https://github.com/ksonnet/ksonnet/releases/download/v0.13.1/ks_0.13.1_linux_amd64.tar.gz && \
     tar -xvf ks-13.tar.gz && \
-    mv ks_0.12.0_linux_amd64/ks /usr/local/bin/ks-13 && \
+    mv ks_0.13.1_linux_amd64/ks /usr/local/bin/ks-13 && \
     chmod a+x /usr/local/bin/ks-13
 
 RUN cd /tmp && \

--- a/py/kubeflow/testing/ks_util.py
+++ b/py/kubeflow/testing/ks_util.py
@@ -51,5 +51,8 @@ def get_ksonnet_cmd(app_dir):
   if results["apiVersion"] == "0.2.0":
     return "ks-12"
 
+  if results["apiVersion"] >= "0.3.0":
+    return "ks-13"
+
   # For compatibility reasons we'll keep the default cmd as "ks".
   return "ks"


### PR DESCRIPTION
Add support ksonnet 0.3.0 apps in our test image.  …

* Install ksonnet 0.13.

* If the app spec is 0.3.0 then ks_util.get_command should use ks-13.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/274)
<!-- Reviewable:end -->
