### PR TITLE
Update auto-deploy infrastructure to use the new kfctl binary.

### DIFF
--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -414,9 +414,10 @@ def cleanup_deployments(args): # pylint: disable=too-many-statements,too-many-br
 
       config = yaml.load(manifest["config"]["content"])
 
-      if not config:
+      if not config or not config["resources"]:
         logging.warning("Skipping deployment %s because it has no config; "
                         "is it already being deleted?", name)
+        continue
       zone = config["resources"][0]["properties"]["zone"]
       command = [args.delete_script,
                  "--project=" + args.project, "--deployment=" + name,

--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -274,7 +274,7 @@ def cleanup_health_checks(args):
   # Find all health checks not associated with a service.
   unmatched = []
   matched = []
-  for name in checks.keys():
+  for name in checks.iterkeys():
     if not name in services:
       unmatched.append(name)
       logging.info("Deleting health check: %s", name)

--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -241,10 +241,6 @@ def cleanup_health_checks(args):
   health_checks = compute.healthChecks()
   next_page_token = None
 
-  expired = []
-  unexpired = []
-  unmatched = []
-
   checks = {}
   while True:
     results = health_checks.list(project=args.project,

--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -234,6 +234,64 @@ def cleanup_firewall_rules(args):
   logging.info("Unexpired firewall rules:\n%s", "\n".join(unexpired))
   logging.info("expired firewall rules:\n%s", "\n".join(expired))
 
+def cleanup_health_checks(args):
+  credentials = GoogleCredentials.get_application_default()
+
+  compute = discovery.build('compute', 'v1', credentials=credentials)
+  health_checks = compute.healthChecks()
+  next_page_token = None
+
+  expired = []
+  unexpired = []
+  unmatched = []
+
+  checks = {}
+  while True:
+    results = health_checks.list(project=args.project,
+                                 pageToken=next_page_token).execute()
+    if not "items" in results:
+      break
+    for d in results["items"]:
+      name = d["name"]
+      checks[name] = d
+    if not "nextPageToken" in results:
+      break
+
+    next_page_token = results["nextPageToken"]
+
+  backends = compute.backendServices()
+  services = {}
+  while True:
+    results = backends.list(project=args.project,
+                            pageToken=next_page_token).execute()
+    if not "items" in results:
+      break
+    for d in results["items"]:
+      name = d["name"]
+      services[name] = d
+
+    if not "nextPageToken" in results:
+      break
+
+    next_page_token = results["nextPageToken"]
+
+  # Find all health checks not associated with a service.
+  unmatched = []
+  matched = []
+  for name in checks.keys():
+    if not name in services:
+      unmatched.append(name)
+      logging.info("Deleting health check: %s", name)
+      if not args.dryrun:
+        response = health_checks.delete(project=args.project,
+                                        healthCheck=name).execute()
+        logging.info("response = %s", response)
+    else:
+      matched.append(name)
+
+
+  logging.info("Unmatched health checks:\n%s", "\n".join(unmatched))
+  logging.info("Matched health checks:\n%s", "\n".join(matched))
 
 def cleanup_service_accounts(args):
   credentials = GoogleCredentials.get_application_default()
@@ -483,7 +541,8 @@ def cleanup_all(args):
          cleanup_service_account_bindings,
          cleanup_workflows,
          cleanup_disks,
-         cleanup_firewall_rules]
+         cleanup_firewall_rules,
+         cleanup_health_checks]
   for op in ops:
     try:
       op(args)
@@ -560,6 +619,14 @@ def main():
     "firewall", help="Cleanup firewall rules")
 
   parser_firewall.set_defaults(func=cleanup_firewall_rules)
+
+
+  ######################################################
+  # Parser for health checks
+  parser_health = subparsers.add_parser(
+    "health_checks", help="Cleanup health checks")
+
+  parser_health.set_defaults(func=cleanup_health_checks)
 
   ######################################################
   # Parser for service accounts

