### PR TITLE
set refs for newly fetched remote branch

### DIFF
--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -127,10 +127,10 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
     # We need to get a common ancestor for the PR and the base branch
     cloned_repo_dir = os.path.join(args.repos_dir, repo_owner, repo_name)
 
-    _ = util.run(["git", "fetch", "origin", base_branch_name], cwd=cloned_repo_dir)
+    _ = util.run(["git", "fetch", "origin", base_branch_name + ":refs/remotes/origin/" + base_branch_name], cwd=cloned_repo_dir)
 
     diff_command = ["git", "diff", "--name-only"]
-    diff_branch = "origin/{}".format(base_branch_name)
+    diff_branch = "remotes/origin/{}".format(base_branch_name)
     try:
       common_ancestor = util.run(["git", "merge-base", "HEAD", diff_branch],
                                  cwd=cloned_repo_dir)

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -127,7 +127,8 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
     # We need to get a common ancestor for the PR and the base branch
     cloned_repo_dir = os.path.join(args.repos_dir, repo_owner, repo_name)
 
-    _ = util.run(["git", "fetch", "origin", base_branch_name + ":refs/remotes/origin/" + base_branch_name], cwd=cloned_repo_dir)
+    _ = util.run(["git", "fetch", "origin", base_branch_name + ":refs/remotes/origin/" +
+                  base_branch_name], cwd=cloned_repo_dir)
 
     diff_command = ["git", "diff", "--name-only"]
     diff_branch = "remotes/origin/{}".format(base_branch_name)

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -82,7 +82,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
                                            "some-cluster",)
 
     expected_calls = [
-      ["git", "fetch", "origin", "test_branch"],
+      ["git", "fetch", "origin", "test_branch:refs/remotes/origin/test_branch"],
       ["git", "merge-base", "HEAD", "remotes/origin/test_branch"],
       ["git", "diff", "--name-only", "ab1234"],
       ["ks-13", "version"],

--- a/py/kubeflow/tests/run_e2e_workflow_test.py
+++ b/py/kubeflow/tests/run_e2e_workflow_test.py
@@ -83,7 +83,7 @@ class TestRunE2eWorkflow(unittest.TestCase):
 
     expected_calls = [
       ["git", "fetch", "origin", "test_branch"],
-      ["git", "merge-base", "HEAD", "origin/test_branch"],
+      ["git", "merge-base", "HEAD", "remotes/origin/test_branch"],
       ["git", "diff", "--name-only", "ab1234"],
       ["ks-13", "version"],
       ["ks-13", "env", "add", "kubeflow-presubmit-wf-77-123abc-1234-.*",


### PR DESCRIPTION
Otherwise any non-master branch ends up `FETCH_HEAD`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/419)
<!-- Reviewable:end -->
