### PR TITLE
Add JDK8 to testing worker image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -22,12 +22,14 @@ RUN set -ex \
     uuid-runtime \
     wget \
     ca-certificates \
+    ca-certificates-java \
     git \
     emacs \
     jq \
     zip \
     unzip \
     gcc \
+    openjdk-8-jdk \
     ssh \
     mercurial \
     python-dev \
@@ -38,6 +40,7 @@ RUN set -ex \
     python3-pip \
     && python -V \
     && python3 -V \
+    && update-ca-certificates -f \
     && apt-get clean \
     && rm -rf \
     /var/lib/apt/lists/* \
@@ -193,6 +196,9 @@ RUN cd /tmp && \
     ./bazel-installer.sh --user
 
 ENV PATH=root/bin:${PATH}
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+RUN export JAVA_HOME
 
 # Add the directory where we will checkout kubeflow/testing
 # which contains shared scripts.


### PR DESCRIPTION
Need Java runtime to use [OpenAPI generator](https://github.com/OpenAPITools/openapi-generator#1---installation) to generate OpenAPI client on the fly during metadata e2e test. https://github.com/kubeflow/metadata/issues/28

Tested locally:

```
root@8aef64b69411:/# java -version
openjdk version "1.8.0_212"
OpenJDK Runtime Environment (build 1.8.0_212-8u212-b03-0ubuntu1.16.04.1-b03)
OpenJDK 64-Bit Server VM (build 25.212-b03, mixed mode)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/410)
<!-- Reviewable:end -->