--- a/py/kubeflow/testing/create_kf_instance.py
+++ b/py/kubeflow/testing/create_kf_instance.py
@@ -151,7 +151,7 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
     type=str, help=("Directory to store kubeflow apps."))
 
   parser.add_argument(
-    "--name", type=str, required=True, help=("Name for the deployment."))
+    "--name", type=str, default="", help=("Name for the deployment."))
 
   parser.add_argument(
     "--snapshot_file",

--- a/py/kubeflow/testing/create_kf_instance.py
+++ b/py/kubeflow/testing/create_kf_instance.py
@@ -8,6 +8,9 @@ import logging
 import json
 import os
 import re
+import shutil
+import subprocess
+import tempfile
 import yaml
 
 from googleapiclient import discovery
@@ -39,6 +42,84 @@ def delete_storage_deployment(project, name):
 
   util.wait_for_gcp_operation(dm.operations(), project, None, op["name"])
 
+
+def create_info_file(args, app_dir, git_describe):
+  """Creates an info file in the KF app directory."""
+  # This step needs to be called after kfctl init because the directory needs to
+  # exist.
+  labels = {}
+  with open(os.path.join(app_dir, "kf_app.yaml"), "w") as hf:
+    app = {
+      "labels": {
+        "GIT_LABEL": git_describe,
+        "PURPOSE": "kf-test-cluster",
+      },
+    }
+    if args.timestamp:
+      app["labels"]["SNAPSHOT_TIMESTAMP"] = args.timestamp
+    if args.job_name:
+      app["labels"]["DEPLOYMENT_JOB"] = args.job_name
+    labels = app.get("labels", {})
+    yaml.dump(app, hf)
+
+def deploy_with_kfctl_sh(args, app_dir, env, label_args):
+  """Deploy Kubeflow using kfctl.sh."""
+  kfctl = os.path.join(args.kubeflow_repo, "scripts", "kfctl.sh")
+  ks_app_dir = os.path.join(app_dir, "ks_app")
+  util.run([kfctl, "init", name, "--project", args.project, "--zone", args.zone,
+            "--platform", "gcp", "--skipInitProject", "true"], cwd=args.apps_dir
+           )
+  # We need to apply platform before doing generate k8s because we need
+  # to have a cluster for ksonnet.
+  # kfctl apply all might break during cronjob invocation when depending
+  # components are not ready. Make it retry several times should be enough.
+  run_with_retry([kfctl, "generate", "platform"], cwd=app_dir, env=env)
+  run_with_retry([kfctl, "apply", "platform"], cwd=app_dir, env=env)
+  run_with_retry([kfctl, "generate", "k8s"], cwd=app_dir, env=env)
+  run_with_retry([kfctl, "apply", "k8s"], cwd=app_dir, env=env)
+  run_with_retry(["ks", "generate", "seldon", "seldon"], cwd=ks_app_dir,
+                  env=env)
+
+def build_kfctl_go(args):
+  """Build kfctl go."""
+  build_dir = os.path.join(args.kubeflow_repo, "bootstrap")
+  # We need to use retry builds because when building in the test cluster
+  # we see intermittent failures pulling dependencies
+  util.run(["make", "build-kfctl"], cwd=build_dir)
+  kfctl_path = os.path.join(build_dir, "bin", "kfctl")
+
+  return kfctl_path
+
+def deploy_with_kfctl_go(kfctl_path, args, app_dir, env, label_args):
+  """Deploy Kubeflow using kfctl go binary."""
+  # username and password are passed as env vars and won't appear in the logs
+  #
+  # TODO(https://github.com/kubeflow/kubeflow/issues/2831): We should be
+  # loading the config in the repo we have checked out kfctl doesn't support
+  # specifying a file URI. Once it does we should change --version to
+  # use it.
+  logging.warn("Loading configs from master.")
+  util.run([kfctl_path, "init", app_dir, "-V", "--platform=gcp",
+            "--version=master",
+            "--skip-init-gcp-project",
+            "--disable_usage_report",
+            "--project=" + args.project], env=env)
+
+  # We need to specify a valid email because
+  #  1. We need to create appropriate RBAC rules to allow the current user
+  #     to create the required K8s resources.
+  #  2. Setting the IAM policy will fail if the email is invalid.
+  # TODO(jlewi): kfctl should eventually do this automatically.
+  email = util.run(["gcloud", "config", "get-value", "account"])
+
+  if not email:
+    raise ValueError("Could not determine GCP account being used.")
+
+  util.run([kfctl_path, "generate", "-V", "all", "--email=" + email,
+            "--zone=" + args.zone], env=env, cwd=app_dir)
+
+  util.run([kfctl_path, "apply", "-V", "all"], env=env, cwd=app_dir)
+
 def main(): # pylint: disable=too-many-locals,too-many-statements
   logging.basicConfig(level=logging.INFO,
                       format=('%(levelname)s|%(asctime)s'
@@ -50,14 +131,16 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
   parser = argparse.ArgumentParser()
 
   parser.add_argument(
-    "--project", default="kubeflow-ci", type=str, help=("The project."))
+    "--project", default="kubeflow-ci-deployment", type=str,
+    help=("The project."))
 
   parser.add_argument(
     "--zone", default="us-east1-d", type=str, help=("The zone to deploy in."))
 
   parser.add_argument(
     "--oauth_file",
-    default="gs://kubeflow-ci_kf-data/kf-iap-oauth.kubeflow-ci.yaml",
+    default=("gs://kubeflow-ci-deployment_kf-data/"
+             "kf-iap-oauth.kubeflow-ci-deployment.yaml"),
     type=str, help=("The file containing the OAuth client ID & secret"
                     "for IAP."))
 
@@ -72,8 +155,7 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
     type=str, help=("Directory to store kubeflow apps."))
 
   parser.add_argument(
-    "--name",
-    default="", type=str, help=("Name for the deployment."))
+    "--name", type=str, required=True, help=("Name for the deployment."))
 
   parser.add_argument(
     "--snapshot_file",
@@ -88,6 +170,15 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
     "--job_name",
     default="", type=str, help=("Pod name running the job."))
 
