### PR TITLE
upgrade test worker to go1.11

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -45,7 +45,7 @@ RUN set -ex \
 
 # Install go
 RUN cd /tmp && \
-    wget -O /tmp/go.tar.gz https://redirector.gvt1.com/edgedl/go/go1.9.2.linux-amd64.tar.gz && \
+    wget -O /tmp/go.tar.gz https://redirector.gvt1.com/edgedl/go/go1.11.2.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz
 
 # Install gcloud


### PR DESCRIPTION
We need 1.11 to build bootstrapper which is using go modules.

/cc @kunmingg 
/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/303)
<!-- Reviewable:end -->
