### PR TITLE
Fix auto-deployment from master

### DIFF
--- a/py/kubeflow/testing/create_kf_instance.py
+++ b/py/kubeflow/testing/create_kf_instance.py
@@ -231,7 +231,6 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
   labels = {
     "GIT_LABEL": git_describe,
     "PURPOSE": "kf-test-cluster",
-    "use-kfctl-go": "{0}".format(args.use_kfctl_go),
   }
 
   label_args = []

--- a/py/kubeflow/testing/create_kf_instance.py
+++ b/py/kubeflow/testing/create_kf_instance.py
@@ -109,7 +109,7 @@ def deploy_with_kfctl_go(kfctl_path, args, app_dir, env):
   logging.info("KFDefSpec:\n%s", str(config_spec))
   with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
     config_file = f.name
-    logging.info("Writing file %", f.name)
+    logging.info("Writing file %s", f.name)
     yaml.dump(config_spec, f)
 
   util.run([kfctl_path, "init", app_dir, "-V", "--config=" + config_file],
@@ -150,7 +150,8 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
 
   parser.add_argument(
     "--kfctl_config",
-    default="https://raw.githubusercontent.com/kubeflow/kubeflow/master/bootstrap/config/kfctl_gcp_iap.yaml",
+    default=("https://raw.githubusercontent.com/kubeflow/kubeflow/master"
+             "/bootstrap/config/kfctl_gcp_iap.yaml"),
     type=str, help=("Path to the kfctl config to use"))
 
   parser.add_argument(

--- a/py/kubeflow/testing/create_kf_instance.py
+++ b/py/kubeflow/testing/create_kf_instance.py
@@ -193,17 +193,14 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
   else:
     name = args.name
 
-  kfctl_path = None
-  if args.use_kfctl_go:
-    kfctl_path = build_kfctl_go(args)
-
+  kfctl_path = build_kfctl_go(args)
 
   app_dir = os.path.join(args.apps_dir, name)
   # Clean up previous deployment. We attempt to run "kfctl delete all"
   # but we don't depend on it succeeding because the app directory might
   # not be up to date.
   # since we are not able to guarantee apps config in repository is up to date.
-  if os.path.exists(app_dir) and args.use_kfctl_go:
+  if os.path.exists(app_dir):
     try:
       util.run([kfctl_path, "delete", "all", "--delete_storage"], cwd=app_dir)
     except subprocess.CalledProcessError as e:

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -650,6 +650,14 @@ def maybe_activate_service_account():
     logging.info("GOOGLE_APPLICATION_CREDENTIALS is not set.")
 
 
+def filter_spartakus(spec):
+  """Remove spartakus from the list of applications in KfDef."""
+  for i, app in enumerate(spec["applications"]):
+    if app["name"] == "spartakus":
+      spec["applications"].pop(i)
+      break
+  return spec
+
 def upload_to_gcs(contents, target):
   gcs_client = storage.Client()
 

--- a/test-infra/auto-deploy/auto_deploy.sh
+++ b/test-infra/auto-deploy/auto_deploy.sh
@@ -10,7 +10,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 . ${DIR}/lib-args.sh
 
 # Deployment configs.
-required_args=(data_dir repos project job_labels base_name max_num_cluster zone)
+required_args=(data_dir repos project job_labels base_name max_num_cluster zone kfctl_config)
 
 parseArgs $*
 validateRequiredArgs ${required_args}
@@ -69,6 +69,7 @@ python -m kubeflow.testing.create_kf_instance \
   --apps_dir=${APPS_DIR} \
   --project=${project} \
   --snapshot_file=${data_dir}/snapshot.json \
-  --zone=${zone}
+  --zone=${zone} \
+  --kfctl_config=${kfctl_config}
 
 # TODO(gabrielwen): Push changes to app folders to git.

--- a/test-infra/auto-deploy/deploy-cron-master.yaml
+++ b/test-infra/auto-deploy/deploy-cron-master.yaml
@@ -28,6 +28,7 @@ spec:
             - --max_num_cluster=5
             - --zone=us-east1-b
             - --github_token_file=/secret/github-token/github_token
+            - --kfctl_config=https://raw.githubusercontent.com/kubeflow/kubeflow/master/bootstrap/config/kfctl_gcp_iap.yaml
             volumeMounts:
             - name: gcp-credentials
               mountPath: /secret/gcp-credentials

--- a/test-infra/auto-deploy/deploy-cron-v0-6.yaml
+++ b/test-infra/auto-deploy/deploy-cron-v0-6.yaml
@@ -28,6 +28,7 @@ spec:
             - --max_num_cluster=5
             - --zone=us-east1-b
             - --github_token_file=/secret/github-token/github_token
+            - --kfctl_config=https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_gcp_iap.yaml
             volumeMounts:
             - name: gcp-credentials
               mountPath: /secret/gcp-credentials

--- a/test-infra/auto-deploy/deploy-master.yaml
+++ b/test-infra/auto-deploy/deploy-master.yaml
@@ -30,6 +30,7 @@ spec:
         - --max_num_cluster=5
         - --zone=us-east1-b
         - --github_token_file=/secret/github-token/github_token
+        - --kfctl_config=https://raw.githubusercontent.com/kubeflow/kubeflow/master/bootstrap/config/kfctl_gcp_iap.yaml
         volumeMounts:
         - name: gcp-credentials
           mountPath: /secret/gcp-credentials

--- a/test-infra/auto-deploy/deploy-master.yaml
+++ b/test-infra/auto-deploy/deploy-master.yaml
@@ -22,8 +22,7 @@ spec:
           value: /secret/gcp-credentials/key.json
         command:
         - /usr/local/bin/auto_deploy.sh
-        #- --repos=kubeflow/kubeflow;kubeflow/testing
-        - --repos=kubeflow/kubeflow;jlewi/testing@fix_nfs2
+        - --repos=kubeflow/kubeflow;kubeflow/testing
         - --project=kubeflow-ci-deployment
         - --job_labels=/etc/pod-info/labels
         - --data_dir=/mnt/test-data-volume/auto_deploy

--- a/test-infra/auto-deploy/deploy-master.yaml
+++ b/test-infra/auto-deploy/deploy-master.yaml
@@ -22,7 +22,8 @@ spec:
           value: /secret/gcp-credentials/key.json
         command:
         - /usr/local/bin/auto_deploy.sh
-        - --repos=kubeflow/kubeflow;kubeflow/testing
+        #- --repos=kubeflow/kubeflow;kubeflow/testing
+        - --repos=kubeflow/kubeflow;jlewi/testing@fix_nfs2
         - --project=kubeflow-ci-deployment
         - --job_labels=/etc/pod-info/labels
         - --data_dir=/mnt/test-data-volume/auto_deploy


### PR DESCRIPTION
* Auto deployment from master should use --config flag to initialize KfDef
  * I think we are pulling in outdated configs which is why master deployment
    isn't working

* Clean up some of the old code for deploying with kfctl.sh since we no longer
  use that.

* Related to kubeflow/kubeflow#3905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/441)
<!-- Reviewable:end -->
