### PR TITLE
Add a custom exception wrapping workflow results

### DIFF
--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -546,6 +546,12 @@ class TimeoutError(Exception):  # pylint: disable=redefined-builtin
   """An error indicating an operation timed out."""
 
 
+class ExceptionWithWorkflowResults(Exception):
+  def __init__(self, message, workflow_results):
+    super(ExceptionWithWorkflowResults, self).__init__(message)
+    self.workflow_results = workflow_results
+
+
 GCS_REGEX = re.compile("gs://([^/]*)(/.*)?")
 
 

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -75,7 +75,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
             "--zone=us-east1-d", "--bucket=some-bucket",
             "--config_file=" + name,
             "--repos_dir=" + repo_dir]
-    mock_wait_for_workflows.return_value = [], True
+    mock_wait_for_workflows.return_value = []
     run_e2e_workflow.main(args)
 
     mock_configure.assert_called_once_with("some-project", "us-east1-d",


### PR DESCRIPTION
**Background**

This PR should fix https://github.com/kubeflow/testing/issues/386.

**Changes**

* Created a new exception type `ExceptionWithWorkflowResults` and I'm now using this type to reraise internal exceptions and store the most recent set of workflow results.

* Used the status code defined in `httplib` instead of manually defining status codes.

**Tests**

Not Applicable.

BTW, @jlewi One issue I'm seeing these days is right now there seems to be no easy way to locally validate our changes in this repo. Do you expect in the long term there shouldn't be that many changes in the testing repo so it's OK doing things this way or we should probably write some docs or find ways to make the changes easier to be tested?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/401)
<!-- Reviewable:end -->
