### PR TITLE
Add cmake to testing worker image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
     && apt-get update -yqq \
     && apt-get install -yqq --no-install-recommends \
     build-essential \
+    cmake \
     curl \
     locales \
     uuid-runtime \


### PR DESCRIPTION
Add `cmake` to compile C++ dependencies for Kubeflow metadata server build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/399)
<!-- Reviewable:end -->
