### PR TITLE
Adopting Python pkgutil-style namespacing

### DIFF
--- a/py/kubeflow/__init__.py
+++ b/py/kubeflow/__init__.py
@@ -1,2 +1,1 @@
 path__ = __import__('pkgutil').extend_path(__path__, __name__)
-

--- a/py/kubeflow/__init__.py
+++ b/py/kubeflow/__init__.py
@@ -1,0 +1,2 @@
+path__ = __import__('pkgutil').extend_path(__path__, __name__)
+


### PR DESCRIPTION
To resolve [this issue](https://github.com/kubeflow/tf-operator/issues/914) we followed instructions at [python package namespacing](https://packaging.python.org/guides/packaging-namespace-packages/) to adopt pkgutil namespacing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/322)
<!-- Reviewable:end -->
