### PR TITLE
Update cronjob to deploy testing clusters to kubeflow-ci-deployment

### DIFF
--- a/py/kubeflow/testing/create_kf_instance.py
+++ b/py/kubeflow/testing/create_kf_instance.py
@@ -260,6 +260,13 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
             "--update-labels", ",".join(label_args)],
             cwd=app_dir)
 
+  # Set labels on the cluster. Labels on the deployment is not shown on
+  # Pantheon - it's easier for users to read if cluster also has labels.
+  util.run(["gcloud", "container", "clusters", "update", name,
+            "--zone", args.zone,
+            "--update-labels", ",".join(label_args)],
+           cwd=app_dir)
+
   # To work around lets-encrypt certificate uses create a self-signed
   # certificate
   util.run(["kubectl", "config", "use-context", name])

--- a/test-infra/auto-deploy/auto_deploy.sh
+++ b/test-infra/auto-deploy/auto_deploy.sh
@@ -15,6 +15,9 @@ required_args=(data_dir repos project job_labels base_name max_num_cluster zone)
 parseArgs $*
 validateRequiredArgs ${required_args}
 
+export CLIENT_ID=$(cat /secret/oauth-secret/CLIENT_ID)
+export CLIENT_SECRET=$(cat /secret/oauth-secret/CLIENT_SECRET)
+
 # Activate service account auth.
 if [ ! -z ${GOOGLE_APPLICATION_CREDENTIALS} ]; then
   gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}

--- a/test-infra/auto-deploy/deploy-cron-master.yaml
+++ b/test-infra/auto-deploy/deploy-cron-master.yaml
@@ -14,14 +14,10 @@ spec:
         spec:
           containers:
           - name: deploy-worker
-            image: gcr.io/kubeflow-ci/deploy-worker:v20190403-33a1352-e3b0c4
+            image: gcr.io/kubeflow-ci/deploy-worker:v20190404-988c459-dirty-171aa4
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secret/gcp-credentials/key.json
-            - name: CLIENT_ID
-              value: 29647740582-7meo6c7a9a76jvg54j0g2lv8lrsb4l8g.apps.googleusercontent.com
-            - name: CLIENT_SECRET
-              value: CJ4qVPLTi0j0GJMkONj7Quwt
             command:
             - /usr/local/bin/auto_deploy.sh
             - --repos=kubeflow/kubeflow;kubeflow/testing
@@ -35,6 +31,9 @@ spec:
             volumeMounts:
             - name: gcp-credentials
               mountPath: /secret/gcp-credentials
+              readOnly: true
+            - name: oauth-secret
+              mountPath: /secret/oauth-secret
               readOnly: true
             - name: pod-info
               mountPath: /etc/pod-info
@@ -50,6 +49,9 @@ spec:
           - name: gcp-credentials
             secret:
               secretName: gcp-credentials
+          - name: oauth-secret
+            secret:
+              secretName: kubeflow-ci-deployment-iap-testing-oauth
           - name: github-token
             secret:
               secretName: github-token

--- a/test-infra/auto-deploy/deploy-cron-master.yaml
+++ b/test-infra/auto-deploy/deploy-cron-master.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: deploy-worker
-            image: gcr.io/kubeflow-ci/deploy-worker:v20190404-988c459-dirty-171aa4
+            image: gcr.io/kubeflow-ci/deploy-worker:v20190404-cda5cee-e3b0c4
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secret/gcp-credentials/key.json

--- a/test-infra/auto-deploy/deploy-cron-master.yaml
+++ b/test-infra/auto-deploy/deploy-cron-master.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: deploy-worker
-            image: gcr.io/kubeflow-ci/deploy-worker:v20190302-afc8ef8-dirty-201fe5
+            image: gcr.io/kubeflow-ci/deploy-worker:v20190403-33a1352-e3b0c4
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secret/gcp-credentials/key.json

--- a/test-infra/auto-deploy/deploy-cron-master.yaml
+++ b/test-infra/auto-deploy/deploy-cron-master.yaml
@@ -18,10 +18,14 @@ spec:
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secret/gcp-credentials/key.json
+            - name: CLIENT_ID
+              value: 29647740582-7meo6c7a9a76jvg54j0g2lv8lrsb4l8g.apps.googleusercontent.com
+            - name: CLIENT_SECRET
+              value: CJ4qVPLTi0j0GJMkONj7Quwt
             command:
             - /usr/local/bin/auto_deploy.sh
             - --repos=kubeflow/kubeflow;kubeflow/testing
