### PR TITLE
Upgrade kustomize from 2.0.3 to 3.2.0

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=linux
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-ENV KUSTOMIZE_VERSION 2.0.3
+ENV KUSTOMIZE_VERSION 3.2.0
 
 # gcc & python-dev are needed so we can install crcmod for gsutil
 # also includes installations for Python3


### PR DESCRIPTION
Get the test worker to use kustomize 3.2.0 instead of kustomize 2.0.3

This fixes: https://github.com/kubeflow/testing/issues/465

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/470)
<!-- Reviewable:end -->
