### PR TITLE
Improve cleanup of SSl certificates

### DIFF
--- a/py/kubeflow/testing/argo_build_util.py
+++ b/py/kubeflow/testing/argo_build_util.py
@@ -140,8 +140,15 @@ def add_task_to_dag(workflow, dag_name, task, dependencies):
 
   dag["dag"]["tasks"].append(new_task)
 
-  workflow["spec"]["templates"].append(task)
+  new_template = deep_copy(task)
 
+  if "name" not in new_template:
+    raise ValueError("Task template is missing name")
+
+  if not new_template["name"]:
+    raise ValueError("Task template name can't be empty string")
+
+  workflow["spec"]["templates"].append(new_template)
 
 def set_task_template_labels(workflow):
   """Automatically set the labels and annotations on each step.


### PR DESCRIPTION
* Parse the SSL certificates so that we get the associated domain.

  Use this to expire SSL certificates from pre/postsubmits after a couple
  hours while leaving the certificates for the auto deployments around longer.

* Minor fixes to some of the other tools.

Related to #461

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/474)
<!-- Reviewable:end -->
