### PR TITLE
Show Argo workflow URLs when test starts.

### DIFF
--- a/py/kubeflow/testing/prow_artifacts.py
+++ b/py/kubeflow/testing/prow_artifacts.py
@@ -28,6 +28,8 @@ def create_started(ui_urls):
       "timestamp": int(time.time()),
       "repos": {
       },
+      "metadata": {
+      },
   }
 
   repo_owner = os.getenv("REPO_OWNER", "")

--- a/py/kubeflow/testing/prow_artifacts.py
+++ b/py/kubeflow/testing/prow_artifacts.py
@@ -15,8 +15,11 @@ from kubeflow.testing import util
 # TODO(jlewi): Replace create_finished in tensorflow/k8s/py/prow.py with this
 # version. We should do that when we switch tensorflow/k8s to use Argo instead
 # of Airflow.
-def create_started():
+def create_started(ui_urls):
   """Return a string containing the contents of started.json for gubernator.
+
+  ui_urls: Dictionary of workflow name to URL corresponding to the Argo UI
+      for the workflows launched.
   """
   # See:
   # https://github.com/kubernetes/test-infra/tree/master/gubernator#job-artifact-gcs-layout
@@ -42,6 +45,8 @@ def create_started():
   if PULL_REFS:
     started["pull"] = PULL_REFS
 
+  for n, v in ui_urls.iteritems():
+    started["metadata"][n + "-ui"] = v
   return json.dumps(started)
 
 # TODO(jlewi): Replace create_finished in tensorflow/k8s/py/prow.py with this

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -75,9 +75,9 @@ class WorkflowComponent(object):
 def _get_src_dir():
   return os.path.abspath(os.path.join(__file__, "..",))
 
-def create_started_file(bucket):
+def create_started_file(bucket, ui_urls):
   """Create the started file in gcs for gubernator."""
-  contents = prow_artifacts.create_started()
+  contents = prow_artifacts.create_started(ui_urls)
 
   target = os.path.join(prow_artifacts.get_gcs_dir(bucket), "started.json")
   util.upload_to_gcs(contents, target)
@@ -144,8 +144,6 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   workflows = []
   if args.config_file:
     workflows.extend(parse_config_file(args.config_file, args.repos_dir))
-
-  create_started_file(args.bucket)
 
   util.maybe_activate_service_account()
 
@@ -257,6 +255,9 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
               "?tab=workflow".format(workflow_name))
     ui_urls[workflow_name] = ui_url
     logging.info("URL for workflow: %s", ui_url)
+
+  # We delay creating started.json until we know the Argo workflow URLs
+  create_started_file(args.bucket, ui_urls)
 
   success = True
   workflow_phase = {}

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -145,6 +145,9 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   if args.config_file:
     workflows.extend(parse_config_file(args.config_file, args.repos_dir))
 
+  # Create an initial version of the file with no urls
+  create_started_file(args.bucket, {})
+
   util.maybe_activate_service_account()
 
   util.configure_kubectl(args.project, args.zone, args.cluster)

--- a/py/kubeflow/tests/prow_artifacts_test.py
+++ b/py/kubeflow/tests/prow_artifacts_test.py
@@ -19,9 +19,15 @@ class TestProw(unittest.TestCase):
         "repos": {
             "fake_org/fake_name": "123abc",
         },
+        "metadata": {
+          "workflow1-ui": "http://argo",
+        },
     }
 
-    actual = prow_artifacts.create_started()
+    ui_urls = {
+      "workflow1": "http://argo",
+    }
+    actual = prow_artifacts.create_started(ui_urls)
 
     self.assertEqual(expected, json.loads(actual))
 


### PR DESCRIPTION
* We want gubernator to surface Argo UI URLs when the test starts rather
  than having to wait until it finishes.

* We do this by including the links in the started.json metadata.
* This will be surfaced in gubernator until finished.json is created.

Fix #82

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/291)
<!-- Reviewable:end -->
