### PR TITLE
Make util.run py3 compatible.

### DIFF
--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import os
 import re
+import six
 import subprocess
 import time
 import urllib
@@ -57,16 +58,25 @@ def run(command,
   output = []
   while process.poll() is None:
     process.stdout.flush()
-    for line in iter(process.stdout.readline, ''):
-      output.append(line.strip())
-      logging.info(line.strip())
+    for line in iter(process.stdout.readline, b''):
+      if six.PY2:
+        line = line.strip()
+      else:
+        line = line.decode().strip()
+
+      output.append(line)
+      logging.info(line)
 
     time.sleep(polling_interval.total_seconds())
 
   process.stdout.flush()
   for line in iter(process.stdout.readline, b''):
-    output.append(line.strip())
-    logging.info(line.strip())
+    if six.PY2:
+      line = line.strip()
+    else:
+      line = line.decode().strip()
+    output.append(line)
+    logging.info(line)
 
   if process.returncode != 0:
     raise subprocess.CalledProcessError(


### PR DESCRIPTION
* It looks like on python3 util.run keeps polling for the end of stdout
  becase we don't treat the final line as a byte string e.g b''.

* Need to decode some strings in python3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/281)
<!-- Reviewable:end -->
