### PR TITLE
Fix some issues with run_e2e_workflow.py and pyfunc

### DIFF
--- a/hack/run_e2e_workflow_k8s_job.yaml
+++ b/hack/run_e2e_workflow_k8s_job.yaml
@@ -1,0 +1,100 @@
+# A Sample K8s job for running run_e2e_workflow.py
+#
+# This is useful for debugging/testing run_e2e_workflow.py during development.
+# The job is intended to simulate what runs in our prow job.
+# https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubeflow/kubeflow-presubmits.yaml
+# Using a K8s job gives us more control over what we run. For example
+# we can use EXTRA_REPOS to check out a PR of kubeflow/testing to checks changes to run_e2e_workflow.py
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: run-e2e-workflow
+  namespace: kubeflow-test-infra
+  labels:
+    app: run-e2e-workflow
+spec:
+  template:
+    spec:
+      initContainers:
+        # This init container checks out the source code.
+        - command:
+          - /usr/local/bin/checkout_repos.sh
+          # TODO(jlewi): Why are we checkout out fairing?
+          # TODO(jlewi): Stop checking out PR for kubeflow/kubeflow once its merged
+          #- --repos=kubeflow/kubeflow@HEAD:3958,kubeflow/fairing@HEAD,kubeflow/testing@HEAD,kubeflow/manifests@HEAD
+          - --repos=kubeflow/testing@HEAD:466,kubeflow/kubeflow@HEAD:4148
+          - --src_dir=/src
+          # Don't do a shallow clone because we need to compute when files were modified and shallow clones prevent pushing
+          # branches.
+          - --depth=all
+          name: checkout
+          image: gcr.io/kubeflow-ci/test-worker:latest
+          volumeMounts:
+          - mountPath: /src
+            name: src
+        #- command:
+        #  - cp
+          # TODO(jlewi): Why are we checkout out fairing?
+          # TODO(jlewi): Stop checking out PR for kubeflow/kubeflow once its merged
+          #- --repos=kubeflow/kubeflow@HEAD:3958,kubeflow/fairing@HEAD,kubeflow/testing@HEAD,kubeflow/manifests@HEAD
+       #   - /src/kubeflow/testing/py/kubeflow/testing/run_e2e_workflow.py
+        #  - /src/run_e2e_workflow.py
+        #  name: link
+        #  image: gcr.io/kubeflow-ci/test-worker:latest
+        #  volumeMounts:
+        #  - mountPath: /src
+        #    name: src
+      containers:
+        - name: test-worker
+          image: gcr.io/kubeflow-ci/test-worker:latest
+          command:
+            - python 
+            - -m 
+            - kubeflow.testing.run_e2e_workflow
+            #- /src/run_e2e_workflow.py
+            - --project=kubeflow-ci
+            - --zone=us-east1-d
+            - --cluster=kubeflow-testing
+            - --bucket=kubeflow-ci_temp
+            - --config_file=/src/kubeflow/kubeflow/prow_config.yaml
+            - --repos_dir=/src
+          
+          #command:
+          #  - tail
+          #  - -f
+          #  - /dev/null
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /secret/gcp-credentials/key.json
+            - name: PYTHONPATH
+              value: /src/kubeflow/testing/py:/src/kubeflow/kubeflow/py
+            # Set prow environment variables as desired
+            # Current values are set to test kubeflow/kubeflow #4148
+            - name: JOB_NAME
+              value: lewi-test
+            - name: JOB_TYPE
+              value: presubmit
+            - name: BUILD_ID
+              value: "1234"  
+            - name: PROW_JOB_ID
+              value: "jlewi-prow-job"
+            - name: REPO_OWNER
+              value: kubeflow
+            - name: REPO_NAME
+              value: kubeflow
+            - name: PULL_BASE_REF
+              value: master
+            - name: PULL_NUMBER
+              value: "4148"
+          volumeMounts:
+          - mountPath: /src
+            name: src
+          - mountPath: /secret/gcp-credentials
+            name: gcp-credentials          
+      volumes:
+      - name: src
+        emptyDir: {}
+      - name: gcp-credentials
+        secret:
+          secretName: gcp-credentials
+      restartPolicy: Never

--- a/py/kubeflow/testing/e2e_tool.py
+++ b/py/kubeflow/testing/e2e_tool.py
@@ -13,21 +13,27 @@ from kubeflow.testing import argo_build_util
 from kubeflow.testing import run_e2e_workflow
 from kubeflow.testing import util
 
+# TODO(jlewi): Can we automatically handle the case where py_func points
+# to a builder class? Then create the class and call build.
 class E2EToolMain(object): # pylint: disable=useless-object-inheritance
   """A helper class to add some convenient entry points."""
-  def show(self, py_func, name=None, namespace=None): # pylint: disable=no-self-use
+
+  def show(self, py_func, name=None, namespace=None, output=None,
+           **kwargs): # pylint: disable=no-self-use
     """Print out the workflow spec.
 
     Args:
       py_func: Dotted name of the function defining the workflow
     """
-    kwargs = {
-      "name": name,
-      "namespace": namespace,
-    }
+    kwargs.update({"name": name, "namespace": namespace, })
     workflow = run_e2e_workflow.py_func_import(py_func, kwargs)
 
-    print(yaml.safe_dump(workflow))
+    if output:
+      logging.info("Dumping workflow to %s", output)
+      with open(output, "w") as hf:
+        hf.write(yaml.safe_dump(workflow))
+    else:
+      print(yaml.safe_dump(workflow))
 
   def apply(self, py_func, name=None, namespace=None, # pylint: disable=no-self-use
             dry_run=False,


### PR DESCRIPTION
* When trying to import the py_func in the E2E tests for kubeflow/kubeflow repository, I ran into problems with the import failing because the module kubeflow.kubeflow could not be found

  * The issue is tracked kubeflow/testing#467

  * Essentially dynamically  adding the kubeflow/kubeflow/py (i.e. from inside python) didn't work
     * Could be an issue with namespace packaging

* I spent hours trying to make dynamically importing the modules work but I couldn't figure it out

* Setting python path before invoking python appears to work. So as a workaround we have run_e2e_workflow.py shell out to e2e_tool which writes the workflow to a file. run_e2e_workflow.py then loads it from the file.

* Create a K8s job to run run_e2e_workflow.py to simulate what happens
  under prow

* Related to kubeflow/kubeflow#3035 migrate e2e tests off ksonnet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/466)
<!-- Reviewable:end -->
