### PR TITLE
Upload workflow status while timeout

### DIFF
--- a/py/kubeflow/testing/argo_client.py
+++ b/py/kubeflow/testing/argo_client.py
@@ -71,9 +71,9 @@ def get_namespaced_custom_object_with_retries(namespace, name):
 
 
 def wait_for_workflows(namespace, names,
-                      timeout=datetime.timedelta(minutes=30),
-                      polling_interval=datetime.timedelta(seconds=30),
-                      status_callback=None):
+                       timeout=datetime.timedelta(minutes=30),
+                       polling_interval=datetime.timedelta(seconds=30),
+                       status_callback=None):
   """Wait for multiple workflows to finish.
 
   Args:
@@ -86,7 +86,10 @@ def wait_for_workflows(namespace, names,
       is the job.
 
   Returns:
-    results: A list of the final status of the workflows.
+    tuple: (list, bool) consisting of:
+      results: A list of the final status of the workflows.
+      is_timeout: A boolean variable indicating whether this function is
+        returning because of timeout.
   Raises:
     TimeoutError: If timeout waiting for the job to finish.
   """
@@ -106,17 +109,16 @@ def wait_for_workflows(namespace, names,
       # the status field of an object.
       if results.get("status", {}).get("phase", "") not in ["Failed", "Succeeded"]:
         done = False
+        break
 
     if done:
-      return all_results
+      return all_results, False
+
     if datetime.datetime.now() + polling_interval > end_time:
-      raise util.TimeoutError(
-        "Timeout waiting for workflows {0} in namespace {1} to finish.".format(
-          ",".join(names), namespace))
+      return all_results, True
 
     time.sleep(polling_interval.seconds)
 
-  return []
 
 def wait_for_workflow(namespace, name,
                       timeout=datetime.timedelta(minutes=30),

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -267,10 +267,11 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   workflow_phase = {}
   workflow_status_yamls = {}
   try:
-    results = argo_client.wait_for_workflows(get_namespace(args),
-                                             workflow_names,
-                                             timeout=datetime.timedelta(minutes=180),
-                                             status_callback=argo_client.log_status)
+    results, is_timeout = argo_client.wait_for_workflows(
+      get_namespace(args), workflow_names,
+      timeout=datetime.timedelta(minutes=180),
+      status_callback=argo_client.log_status
+    )
     for r in results:
       phase = r.get("status", {}).get("phase")
       name = r.get("metadata", {}).get("name")
@@ -279,6 +280,10 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
       if phase != "Succeeded":
         success = False
       logging.info("Workflow %s/%s finished phase: %s", get_namespace(args), name, phase)
+    if is_timeout:
+      raise util.TimeoutError("Timeout waiting for workflows {0} in namespace "
+                              "{1} to finish.".format(",".join(workflow_names),
+                                                      get_namespace(args)))
   except util.TimeoutError:
     success = False
     logging.exception("Time out waiting for Workflows %s to finish", ",".join(workflow_names))

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -33,9 +33,10 @@ class TestRunE2eWorkflow(unittest.TestCase):
   @mock.patch("kubeflow.testing.run_e2e_workflow.argo_client.wait_for_workflows")
   @mock.patch("kubeflow.testing.run_e2e_workflow.util.configure_kubectl")
   @mock.patch("kubeflow.testing.run_e2e_workflow.util.run")
-  def testWithConfig(self, mock_run, mock_configure, *unused_mocks):  # pylint: disable=no-self-use,unused-argument
+  def testWithConfig(self, mock_run, mock_configure, mock_wait_for_workflows,
+                     *unused_mocks):  # pylint: disable=no-self-use,unused-argument
     """Test creating a workflow from a config file."""
-    # We need to set cwd and the app_dir in the config file consistenly.
+    # We need to set cwd and the app_dir in the config file consistently.
     # The app_dir will be relative to the working dir.
     # We set cwd to the root of the repo and then app dir relative to that.
     this_dir = os.path.basename(__file__)
@@ -74,6 +75,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
             "--zone=us-east1-d", "--bucket=some-bucket",
             "--config_file=" + name,
             "--repos_dir=" + repo_dir]
+    mock_wait_for_workflows.return_value = [], True
     run_e2e_workflow.main(args)
 
     mock_configure.assert_called_once_with("some-project", "us-east1-d",


### PR DESCRIPTION
**Background**

This fixes https://github.com/kubeflow/testing/issues/374.

**Changes**

Now `wait_for_workflows` returns a tuple indicating whether we are returning because the function times out. Then we store the returned `results` in `workflow_status_yamls` and uploads to GCS anyways.

**Tests**

In Progress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/377)
<!-- Reviewable:end -->
