### PR TITLE
Fix repo spec for 0.4 auto-deploy cron job.

### DIFF
--- a/test-infra/auto-deploy/deploy-cron-v0-4.yaml
+++ b/test-infra/auto-deploy/deploy-cron-v0-4.yaml
@@ -20,7 +20,7 @@ spec:
               value: /secret/gcp-credentials/key.json
             command:
             - /usr/local/bin/auto_deploy.sh
-            - --repos=kubeflow/kubeflow;kubeflow/testing@v0.4-branch
+            - --repos=kubeflow/kubeflow@v0.4-branch;kubeflow/testing
             - --project=kubeflow-ci
             - --job_labels=/etc/pod-info/labels
             - --data_dir=/mnt/test-data-volume/auto_deploy


### PR DESCRIPTION
* The v0.4-branch should be specified on the kubeflow/kubeflow repo
  not the testing repo.

Related to #315

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/327)
<!-- Reviewable:end -->
