### PR TITLE
add `s2i` command line tool in kubeflow-ci worker image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -90,6 +90,12 @@ RUN cd /tmp && \
     tar -xvf glide-v0.13.0-linux-amd64.tar.gz && \
     mv ./linux-amd64/glide /usr/local/bin/
 
+# Install s2i
+RUN cd /tmp && \
+    wget -O s2i.tar.gz https://github.com/openshift/source-to-image/releases/download/v1.1.13/source-to-image-v1.1.13-b54d75d3-linux-amd64.tar.gz && \
+    tar -xvf s2i.tar.gz && \
+    mv ./s2i /usr/local/bin
+
 # Install ksonnet. We install multiple versions of ks to support different versions
 # of ksonnet applications. Newer versions of ksonnet are backwards compatible but
 # that can require upgrading the app which isn't something we want to be forced to.


### PR DESCRIPTION
[seldon serving uses source-to-image](https://github.com/SeldonIO/seldon-core/blob/master/docs/wrappers/readme.md) `s2i` to build docker images. 

This PR adds it to the CI worker image to enable e2e tests with seldon serving, e.g. xgboost-ames-housing example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/280)
<!-- Reviewable:end -->
