### PR TITLE
Fix cleanup_ci exception

### DIFF
--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -354,7 +354,7 @@ def getAge(tsInRFC3339):
   age = datetime.datetime.utcnow()- insert_time_utc
   return age
 
-@retrying.retry(stop_max_attempt=5,
+@retrying.retry(stop_max_attempt_number=5,
                 retry_on_exception=is_retryable_exception)
 def execute_rpc(rpc):
   """Execute a Google RPC request with retries."""
@@ -476,13 +476,18 @@ def cleanup_deployments(args): # pylint: disable=too-many-statements,too-many-br
                                  clusterId=name).execute()
 
 def cleanup_all(args):
-  cleanup_deployments(args)
-  cleanup_endpoints(args)
-  cleanup_service_accounts(args)
-  cleanup_service_account_bindings(args)
-  cleanup_workflows(args)
-  cleanup_disks(args)
-  cleanup_firewall_rules(args)
+  ops = [cleanup_deployments,
+         cleanup_endpoints,
+         cleanup_service_accounts,
+         cleanup_service_account_bindings,
+         cleanup_workflows,
+         cleanup_disks,
+         cleanup_firewall_rules]
+  for op in ops:
+    try:
+      op(args)
+    except Exception as e:
+      logging.error(e)
 
 def add_workflow_args(parser):
   parser.add_argument(

--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -486,7 +486,7 @@ def cleanup_all(args):
   for op in ops:
     try:
       op(args)
-    except Exception as e:
+    except Exception as e: # pylint: disable=broad-except
       logging.error(e)
 
 def add_workflow_args(parser):


### PR DESCRIPTION
1. Fix a typo in the code which causes exception:
```
  File "/usr/local/lib/python2.7/dist-packages/retrying.py", line 49, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
TypeError: __init__() got an unexpected keyword argument 'stop_max_attempt'
```

2. Make all cleanup operations best effort: a failure of one will not block the following operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/340)
<!-- Reviewable:end -->
