### PR TITLE
Fix cleanup_ci.py - fix cleanup of argo workflows and IAM policy bindings

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,21 +1,7 @@
 # TODO(jlewi): We should probably have OWNERs files in subdirectories that
 # list approvers for individual components (e.g. Seldon folks for Seldon component)
 approvers:
-  - DjangoPeng
-  - gaocegege
   - jlewi
   - lluunn
-  - pdmack
-  - ScorpioCPH
   - kunmingg
   - richardsliu
-reviewers:
-  - DjangoPeng
-  - gaocegege
-  - Jimexist
-  - jlewi
-  - lluunn
-  - ScorpioCPH
-  - wbuchwalter
-  - zjj2wry
-  - kunmingg

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex \
     wget \
     ca-certificates \
     git \
+    emacs \
     jq \
     zip \
     unzip \
@@ -136,13 +137,16 @@ RUN cd /tmp/ && \
     pip2 install -U wheel filelock && \
     pip2 install pipenv && \
     pip2 install requests && \
-    pip2 install google-api-python-client && \
     pip2 install prometheus_client && \
     pipenv install --system --two && \
     pip3 install -U wheel filelock
 
 RUN pip3 install pipenv==2018.10.9
 RUN cd /tmp/ && pipenv install --system --three
+
+# Force update of googleapipython client
+# Do this after pipenv because we want to override what pipenv installs.
+RUN pip2 install --upgrade google-api-python-client==1.7.0
 
 RUN pip install yq
 

--- a/images/gcb_build/image_build.json
+++ b/images/gcb_build/image_build.json
@@ -1,6 +1,6 @@
 {
    "images": [
-      "gcr.io/kubeflow-ci/test-worker:v20190302-c0829e8-dirty-f1d98c",
+      "gcr.io/kubeflow-ci/test-worker:v20190415-53ad3b5-dirty-5bc1cf",
       "gcr.io/kubeflow-ci/test-worker:latest"
    ],
    "steps": [
@@ -19,7 +19,7 @@
          "args": [
             "build",
             "-t",
-            "gcr.io/kubeflow-ci/test-worker:v20190302-c0829e8-dirty-f1d98c",
+            "gcr.io/kubeflow-ci/test-worker:v20190415-53ad3b5-dirty-5bc1cf",
             "--label=git-versions=",
             "--file=./Dockerfile",
             "--cache-from=gcr.io/kubeflow-ci/test-worker:latest",
@@ -34,7 +34,7 @@
       {
          "args": [
             "tag",
-            "gcr.io/kubeflow-ci/test-worker:v20190302-c0829e8-dirty-f1d98c",
+            "gcr.io/kubeflow-ci/test-worker:v20190415-53ad3b5-dirty-5bc1cf",
             "gcr.io/kubeflow-ci/test-worker:latest"
          ],
          "id": "tag-test-worker",

--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -88,7 +88,7 @@ def cleanup_workflows(args):
           crd_api.delete_namespaced_custom_object(
             argo_client.GROUP, argo_client.VERSION, args.namespace,
             argo_client.PLURAL, name, k8s_client.V1DeleteOptions())
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-except
           logging.error("There was a problem deleting workflow %s.%s; "
                         "error: %s", args.namespace, args.name, e)
     if is_expired:

--- a/test-infra/ks_app/components/cleanup-ci.libsonnet
+++ b/test-infra/ks_app/components/cleanup-ci.libsonnet
@@ -34,7 +34,7 @@
                 "--delete_script=/src/kubeflow/kubeflow/scripts/gke/delete_deployment.sh",
               ],
               ]), 
-              "image": "gcr.io/kubeflow-ci/test-worker/test-worker:v20190116-b7abb8d-e3b0c4", 
+              "image": "gcr.io/kubeflow-ci/test-worker:v20190415-53ad3b5-dirty-5bc1cf", 
               "name": "label-sync",
               env: [
                 {


### PR DESCRIPTION
Fix cleanup_ci.py - cleaning of Argo and service account binding

* Add logging to make it easier to monitor progress.
* Print out stack traces on errors.

* cleanup_workflows needs to get GKE credentials.
  * The project might be different from the project where KF is deployed.

Related to #358 cleanup ci not cleaning up Argo workflows

Related to #357 cleanup ci not cleaning up IAM policies.

* Fix bug in cleaning up Argo workflows; we should not break out of loop.

* Don't exit if delete of Workflow fails; it looks like there might be
  some race conditions.

* Update the docker image to use google-api-python-client library 1.7.0 instead
  of 1.6.5. It looks like using 1.6.5 gives us an error when getting IAM
  policy.

* Prune the OWNERs file to remove a bunch of approvers who haven't been active.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/359)
<!-- Reviewable:end -->
