### PR TITLE
Add fire, gitpython and hub to test image and fix namespace packaging

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -137,9 +137,9 @@ RUN cd /tmp/ && \
     pip2 install -U wheel filelock && \
     pip2 install pipenv && \
     pip2 install requests && \
-    pip2 install prometheus_client && \
+    pip2 install prometheus_client fire && \
     pipenv install --system --two && \
-    pip3 install -U wheel filelock
+    pip3 install -U wheel filelock gitpython fire
 
 RUN pip3 install pipenv==2018.10.9
 RUN cd /tmp/ && pipenv install --system --three
@@ -148,10 +148,19 @@ RUN cd /tmp/ && pipenv install --system --three
 # Do this after pipenv because we want to override what pipenv installs.
 RUN pip2 install --upgrade google-api-python-client==1.7.0
 
+# Install the hub CLI for git
+RUN cd /tmp && \
+    curl -LO  https://github.com/github/hub/releases/download/v2.11.2/hub-linux-amd64-2.11.2.tgz && \
+    tar -xvf hub-linux-amd64-2.11.2.tgz && \
+    mv hub-linux-amd64-2.11.2 /usr/local && \
+    ln -sf /usr/local/hub-linux-amd64-2.11.2/bin/hub /usr/local/bin/hub
+
 RUN pip install yq
 
 COPY checkout.sh /usr/local/bin
-RUN chmod a+x /usr/local/bin/checkout.sh
+COPY checkout_repos.sh /usr/local/bin
+COPY setup_ssh.sh /usr/local/bin
+RUN chmod a+x /usr/local/bin/checkout* /usr/local/bin/setup_ssh.sh
 
 COPY run_workflows.sh /usr/local/bin
 RUN chmod a+x /usr/local/bin/run_workflows.sh

--- a/images/Makefile
+++ b/images/Makefile
@@ -15,8 +15,9 @@
 # Requirements:
 #   https://github.com/mattrobenolt/jinja2-cli
 #   pip install jinja2-clie
-IMG = gcr.io/kubeflow-ci/test-worker
-RELEASE_WORKER = gcr.io/kubeflow-releasing/worker
+BUILD_PROJECT ?= kubeflow-ci
+IMG ?= gcr.io/kubeflow-ci/test-worker
+RELEASE_WORKER ?= gcr.io/kubeflow-releasing/worker
 
 # Whether to use cached images with GCB
 USE_IMAGE_CACHE ?= true
@@ -63,6 +64,6 @@ build-gcb-spec:
 # and don't want to pull images locally.
 # Its also used to build from our CI system.
 build-gcb: build-gcb-spec		
-	gcloud builds submit --machine-type=n1-highcpu-32 --project=kubeflow-ci \
+	gcloud builds submit --machine-type=n1-highcpu-32 --project=$(BUILD_PROJECT) \
 	    --config=./gcb_build/image_build.json \
 		--timeout=3600 .