-            - --project=kubeflow-ci
+            - --project=kubeflow-ci-deployment
             - --job_labels=/etc/pod-info/labels
             - --data_dir=/mnt/test-data-volume/auto_deploy
             - --base_name=kf-vmaster

--- a/test-infra/auto-deploy/deploy-cron-v0-5.yaml
+++ b/test-infra/auto-deploy/deploy-cron-v0-5.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: deploy-worker
-            image: gcr.io/kubeflow-ci/deploy-worker:v20190403-33a1352-e3b0c4
+            image: gcr.io/kubeflow-ci/deploy-worker:v20190404-cda5cee-e3b0c4
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secret/gcp-credentials/key.json

--- a/test-infra/auto-deploy/deploy-cron-v0-5.yaml
+++ b/test-infra/auto-deploy/deploy-cron-v0-5.yaml
@@ -18,6 +18,10 @@ spec:
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secret/gcp-credentials/key.json
+            - name: CLIENT_ID
+              value: 29647740582-7meo6c7a9a76jvg54j0g2lv8lrsb4l8g.apps.googleusercontent.com
+            - name: CLIENT_SECRET
+              value: CJ4qVPLTi0j0GJMkONj7Quwt
             command:
             - /usr/local/bin/auto_deploy.sh
             - --repos=kubeflow/kubeflow@v0.5-branch;kubeflow/testing

--- a/test-infra/auto-deploy/deploy-cron-v0-5.yaml
+++ b/test-infra/auto-deploy/deploy-cron-v0-5.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: auto-deploy-v0-4
+  name: auto-deploy-v0-5
   clusterName: kubeflow-testing
   namespace: kubeflow-test-infra
 spec:

--- a/test-infra/auto-deploy/deploy-cron-v0-5.yaml
+++ b/test-infra/auto-deploy/deploy-cron-v0-5.yaml
@@ -24,7 +24,7 @@ spec:
             - --project=kubeflow-ci-deployment
             - --job_labels=/etc/pod-info/labels
             - --data_dir=/mnt/test-data-volume/auto_deploy
-            - --base_name=kf-vmaster
+            - --base_name=kf-v0-5
             - --max_num_cluster=5
             - --zone=us-east1-b
             - --github_token_file=/secret/github-token/github_token

--- a/test-infra/auto-deploy/deploy-cron-v0-5.yaml
+++ b/test-infra/auto-deploy/deploy-cron-v0-5.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: deploy-worker
-            image: gcr.io/kubeflow-ci/deploy-worker:v20190302-afc8ef8-dirty-201fe5
+            image: gcr.io/kubeflow-ci/deploy-worker:v20190403-33a1352-e3b0c4
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secret/gcp-credentials/key.json

--- a/test-infra/auto-deploy/deploy-cron-v0-5.yaml
+++ b/test-infra/auto-deploy/deploy-cron-v0-5.yaml
@@ -18,10 +18,6 @@ spec:
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secret/gcp-credentials/key.json
-            - name: CLIENT_ID
-              value: 29647740582-7meo6c7a9a76jvg54j0g2lv8lrsb4l8g.apps.googleusercontent.com
-            - name: CLIENT_SECRET
-              value: CJ4qVPLTi0j0GJMkONj7Quwt
             command:
             - /usr/local/bin/auto_deploy.sh
             - --repos=kubeflow/kubeflow@v0.5-branch;kubeflow/testing
@@ -35,6 +31,9 @@ spec:
             volumeMounts:
             - name: gcp-credentials
               mountPath: /secret/gcp-credentials
+              readOnly: true
+            - name: oauth-secret
+              mountPath: /secret/oauth-secret
               readOnly: true
             - name: pod-info
               mountPath: /etc/pod-info
@@ -50,6 +49,9 @@ spec:
           - name: gcp-credentials
             secret:
               secretName: gcp-credentials
+          - name: oauth-secret
+            secret:
+              secretName: kubeflow-ci-deployment-iap-testing-oauth
           - name: github-token
             secret:
               secretName: github-token


### PR DESCRIPTION
Fixes #350
Updates with this PR:
1. Adds back labels to clusters.
1. Use `CLIENT_ID/CLIENT_SECRET` from kubeflow-ci-deployment.
1. Fixes base name for v0-5 cronjobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/352)
<!-- Reviewable:end -->
