### PR TITLE
GC backend services in kubeflow-ci-deployment

### DIFF
--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -254,8 +254,7 @@ def cleanup_firewall_rules(args):
   logging.info("expired firewall rules:\n%s", "\n".join(expired))
 
 def cleanup_backend_services(args):
-  # We only GC backend services for kubeflow-ci-deployment.
-  if args.project != "kubeflow-ci-deployment":
+  if not args.gc_backend_services:
     return
 
   credentials = GoogleCredentials.get_application_default()
@@ -274,7 +273,7 @@ def cleanup_backend_services(args):
       name = s["name"]
       age = getAge(s["creationTimestamp"])
       if age > datetime.timedelta(
-        hours=args.max_ci_deployemnt_resource_age_hours):
+        hours=args.max_ci_deployment_resource_age_hours):
         logging.info("Deleting backend services: %s, age = %r", name, age)
         if not args.dryrun:
           response = backends.delete(project=args.project, backendService=name)
@@ -664,7 +663,12 @@ def main():
     "--max_age_hours", default=3, type=int, help=("The age of deployments to gc."))
 
   parser.add_argument(
-    "--max_ci_deployemnt_resource_age_hours",
+    "--gc_backend_services", default=False, type=bool,
+    help=("""Whether to GC backend services that are older
+          than --max_ci_deployment_resource_age_hours."""))
+
+  parser.add_argument(
+    "--max_ci_deployment_resource_age_hours",
     default=24, type=int,
     help=("The age of resources in kubeflow-ci-deployment to gc."))
 

--- a/test-infra/ks_app/components/cleanup-ci-cron.jsonnet
+++ b/test-infra/ks_app/components/cleanup-ci-cron.jsonnet
@@ -35,5 +35,5 @@ local job(project) = {
 std.prune(k.core.v1.list.new([
   // Setup 2 cron jobs for the two projects.
   job("kubeflow-ci"),
-  job("kubeflow-ci-deployment"),
+  job("kubeflow-ci-deployment", true),
 ]))

--- a/test-infra/ks_app/components/cleanup-ci.libsonnet
+++ b/test-infra/ks_app/components/cleanup-ci.libsonnet
@@ -16,7 +16,7 @@
       )
   )],
 
-  jobSpec:: function(project="kubeflow-ci"){      
+  jobSpec:: function(project="kubeflow-ci", gcBackendServices=false){
       "template": {
         "spec": {
           "containers": [
@@ -24,7 +24,7 @@
               command: $.buildCommand([[
                 "/usr/local/bin/checkout.sh",
                 "/src",
-              ],             
+              ],
               [
                 "python",
                 "-m",
@@ -32,33 +32,34 @@
                 "--project=" + project,
                 "all",
                 "--delete_script=/src/kubeflow/kubeflow/scripts/gke/delete_deployment.sh",
+                "--gc_backend_services=" + gcBackendServices,
               ],
-              ]), 
-              "image": "gcr.io/kubeflow-ci/test-worker:v20190415-53ad3b5-dirty-5bc1cf", 
+              ]),
+              "image": "gcr.io/kubeflow-ci/test-worker:v20190415-53ad3b5-dirty-5bc1cf",
               "name": "label-sync",
               env: [
                 {
                   name: "REPO_OWNER",
-                  value: "kubeflow",                  
+                  value: "kubeflow",
                 },
                 {
                   name: "REPO_NAME",
-                  value: "testing",                  
+                  value: "testing",
                 },
                 {
                   name: "PYTHONPATH",
                   value: "/src/kubeflow/testing/py",
                 },
                 {
-                  name: "EXTRA_REPOS",                  
+                  name: "EXTRA_REPOS",
                   value: "kubeflow/kubeflow@HEAD",
                 },
                 {
                   name: "GOOGLE_APPLICATION_CREDENTIALS",
                   value: "/secret/gcp-credentials/key.json",
-                },              
+                },
               ],
-              "volumeMounts": [                
+              "volumeMounts": [
                 {
                   name: "gcp-credentials",
                   mountPath: "/secret/gcp-credentials",
@@ -66,15 +67,15 @@
                 },
               ]
             }
-          ], 
-          "restartPolicy": "Never", 
+          ],
+          "restartPolicy": "Never",
           "volumes": [
             {
               name: "gcp-credentials",
               secret: {
                 secretName: "kubeflow-testing-credentials",
               },
-            },            
+            },
           ]
         }
       }


### PR DESCRIPTION
#361 

Clean up backend services older than 24 hours in kubeflow-ci-deployment. The health checks related to the backend service will be cleaned up by existing `cleanup_health_checks` function.

/cc @jlewi @gabrielwen

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/382)
<!-- Reviewable:end -->
