### PR TITLE
Support Python functions in workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,8 @@ Some examples to look at
 
 Follow these steps to add a new test to a repository.
 
+#### ksonnet
+
 1. Create a ksonnet App in that repository and define an Argo workflow if one doesn't already exist
    * We use ksonnet apps defined in each repository to define the Argo workflows corresponding to E2E tests
    * If a ksonnet app already exists you can just define a new component in that app
@@ -758,6 +760,32 @@ Follow these steps to add a new test to a repository.
 
      * **params**: A dictionary of parameters to set on the ksonnet component e.g. by running `ks param set ${COMPONENT} ${PARAM_NAME} ${PARAM_VALUE}`
 
+#### Python function
+
+* **Note**: ksonnet is being deprecated, please start using Python functions to parameterize Argo workflows in E2E tests.
+
+1. Create a Python function in that repository and return an Argo workflow if one doesn't already exist
+   * We use Python functions defined in each repository to define the Argo workflows corresponding to E2E tests
+
+   * You can look at `prow_config.yaml` (see below) to see which Python functions are already defined in a repository.
+
+1. Modify the `prow_config.yaml` at the root of the repo to trigger your new test.
+
+   * If `prow_config.yaml` doesn't exist (e.g. the repository is new) copy one from an existing repository ([example](https://github.com/kubeflow/kubeflow/blob/master/prow_config.yaml)).
+
+   * `prow_config.yaml` contains an array of workflows where each workflow defines an E2E test to run; example
+
+       ```
+       workflows:
+        - name: workflow-test
+          py_func: my_test_package.my_test_module.my_test_workflow
+          kw_args:
+              arg1: argument
+       ```
+
+       * **py_func**: Is the Python method to invoke Argo workflows
+       * **kw_args**: This is an array of arguments passed to the Python method
+       * **name**: This is the base name to use for the submitted Argo workflow.
 
 ### Prow Variables
 

--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ Follow these steps to add a new test to a repository.
               arg1: argument
        ```
 
-       * **py_func**: Is the Python method to invoke Argo workflows
+       * **py_func**: Is the Python method to create a python object representing the Argo workflow resource
        * **kwargs**: This is an array of arguments passed to the Python method
        * **name**: This is the base name to use for the submitted Argo workflow.
 

--- a/README.md
+++ b/README.md
@@ -779,12 +779,12 @@ Follow these steps to add a new test to a repository.
        workflows:
         - name: workflow-test
           py_func: my_test_package.my_test_module.my_test_workflow
-          kw_args:
+          kwargs:
               arg1: argument
        ```
 
        * **py_func**: Is the Python method to invoke Argo workflows
-       * **kw_args**: This is an array of arguments passed to the Python method
+       * **kwargs**: This is an array of arguments passed to the Python method
        * **name**: This is the base name to use for the submitted Argo workflow.
 
 ### Prow Variables

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -4,3 +4,10 @@ workflows:
   - app_dir: kubeflow/testing/workflows
     component: workflows
     name: unittests
+
+  - py_func: kubeflow.testing.ci.kf_unittests.create_workflow
+    name: pyfunctest
+    # can optionally take keyword arguments
+    # kw_args:
+    #  a: 1
+    #  b: 2

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -5,6 +5,18 @@ workflows:
     component: workflows
     name: unittests
 