+  parser.add_argument(
+    "--use_kfctl_go", dest="use_kfctl_go", action="store_true",
+    help=("Use the go binary."))
+
+  parser.add_argument(
+    "--no-use_kfctl_go", dest="use_kfctl_go", action="store_false",
+    help=("Use kfctl.sh."))
+
+  parser.set_defaults(use_kfctl_go=True)
   args = parser.parse_args()
 
   bucket, blob_path = util.split_gcs_uri(args.oauth_file)
@@ -113,9 +204,27 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
   else:
     name = args.name
 
-  # Clean up previous deployment. We are not able to run "kfctl delete all"
+  kfctl_path = None
+  if args.use_kfctl_go:
+    kfctl_path = build_kfctl_go(args)
+
+
+  app_dir = os.path.join(args.apps_dir, name)
+  # Clean up previous deployment. We attempt to run "kfctl delete all"
+  # but we don't depend on it succeeding because the app directory might
+  # not be up to date.
   # since we are not able to guarantee apps config in repository is up to date.
-  util.run(["rm", "-rf", name], cwd=args.apps_dir)
+  if os.path.exists(app_dir) and args.use_kfctl_go:
+    try:
+      util.run([kfctl_path, "delete", "all", "--delete_storage"], cwd=app_dir)
+    except subprocess.CalledProcessError as e:
+      logging.error("kfctl delete all failed; %s", e)
+
+  if os.path.exists(app_dir):
+    shutil.rmtree(app_dir)
+
+  if not os.path.exists(args.apps_dir):
+    os.makedirs(args.apps_dir)
 
   # Delete deployment beforehand. If not, updating action might be failed when
   # resource permission/requirement is changed. It's cleaner to delete and
@@ -129,27 +238,15 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
   # Delete script doesn't delete storage deployment by design.
   delete_storage_deployment(args.project, name + "-storage")
 
-  app_dir = os.path.join(args.apps_dir, name)
-  kfctl = os.path.join(args.kubeflow_repo, "scripts", "kfctl.sh")
-  ks_app_dir = os.path.join(app_dir, "ks_app")
-  util.run([kfctl, "init", name, "--project", args.project, "--zone", args.zone,
-            "--platform", "gcp", "--skipInitProject", "true"], cwd=args.apps_dir
-           )
+  env = {}
+  env.update(os.environ)
+  env.update(oauth_info)
 
