### PR TITLE
Argo workflows's should stick around for a week or so.

### DIFF
--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -80,7 +80,7 @@ def cleanup_workflows(args):
 
     name = w["metadata"]["name"]
     age = now - start_time
-    if age > datetime.timedelta(hours=args.max_age_hours):
+    if age > datetime.timedelta(hours=args.max_wf_age_hours):
       logging.info("Deleting workflow: %s", name)
       is_expired = True
       if not args.dryrun:
@@ -623,6 +623,10 @@ def main():
 
   parser.add_argument(
     "--max_age_hours", default=3, type=int, help=("The age of deployments to gc."))
+
+  parser.add_argument(
+    "--max_wf_age_hours", default=7*24, type=int,
+    help=("How long to wait before garbage collecting Argo workflows."))
 
   parser.add_argument('--dryrun', dest='dryrun', action='store_true')
   parser.add_argument('--no-dryrun', dest='dryrun', action='store_false')


### PR DESCRIPTION
* Argo workflows were being GC'd after 3 hours like other resources. That is
too aggressive. We want the workflows to be around longer to aid debugging.
* Fix 362

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/363)
<!-- Reviewable:end -->
