### PR TITLE
Improve the cleanup of Kubeflow deployments.

### DIFF
--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -267,6 +267,8 @@ def cleanup_deployments(args): # pylint: disable=too-many-statements
   for zone in args.zones.split(","):
     clusters = clusters_client.list(projectId=args.project, zone=zone).execute()
 
+    if not clusters:
+      continue
     for c in clusters["clusters"]:
       name = c["name"]
       if not is_match(name):

--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -170,7 +170,7 @@ def cleanup_service_accounts(args):
   logging.info("Unexpired emails:\n%s", "\n".join(unexpired_emails))
   logging.info("expired emails:\n%s", "\n".join(expired_emails))
 
-def cleanup_deployments(args): # pylint: disable=too-many-statements
+def cleanup_deployments(args): # pylint: disable=too-many-statements,too-many-branches
   if not args.delete_script:
     raise ValueError("--delete_script must be specified.")
 


### PR DESCRIPTION
* Use the changes in kubeflow/kubeflow#2344; specify command line arguments
  for delete_deployment.sh by name not position
  * Get the zone from the deployment manifest

* kubeflow/kubeflow#2344 doesn't depend on iam_patch.yaml; instead it
  loos for bindings with the specified name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/293)
<!-- Reviewable:end -->