+  - app_dir: kubeflow/kubeflow/testing/workflows
+    component: click_deploy_test
+    name: skipmeplease
+    job_types:
+    - periodic
+    include_dirs:
+    - bootstrap/*
+    - kubeflow/*
+    - testing/*
+    params:
+      workflowName: skipmeplease
+
   - py_func: kubeflow.testing.ci.kf_unittests.create_workflow
     name: pyfunctest
     # can optionally take keyword arguments

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -5,18 +5,19 @@ workflows:
     component: workflows
     name: unittests
 
-  - app_dir: kubeflow/kubeflow/testing/workflows
+  # Verifies the workflow is skipped because the test would fail since it
+  # doesn't exist
+  - app_dir: kubeflow/kubeflow/testing/lmnop
     component: click_deploy_test
     name: skipmeplease
     job_types:
-    - periodic
+    - presubmit
     include_dirs:
-    - bootstrap/*
-    - kubeflow/*
-    - testing/*
+    - xyz/*
     params:
       workflowName: skipmeplease
 
+  # Smoke test to verify that the workflow is actually triggered
   - py_func: kubeflow.testing.ci.kf_unittests.create_workflow
     name: pyfunctest
     kwargs:

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -19,7 +19,5 @@ workflows:
 
   - py_func: kubeflow.testing.ci.kf_unittests.create_workflow
     name: pyfunctest
-    # can optionally take keyword arguments
-    # kw_args:
-    #  a: 1
-    #  b: 2
+    kwargs:
+     url: https://raw.githubusercontent.com/argoproj/argo/master/examples/hello-world.yaml

--- a/py/kubeflow/testing/ci/kf_unittests.py
+++ b/py/kubeflow/testing/ci/kf_unittests.py
@@ -1,0 +1,15 @@
+"""Test Argo workflow"""
+
+import requests
+import yaml
+
+def create_workflow():
+  """ Loads Argo example YAML and returns dictionary object """
+  # TODO: define workflow to run unittests
+  argo_hello_world = requests.get("https://raw.githubusercontent.com/argoproj/"
+  "argo/master/examples/hello-world.yaml")
+  yaml_result = yaml.safe_load(argo_hello_world.text)
+  return yaml_result
+
+if __name__ == "__main__":
+  create_workflow()

--- a/py/kubeflow/testing/ci/kf_unittests.py
+++ b/py/kubeflow/testing/ci/kf_unittests.py
@@ -1,13 +1,12 @@
-"""Test Argo workflow"""
+"""Uses an Argo example to generate to create a workflow"""
 
 import requests
 import yaml
 
-def create_workflow():
+def create_workflow(**kwargs):
   """ Loads Argo example YAML and returns dictionary object """
   # TODO: define workflow to run unittests
-  argo_hello_world = requests.get("https://raw.githubusercontent.com/argoproj/"
-  "argo/master/examples/hello-world.yaml")
+  argo_hello_world = requests.get(''.join([v for k, v in kwargs.items()]))
   yaml_result = yaml.safe_load(argo_hello_world.text)
   return yaml_result
 

--- a/py/kubeflow/testing/ci/kf_unittests.py
+++ b/py/kubeflow/testing/ci/kf_unittests.py
@@ -1,4 +1,13 @@
-"""Uses an Argo example to generate to create a workflow"""
+"""
+A smoke test to ensure run_e2e_workflow.py can properly trigger workflows using
+a py_func.
+
+This module defines a simple py_func which will return the Argo workflow
+resulting from loading the specified YAML file.
+
+The purpose of this is to allow the presubmits/postsubmits to verify that
+run_e2e_workflow.py is actually triggering workflows using py_func.
+"""
 
 import requests
 import yaml

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -78,9 +78,9 @@ def py_func_import(py_func, kwargs):
   met = getattr(mod, module)
   return met(**kwargs)
 
-class WorkflowComponent(object):
+class WorkflowComponent(object): # pylint: disable=too-many-instance-attributes
   """Datastructure to represent a component to submit a workflow."""
-  def __init__(self, root_dir, data): # pylint: disable=too-many-instance-attributes
+  def __init__(self, root_dir, data):
     self.name = data.get("name")
     self.job_types = data.get("job_types", [])
     self.include_dirs = data.get("include_dirs", [])

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -18,6 +18,8 @@ workflows:
       tensorflow/*
 
   - name: workflow-test
+    job_types:
+      presubmit
     py_func: my_test_package.my_test_module.my_test_workflow
     kw_args:
         arg1: argument
@@ -76,7 +78,7 @@ def py_func_import(py_func, kwargs):
   met = getattr(mod, module)
   return met(**kwargs)
 
-class WorkflowComponent(object):
+class WorkflowKSComponent(object):
   """Datastructure to represent a ksonnet component to submit a workflow."""
 
   def __init__(self, name, app_dir, component, job_types, include_dirs, params):
@@ -90,8 +92,9 @@ class WorkflowComponent(object):
 class WorkflowPyComponent(object):
   """Datastructure to represent a Python function to submit a workflow."""
 
-  def __init__(self, name, py_func, kw_args):
+  def __init__(self, name, job_types, py_func, kw_args):
     self.name = name
+    self.job_types = job_types
     self.py_func = py_func
     self.args = kw_args
 
@@ -111,16 +114,13 @@ def parse_config_file(config_file, root_dir):
 
   components = []
   for i in results["workflows"]:
-    components.append(WorkflowComponent(
-      i["name"], os.path.join(root_dir, i["app_dir"]), i["component"], i.get("job_types", []),
-      i.get("include_dirs", []), i.get("params", {})))
     if i.get("app_dir"):
       components.append(WorkflowKSComponent(
         i["name"], os.path.join(root_dir, i["app_dir"]), i["component"],
         i.get("job_types", []), i.get("include_dirs", []), i.get("params", {})))
     if i.get("py_func"):
       components.append(WorkflowPyComponent(
-        i["name"], i["py_func"], i.get("kw_args", {})))
+        i["name"], i.get("job_types", []), i["py_func"], i.get("kw_args", {})))
   return components
 
 def generate_env_from_head(args):

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -217,6 +217,27 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
                    "%s.", w.name, job_type, w.job_types)
       continue
 
+    # If we are scoping this workflow to specific directories, check if any files
+    # modified match the specified regex patterns.
+    dir_modified = False
+    if w.include_dirs:
+      for f in changed_files:
+        for d in w.include_dirs:
+          if fnmatch.fnmatch(f, d):
+            dir_modified = True
+            logging.info("Triggering workflow %s because %s in dir %s is modified.",
+                         w.name, f, d)
+            break
+        if dir_modified:
+          break
+
+    # Only consider modified files when the job is pre or post submit, and if
+    # the include_dirs stanza is defined.
+    if job_type != "periodic" and w.include_dirs and not dir_modified:
+      logging.info("Skipping workflow %s because no code modified in %s.",
+                   w.name, w.include_dirs)
+      continue
+
     if job_type == "presubmit":
       workflow_name += "-{0}".format(os.getenv("PULL_NUMBER"))
       workflow_name += "-{0}".format(os.getenv("PULL_PULL_SHA")[0:7])
@@ -240,27 +261,6 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
 
       # Print ksonnet version
       util.run([ks_cmd, "version"])
-
-      # If we are scoping this workflow to specific directories, check if any files
-      # modified match the specified regex patterns.
-      dir_modified = False
-      if w.include_dirs:
-        for f in changed_files:
-          for d in w.include_dirs:
-            if fnmatch.fnmatch(f, d):
-              dir_modified = True
-              logging.info("Triggering workflow %s because %s in dir %s is modified.",
-                           w.name, f, d)
-              break
-          if dir_modified:
-            break
-
-      # Only consider modified files when the job is pre or post submit, and if
-      # the include_dirs stanza is defined.
-      if job_type != "periodic" and w.include_dirs and not dir_modified:
-        logging.info("Skipping workflow %s because no code modified in %s.",
-                     w.name, w.include_dirs)
-        continue
 
       # Create a new environment for this run
       env = workflow_name

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -21,10 +21,10 @@ workflows:
     job_types:
       presubmit
     py_func: my_test_package.my_test_module.my_test_workflow
-    kw_args:
+    kwargs:
         arg1: argument
 
-app_dir is expected to be in the form of
+app_dir is expected to be in the form ofx
 {REPO_OWNER}/{REPO_NAME}/path/to/ksonnet/app
 
 component is the name of the ksonnet component corresponding
@@ -38,7 +38,7 @@ should run this workflow.
 
 py_func is the Python method to invoke Argo workflows
 
-kw_args is an array of arguments passed to the Python method
+kwargs is an array of arguments passed to the Python method
 
 The script expects that the directories
 {repos_dir}/{app_dir} exists. Where repos_dir is provided
@@ -92,11 +92,11 @@ class WorkflowKSComponent(object):
 class WorkflowPyComponent(object):
   """Datastructure to represent a Python function to submit a workflow."""
 
-  def __init__(self, name, job_types, py_func, kw_args):
+  def __init__(self, name, job_types, py_func, kwargs):
     self.name = name
     self.job_types = job_types
     self.py_func = py_func
-    self.args = kw_args
+    self.args = kwargs
 
 def _get_src_dir():
   return os.path.abspath(os.path.join(__file__, "..",))
@@ -120,7 +120,7 @@ def parse_config_file(config_file, root_dir):
         i.get("job_types", []), i.get("include_dirs", []), i.get("params", {})))
     if i.get("py_func"):
       components.append(WorkflowPyComponent(
-        i["name"], i.get("job_types", []), i["py_func"], i.get("kw_args", {})))
+        i["name"], i.get("job_types", []), i["py_func"], i.get("kwargs", {})))
   return components
 
 def generate_env_from_head(args):


### PR DESCRIPTION
As ksonnet is being deprecated, this PR allows for Python functions to be used to parameterize Argo workflows in E2E tests.

Fixes #423 

Related to https://github.com/kubeflow/testing/pull/431 which was rolled back. This should be fixed as with the following section which is moved to the correct place:

```
    # Skip this workflow if it is scoped to a different job type.
    if w.job_types and not job_type in w.job_types:
      logging.info("Skipping workflow %s because job type %s is not one of "
                   "%s.", w.name, job_type, w.job_types)
      continue
```

/assign @jlewi 
/cc @kkasravi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/451)
<!-- Reviewable:end -->