--- a/images/checkout_repos.sh
+++ b/images/checkout_repos.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# This script is used to checkout repositories.
+# This is typically used to bootstrap various scripts
+# by first checking out the code in an init container.
+#
+# For a pull request do
+# {REPO_ORG}/{REPO_NAME}@{SHA}:{PULL_NUMBER}
+#
+# You can use HEAD as the sha to get the latest for a pull request.
+#
+# You can use "--links" to create symbolic links to the newly created directories.
+# This allows you to check out forks of the Kubeflow repos but lay them out as if you
+# checked out the original repos so that you can use scripts that depend on that layout.
+set -xe
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+parseArgs() {
+  # Parse all command line options
+  while [[ $# -gt 0 ]]; do
+    # Parameters should be of the form
+    # --{name}=${value}
+    echo parsing "$1"
+    if [[ $1 =~ ^--(.*)=(.*)$ ]]; then
+      name=${BASH_REMATCH[1]}
+      value=${BASH_REMATCH[2]}
+
+      eval ${name}="${value}"
+    elif [[ $1 =~ ^--(.*)$ ]]; then
+    name=${BASH_REMATCH[1]}
+    value=true
+    eval ${name}="${value}"
+    else
+      echo "Argument $1 did not match the pattern --{name}={value} or --{name}"
+    fi
+    shift
+  done
+}
+
+usage() {
+  echo "Usage: checkout_repos --repos=<{REPO_ORG}/{REPO_NAME}@{SHA}:{PULL_NUMBER},{REPO_ORG}/{REPO_NAME}@HEAD:{PULL_NUMBER}> --src_dir=<Where to check them out> --links=<src1>=<dest1>,<src2>=<dest2>"
+}
+
+main() {
+
+  cd "${DIR}"
+
+  # List of required parameters
+  names=(repos src_dir)
+
+  missingParam=false
+  for i in ${names[@]}; do
+    if [ -z ${!i} ]; then
+      echo "--${i} not set"
+      missingParam=true
+    fi
+  done
+
+  if ${missingParam}; then
+    usage
+    exit 1
+  fi
+
+  # Check out any extra repos.
+  IFS=',' read -ra SPLIT_REPOS <<< "${repos}"
+  echo SPLIT_REPOS=${SPLIT_REPOS}
+  for r in "${SPLIT_REPOS[@]}"; do
+    echo "Processing ${r}" 
+    ORG_NAME="$(cut -d'@' -f1 <<< "$r")"
+    EXTRA_ORG="$(cut -d'/' -f1 <<< "$ORG_NAME")"
+    EXTRA_NAME="$(cut -d'/' -f2<<< "$ORG_NAME")"
+    SHA_AND_PR="$(cut -d'@' -f2 <<< "$r")"  
+    SHA="$(cut -d':' -f1 <<< "$SHA_AND_PR")"  
+    EXTRA_PR="$(cut -d':' -s -f2 <<< "$SHA_AND_PR")"
+    URL=https://github.com/${EXTRA_ORG}/${EXTRA_NAME}.git
+    TARGET=${src_dir}/${EXTRA_ORG}/${EXTRA_NAME}
+
+    mkdir -p ${src_dir}/${EXTRA_ORG}
+
+    if [ ! -d ${TARGET} ]; then
+      git clone  ${URL} ${TARGET}      
+    else 
+      # init containers might get restarted so its possible we already checked out the repo
+      echo ${TARGET} already exists
+    fi
+
+    cd ${TARGET}
+
+    if [ ! -z ${EXTRA_PR} ]; then
+      git fetch origin  pull/${EXTRA_PR}/head:pr
+      git checkout pr
+
+      if [ "$SHA" -ne "HEAD" ]; then
+        git checkout ${SHA}
+      fi      
+    else    
+      git checkout ${SHA}
+    fi
+    echo ${TARGET} is at `git describe --tags --always --dirty`
+  done  
+
+  IFS=',' read -ra LINKS <<< "${links}"
+  echo LINKS=${LINKS}
+  for r in "${LINKS[@]}"; do
+    link_src="$(cut -d'=' -f1 <<< "$r")"
+    link_dest="$(cut -d'=' -f2<<< "$r")"
+    # Ensure parent directory exists
+    mkdir -p $(dirname ${src_dir}/${link_dest})
+    ln -sf ${src_dir}/${link_src} ${src_dir}/${link_dest}
+  done
+}
+
+parseArgs $*
+main

--- a/images/gcb_build/image_build.json
+++ b/images/gcb_build/image_build.json
@@ -1,13 +1,13 @@
 {
    "images": [
-      "gcr.io/kubeflow-ci/test-worker:v20190415-53ad3b5-dirty-5bc1cf",
-      "gcr.io/kubeflow-ci/test-worker:latest"
+      "gcr.io/kubeflow-releasing/test-worker:v20190421-c9a1370-dirty-3a99df",
+      "gcr.io/kubeflow-releasing/test-worker:latest"
    ],
    "steps": [
       {
          "args": [
             "pull",
-            "gcr.io/kubeflow-ci/test-worker:latest"
+            "gcr.io/kubeflow-releasing/test-worker:latest"
          ],
          "id": "pull-test-worker",
          "name": "gcr.io/cloud-builders/docker",
@@ -19,10 +19,10 @@
          "args": [
             "build",
             "-t",
-            "gcr.io/kubeflow-ci/test-worker:v20190415-53ad3b5-dirty-5bc1cf",
+            "gcr.io/kubeflow-releasing/test-worker:v20190421-c9a1370-dirty-3a99df",
             "--label=git-versions=",
             "--file=./Dockerfile",
-            "--cache-from=gcr.io/kubeflow-ci/test-worker:latest",
+            "--cache-from=gcr.io/kubeflow-releasing/test-worker:latest",
             "."
          ],
          "id": "build-test-worker",
@@ -34,8 +34,8 @@
       {
          "args": [
             "tag",
-            "gcr.io/kubeflow-ci/test-worker:v20190415-53ad3b5-dirty-5bc1cf",
-            "gcr.io/kubeflow-ci/test-worker:latest"
+            "gcr.io/kubeflow-releasing/test-worker:v20190421-c9a1370-dirty-3a99df",
+            "gcr.io/kubeflow-releasing/test-worker:latest"
          ],
          "id": "tag-test-worker",
          "name": "gcr.io/cloud-builders/docker",

--- a/images/setup_ssh.sh
+++ b/images/setup_ssh.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# This script is used to setup a .ssh directory that mounts an SSH key.
+#
+set -xe
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+parseArgs() {
+  # Parse all command line options
+  while [[ $# -gt 0 ]]; do
+    # Parameters should be of the form
+    # --{name}=${value}
+    echo parsing "$1"
+    if [[ $1 =~ ^--(.*)=(.*)$ ]]; then
+      name=${BASH_REMATCH[1]}
+      value=${BASH_REMATCH[2]}
+
+      eval ${name}="${value}"
+    elif [[ $1 =~ ^--(.*)$ ]]; then
+    name=${BASH_REMATCH[1]}
+    value=true
+    eval ${name}="${value}"
+    else
+      echo "Argument $1 did not match the pattern --{name}={value} or --{name}"
+    fi
+    shift
+  done
+}
+
+usage() {
+  echo "Usage: setup_ssh.sh --ssh_dir=<path to ssh dir> --private_key=<path to private key> --public_key=<path to public_key>"
+}
+
+main() {
+
+  cd "${DIR}"
+
+  # List of required parameters
+  names=(ssh_dir private_key public_key)
+
+  missingParam=false
+  for i in ${names[@]}; do
+    if [ -z ${!i} ]; then
+      echo "--${i} not set"
+      missingParam=true
+    fi
+  done
+
+  if ${missingParam}; then
+    usage
+    exit 1
+  fi
+
+  mkdir -p ${ssh_dir}
+  cp -f ${private_key} ${ssh_dir}
+  cp -f ${public_key} ${ssh_dir}
+  
+  # Set the permissions
+  chmod 700 ${ssh_dir}
+  chmod 600 ${ssh_dir}/$(basename ${private_key})
+  chmod 644 ${ssh_dir}/$(basename ${public_key})
+}
+
+parseArgs $*
+main

--- a/py/kubeflow/__init__.py
+++ b/py/kubeflow/__init__.py
@@ -1,1 +1,1 @@
-path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/py/kubeflow/testing/test_py_lint.py
+++ b/py/kubeflow/testing/test_py_lint.py
@@ -39,6 +39,7 @@ def test_lint(test_case): # pylint: disable=redefined-outer-name
     "dashboard/frontend/node_modules",
     "kubeflow_testing",
     "dev-kubeflow-org/ks-app/vendor",
+    "release-infra",
   ]
   full_dir_excludes = [
     os.path.join(os.path.abspath(args.src_dir), f) for f in dir_excludes


### PR DESCRIPTION
Add fire, gitpython and hub to test image, fix namespace packaging.

* fire is a python library that makes it easy to define entrypoints
* gitpython is a python library for git; this will be used for gitops and CI/CD
* hub is a CLI for github that will be used for gitops

* Create a script to checkout repos. This is intended to be used in
  situations where we want to check out the latest code and then run some
  script.

* Fix a bug in namespace package __init__.py has a typo.

* Parameterize the makefile for the worker image so that we can build the worker image for project kubeflow-releasing using GCB.

* Add a script for configuring permissions on ssh keys.
  * This can be used in an init container to setup ssh keyes;
    see
    https://github.com/jlewi/kubeflow-dev/blob/master/notes/git_on_kubeflow.md

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/365)
<!-- Reviewable:end -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/365)
<!-- Reviewable:end -->