-  labels = {}
-  with open(os.path.join(app_dir, "kf_app.yaml"), "w") as hf:
-    app = {
-      "labels": {
-        "GIT_LABEL": git_describe,
-        "PURPOSE": "kf-test-cluster",
-      },
-    }
-    if timestamp:
-      app["labels"]["SNAPSHOT_TIMESTAMP"] = timestamp
-    if args.job_name:
-      app["labels"]["DEPLOYMENT_JOB"] = args.job_name
-    labels = app.get("labels", {})
-    yaml.dump(app, hf)
+  labels = {
+    "GIT_LABEL": git_describe,
+    "PURPOSE": "kf-test-cluster",
+    "use-kfctl-go": "{0}".format(args.use_kfctl_go),
+  }
 
   label_args = []
   for k, v in labels.items():
@@ -159,21 +256,12 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
     val = re.sub(r"[^a-z0-9\-_]", "-", val)
     label_args.append("{key}={val}".format(key=k.lower(), val=val))
 
+  if args.use_kfctl_go:
+    deploy_with_kfctl_go(kfctl_path, args, app_dir, env, label_args)
+  else:
+    deploy_with_kfctl_sh(args, app_dir, env, label_args)
 
-  env = {}
-  env.update(os.environ)
-  env.update(oauth_info)
-
-  # We need to apply platform before doing generate k8s because we need
-  # to have a cluster for ksonnet.
-  # kfctl apply all might break during cronjob invocation when depending
-  # components are not ready. Make it retry several times should be enough.
-  run_with_retry([kfctl, "generate", "platform"], cwd=app_dir, env=env)
-  run_with_retry([kfctl, "apply", "platform"], cwd=app_dir, env=env)
-  run_with_retry([kfctl, "generate", "k8s"], cwd=app_dir, env=env)
-  run_with_retry([kfctl, "apply", "k8s"], cwd=app_dir, env=env)
-  run_with_retry(["ks", "generate", "seldon", "seldon"], cwd=ks_app_dir, env=env)
-
+  create_info_file(args, app_dir, git_describe)
   logging.info("Annotating cluster with labels: %s", str(label_args))
 
   # Set labels on the deployment
@@ -184,13 +272,16 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
 
   # To work around lets-encrypt certificate uses create a self-signed
   # certificate
-  util.run(["gcloud", "container", "clusters", "get-credentials", name,
-            "--zone", args.zone,
-            "--project", args.project])
-  tls_endpoint = "--host=%s.endpoints.kubeflow-ci.cloud.goog" % name
-  util.run(["kube-rsa", tls_endpoint])
+  util.run(["kubectl", "config", "use-context", name])
+  tls_endpoint = "--host={0}.endpoints.{1}.cloud.goog".format(
+    name, args.project)
+
+  cert_dir = tempfile.mkdtemp()
+  util.run(["kube-rsa", tls_endpoint], cwd=cert_dir)
   util.run(["kubectl", "-n", "kubeflow", "create", "secret", "tls",
-           "envoy-ingress-tls", "--cert=ca.pem", "--key=ca-key.pem"])
+            "envoy-ingress-tls", "--cert=ca.pem", "--key=ca-key.pem"],
+            cwd=cert_dir)
+  shutil.rmtree(cert_dir)
 
 if __name__ == "__main__":
   main()

--- a/test-infra/auto-deploy/deploy-cron-v0-5.yaml
+++ b/test-infra/auto-deploy/deploy-cron-v0-5.yaml
@@ -20,8 +20,8 @@ spec:
               value: /secret/gcp-credentials/key.json
             command:
             - /usr/local/bin/auto_deploy.sh
-            - --repos=kubeflow/kubeflow@v0.4-branch;kubeflow/testing
-            - --project=kubeflow-ci
+            - --repos=kubeflow/kubeflow@v0.5-branch;kubeflow/testing
+            - --project=kubeflow-ci-deployment
             - --job_labels=/etc/pod-info/labels
             - --data_dir=/mnt/test-data-volume/auto_deploy
             - --base_name=kf-vmaster

--- a/test-infra/auto-deploy/deploy-master.yaml
+++ b/test-infra/auto-deploy/deploy-master.yaml
@@ -23,7 +23,7 @@ spec:
         command:
         - /usr/local/bin/auto_deploy.sh
         - --repos=kubeflow/kubeflow;jlewi/testing@auto_manual
-        - --project=kubeflow-ci
+        - --project=kubeflow-ci-deployment
         - --job_labels=/etc/pod-info/labels
         - --data_dir=/mnt/test-data-volume/auto_deploy
         - --base_name=kf-vmaster

