### PR TITLE
Add  gabrielwen  & zhenghuiwang to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 # TODO(jlewi): We should probably have OWNERs files in subdirectories that
 # list approvers for individual components (e.g. Seldon folks for Seldon component)
 approvers:
+  - gabrielwen
   - jlewi
-  - lluunn
   - kunmingg
+  - lluunn
   - richardsliu
   - zabbasi
-  - gabrielwen
   - zhenghuiwang

--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,5 @@ approvers:
   - kunmingg
   - richardsliu
   - zabbasi
+  - gabrielwen
+  - zhenghuiwang


### PR DESCRIPTION
The ONWERS file https://github.com/kubeflow/testing/blob/master/py/kubeflow/OWNERS doesn't work. So add us to the top level OWNERS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/389)
<!-- Reviewable:end -->
