### PR TITLE
Fetch remote branches in E2E test

### DIFF
--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -125,8 +125,9 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   if job_type == "presubmit":
     # We need to get a common ancestor for the PR and the base branch
     cloned_repo_dir = os.path.join(args.repos_dir, repo_owner, repo_name)
-    _ = util.run(["git", "checkout", base_branch_name], cwd=cloned_repo_dir)
-    common_ancestor = util.run(["git", "merge-base", "HEAD", base_branch_name],
+    _ = util.run(["git", "fetch", "origin", base_branch_name], cwd=cloned_repo_dir)
+    common_ancestor = util.run(["git", "merge-base", "HEAD",
+                                "remotes/origin/{}".format(base_branch_name)],
                                cwd=cloned_repo_dir)
     diff_command = ["git", "diff", "--name-only", common_ancestor]
   elif job_type == "postsubmit":

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -124,7 +124,7 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   diff_command = []
   if job_type == "presubmit":
     # We need to get a common ancestor for the PR and the base branch
-    cloned_repo_dir = os.path.join(args.repo_dir, repo_owner, repo_name)
+    cloned_repo_dir = os.path.join(args.repos_dir, repo_owner, repo_name)
     _ = util.run(["git", "checkout", base_branch_name], cwd=cloned_repo_dir)
     common_ancestor = util.run(["git", "merge-base", "HEAD", base_branch_name],
                                cwd=cloned_repo_dir)

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -124,9 +124,10 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
   diff_command = []
   if job_type == "presubmit":
     # We need to get a common ancestor for the PR and the base branch
-    common_ancestor = util.run(
-      ["git", "merge-base", "HEAD", base_branch_name],
-      cwd=os.path.join(args.repos_dir, repo_owner, repo_name))
+    cloned_repo_dir = os.path.join(args.repo_dir, repo_owner, repo_name)
+    _ = util.run(["git", "checkout", base_branch_name], cwd=cloned_repo_dir)
+    common_ancestor = util.run(["git", "merge-base", "HEAD", base_branch_name],
+                               cwd=cloned_repo_dir)
     diff_command = ["git", "diff", "--name-only", common_ancestor]
   elif job_type == "postsubmit":
     # See: https://git-scm.com/docs/git-diff

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -82,8 +82,8 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
-      ["git", "checkout", "test_branch"],
-      ["git", "merge-base", "HEAD", "test_branch"],
+      ["git", "fetch", "origin" "test_branch"],
+      ["git", "merge-base", "HEAD", "remotes/origin/test_branch"],
       ["git", "diff", "--name-only", "ab1234"],
       ["ks", "version"],
       ["ks", "env", "add", "kubeflow-presubmit-wf-77-123abc-1234-.*",

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -114,7 +114,6 @@ class TestRunE2eWorkflow(unittest.TestCase):
     ]
 
     for i, expected in enumerate(expected_calls):
-      print(expected, mock_run.call_args_list[i][0][0])
       self.assertItemsMatchRegex(
         expected,
         mock_run.call_args_list[i][0][0])

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -82,6 +82,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
+      ["git", "checkout", "test_branch"],
       ["git", "merge-base", "HEAD", "test_branch"],
       ["git", "diff", "--name-only", "ab1234"],
       ["ks", "version"],

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -82,7 +82,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
-      ["git", "fetch", "origin" "test_branch"],
+      ["git", "fetch", "origin", "test_branch"],
       ["git", "merge-base", "HEAD", "remotes/origin/test_branch"],
       ["git", "diff", "--name-only", "ab1234"],
       ["ks", "version"],
@@ -114,6 +114,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
     ]
 
     for i, expected in enumerate(expected_calls):
+      print(expected, mock_run.call_args_list[i][0][0])
       self.assertItemsMatchRegex(
         expected,
         mock_run.call_args_list[i][0][0])

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -117,10 +117,14 @@ class TestRunE2eWorkflow(unittest.TestCase):
       self.assertItemsMatchRegex(
         expected,
         mock_run.call_args_list[i][0][0])
-      if i > 2:
+      if mock_run.call_args_list[i][0][0][0] == 'git':
         self.assertEqual(
-           os.path.join(cwd, "workflows"),
-           mock_run.call_args_list[i][1]["cwd"])
+          os.path.join(cwd, os.environ['REPO_OWNER'], os.environ['REPO_NAME']),
+          mock_run.call_args_list[i][1]['cwd'])
+      elif 'cwd' in mock_run.call_args_list[i][1]:
+        self.assertEqual(
+          os.path.join(cwd, 'workflows'),
+          mock_run.call_args_list[i][1]["cwd"])
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
**Background**

In https://github.com/kubeflow/kubeflow/pull/3216, @gabrielwen is observing error messages like ```fatal: Not a valid object name v0.5-branch``` in the presubmit tests.

This is because I was doing things like `git merge-base HEAD v0.5-branch` in https://github.com/kubeflow/testing/pull/378, e.g.

```
~/src/kubeflow/kubeflow master
❯ git merge-base HEAD v0.5-branch
fatal: Not a valid object name v0.5-branch
```

Instead we should do:

```
~/src/kubeflow/kubeflow v0.5-branch
❯ git merge-base HEAD remotes/origin/v0.4-branch
d48e22b2f7d7b80e14c5a07bf171f358b9f91131
```

**Changes**

* Added `remotes/origin` before the branch name in `git merge-base`

**Tests**

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/385)
<!-- Reviewable:end -->