--- a/test-infra/auto-deploy/deploy-master.yaml
+++ b/test-infra/auto-deploy/deploy-master.yaml
@@ -22,7 +22,8 @@ spec:
           value: /secret/gcp-credentials/key.json
         command:
         - /usr/local/bin/auto_deploy.sh
-        - --repos=kubeflow/kubeflow;jlewi/testing@auto_manual
+        # TODO(jlewi): Stop using Jeremy's repo once #344 is checked in.
+        - --repos=kubeflow/kubeflow;jlewi/testing@autodeploy_kfctl
         - --project=kubeflow-ci-deployment
         - --job_labels=/etc/pod-info/labels
         - --data_dir=/mnt/test-data-volume/auto_deploy

--- a/test-infra/ks_app/components/cleanup-ci-cron.jsonnet
+++ b/test-infra/ks_app/components/cleanup-ci-cron.jsonnet
@@ -6,14 +6,15 @@ local env = std.extVar("__ksonnet/environments");
 local k = import "k.libsonnet";
 local cleanup = import "cleanup-ci.libsonnet";
 
-local job = {
+local project = "kubeflow-ci";
+local job(project) = {
     "apiVersion": "batch/v1beta1", 
     "kind": "CronJob", 
     "metadata": {           
-      name: params.name,
+      name: params.name + "-" + project,
       namespace: env.namespace,
       labels: {
-        app: "cleanup-ci"
+        app: "cleanup-ci-" + project,
       },
     }, 
     spec: {
@@ -23,14 +24,16 @@ local job = {
       jobTemplate: {
         metadata: {
           labels: {
-            app: "cleanup-ci",
+            app: "cleanup-ci-" + project,
           },
         },
-        spec: cleanup.jobSpec,
+        spec: cleanup.jobSpec(project),
       },
     }, 
 };
 
-std.prune(k.core.v1.list.new([  
-  job,
+std.prune(k.core.v1.list.new([
+  // Setup 2 cron jobs for the two projects.
+  job("kubeflow-ci"),
+  job("kubeflow-ci-deployment"),
 ]))

--- a/test-infra/ks_app/components/cleanup-ci.jsonnet
+++ b/test-infra/ks_app/components/cleanup-ci.jsonnet
@@ -6,19 +6,20 @@ local env = std.extVar("__ksonnet/environments");
 local k = import "k.libsonnet";
 local cleanup = import "cleanup-ci.libsonnet";
 
-local job = {
+local job(project) = {
     "apiVersion": "batch/v1", 
     "kind": "Job", 
     "metadata": {           
-      name: params.name,
+      name: params.name + "-" + project,
       namespace: env.namespace,
       labels: {
-        app: "cleanup-ci"
+        app: "cleanup-ci" + "-" + project,
       },
     }, 
-    "spec": cleanup.jobSpec,
+    "spec": cleanup.jobSpec(project),
 };
 
 std.prune(k.core.v1.list.new([  
-  job,
+  job("kubeflow-ci"),
+  job("kubeflow-ci-deployment"),
 ]))

--- a/test-infra/ks_app/components/cleanup-ci.libsonnet
+++ b/test-infra/ks_app/components/cleanup-ci.libsonnet
@@ -16,7 +16,7 @@
       )
   )],
 
-  jobSpec:: {
+  jobSpec:: function(project="kubeflow-ci"){      
       "template": {
         "spec": {
           "containers": [
@@ -29,6 +29,7 @@
                 "python",
                 "-m",
                 "kubeflow.testing.cleanup_ci",
+                "--project=" + project,
                 "all",
                 "--delete_script=/src/kubeflow/kubeflow/scripts/gke/delete_deployment.sh",
               ],


### PR DESCRIPTION
* Move auto-deployments into project kubeflow-ci-deployment.

* Fix a bug in cleanup_ci.py; we were not properly handling the case where there was no manifest in the deployment.

* Update cleanup ci cron jobs to run in two projects
  kubeflow-ci and kubeflow-ci-deployment.

* Create a cron job for auto deploying 0.5
* Update the cron job for auto-deploying master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/344)
<!-- Reviewable:end -->
