### PR TITLE
Use the injected base branch env var

### DIFF
--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -112,17 +112,20 @@ def generate_env_from_head(args):
     os.environ[k] = env_var.get(k)
 
 def run(args, file_handler): # pylint: disable=too-many-statements,too-many-branches
+  # Check https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md
+  # for a description of the injected environment variables.
   job_type = os.getenv("JOB_TYPE")
   repo_owner = os.getenv("REPO_OWNER")
   repo_name = os.getenv("REPO_NAME")
+  base_branch_name = os.getenv("PULL_BASE_REF")
   pull_base_sha = os.getenv("PULL_BASE_SHA")
 
   # For presubmit/postsubmit jobs, find the list of files changed by the PR.
   diff_command = []
   if job_type == "presubmit":
-    # We need to get a common ancestor for the PR and the master branch
+    # We need to get a common ancestor for the PR and the base branch
     common_ancestor = util.run(
-      ["git", "merge-base", "HEAD", "master"],
+      ["git", "merge-base", "HEAD", base_branch_name],
       cwd=os.path.join(args.repos_dir, repo_owner, repo_name))
     diff_command = ["git", "diff", "--name-only", common_ancestor]
   elif job_type == "postsubmit":

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -58,15 +58,15 @@ class TestRunE2eWorkflow(unittest.TestCase):
     with tempfile.NamedTemporaryFile(delete=False) as hf:
       yaml.dump(config, hf)
       name = hf.name
-    os.environ = {}
-    os.environ["REPO_OWNER"] = "fake_org"
-    os.environ["REPO_NAME"] = "fake_name"
-    os.environ["PULL_NUMBER"] = "77"
-    os.environ["PULL_PULL_SHA"] = "123abc"
-    os.environ["JOB_NAME"] = "kubeflow-presubmit"
-    os.environ["JOB_TYPE"] = "presubmit"
-    os.environ["BUILD_NUMBER"] = "1234"
-    os.environ["BUILD_ID"] = "11"
+    os.environ = {"REPO_OWNER": "fake_org",
+                  "REPO_NAME": "fake_name",
+                  "PULL_NUMBER": "77",
+                  "PULL_PULL_SHA": "123abc",
+                  "JOB_NAME": "kubeflow-presubmit",
+                  "JOB_TYPE": "presubmit",
+                  "BUILD_NUMBER": "1234",
+                  "BUILD_ID": "11",
+                  "PULL_BASE_REF": "test_branch"}
 
     mock_run.return_value = "ab1234"
 
@@ -80,7 +80,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
-      ["git", "merge-base", "HEAD", "master"],
+      ["git", "merge-base", "HEAD", "test_branch"],
       ["git", "diff", "--name-only", "ab1234"],
       ["ks", "version"],
       ["ks", "env", "add", "kubeflow-presubmit-wf-77-123abc-1234-.*",


### PR DESCRIPTION
**Background**

This fixes #375.

**Changes**

Used `PULL_BASE_REF` to get the base branch name and get a common ancestor for the PR and the base branch.

**Tests**

In Progress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/378)
<!-- Reviewable:end -->
