### PR TITLE
Fix bucket where artifacts are uploaded to

### DIFF
--- a/py/kubeflow/testing/ci/kf_unittests.py
+++ b/py/kubeflow/testing/ci/kf_unittests.py
@@ -38,6 +38,9 @@ class Builder:
     # The directory containing the kubeflow/kubeflow repo
     self.src_dir = self.src_root_dir + "/kubeflow/kubeflow"
 
+    # Root of testing repo.
+    self.testing_src_dir = os.path.join(self.src_root_dir, "kubeflow/testing")
+
     # Top level directories for python code
     self.kubeflow_py = self.src_dir
 
@@ -190,6 +193,7 @@ class Builder:
                                        "kubeflow.testing.test_py_lint",
                                        "--artifacts_dir=" + self.artifacts_dir,
                                        "--src_dir=" + self.kubeflow_testing_py,
+                                       "--rcfile=" + os.path.join(self.testing_src_dir, ".pylintrc"),
                                        ]
 
     argo_build_util.add_task_to_dag(workflow, E2E_DAG_NAME, py_lint,

--- a/py/kubeflow/testing/ci/kf_unittests.py
+++ b/py/kubeflow/testing/ci/kf_unittests.py
@@ -14,7 +14,7 @@ EXIT_DAG_NAME = "exit-handler"
 
 TEMPLATE_LABEL = "kf_unittests"
 
-class Builder:
+class Builder: # pylint: disable=too-many-instance-attributes
   def __init__(self, name=None, namespace=None, bucket=None):
     self.name = name
     self.namespace = namespace
@@ -182,9 +182,9 @@ class Builder:
                                     [checkout["name"]])
 
 
-    #*****************************************************************************
+    #***************************************************************************
     # py lint
-    #****************************************************************************
+    #***************************************************************************
     py_lint = argo_build_util.deep_copy(task_template)
 
     py_lint["name"] = "py-lint"
@@ -193,7 +193,8 @@ class Builder:
                                        "kubeflow.testing.test_py_lint",
                                        "--artifacts_dir=" + self.artifacts_dir,
                                        "--src_dir=" + self.kubeflow_testing_py,
-                                       "--rcfile=" + os.path.join(self.testing_src_dir, ".pylintrc"),
+                                       "--rcfile=" + os.path.join(
+                                         self.testing_src_dir, ".pylintrc"),
                                        ]
 
     argo_build_util.add_task_to_dag(workflow, E2E_DAG_NAME, py_lint,

--- a/py/kubeflow/testing/ci/kf_unittests.py
+++ b/py/kubeflow/testing/ci/kf_unittests.py
@@ -15,7 +15,7 @@ EXIT_DAG_NAME = "exit-handler"
 TEMPLATE_LABEL = "kf_unittests"
 
 class Builder:
-  def __init__(self, name=None, namespace=None, bucket="kubeflow-ci_temp"):
+  def __init__(self, name=None, namespace=None, bucket=None):
     self.name = name
     self.namespace = namespace
     self.bucket = bucket
@@ -207,8 +207,11 @@ class Builder:
                                        "kubeflow.testing.prow_artifacts",
                                        "--artifacts_dir=" + self.output_dir,
                                        "create_pr_symlink",
-                                       "--bucket=" + self.bucket,
                                        ]
+
+    if self.bucket:
+      symlink["container"]["command"].append("--bucket=" + self.bucket)
+
     argo_build_util.add_task_to_dag(workflow, E2E_DAG_NAME, symlink,
                                     [checkout["name"]])
 
@@ -223,9 +226,11 @@ class Builder:
                                               "kubeflow.testing.prow_artifacts",
                                               "--artifacts_dir=" +
                                               self.output_dir,
-                                              "copy_artifacts",
-                                              "--bucket=" + self.bucket,
-                                              "--suffix=fakesuffix",]
+                                              "copy_artifacts"]
+
+    if self.bucket:
+      copy_artifacts["container"]["command"].append("--bucket=" + self.bucket)
+
 
     argo_build_util.add_task_to_dag(workflow, EXIT_DAG_NAME, copy_artifacts, [])
 
@@ -235,7 +240,7 @@ class Builder:
 
     return workflow
 
-def create_workflow(name=None, namespace=None, bucket="kubeflow-ci_temp"): # pylint: disable=too-many-statements
+def create_workflow(name=None, namespace=None, bucket=None): # pylint: disable=too-many-statements
   """Create workflow returns an Argo workflow to test kfctl upgrades.
 
   Args:

--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -4,16 +4,12 @@ import argparse
 import datetime
 from dateutil import parser as date_parser
 import logging
-import os
 import re
 import retrying
 import socket
-import subprocess
 import sys
 import traceback
-import tempfile
 import time
-import yaml
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -290,7 +286,7 @@ def cleanup_instance_groups(args):
           if not args.dryrun:
             try:
               response = instanceGroups.delete(project=args.project,
-                                              zone=zone,
+                                               zone=zone,
                                               instanceGroup=name).execute()
               logging.info("response = %r", response)
               expired.append(name)
@@ -509,7 +505,7 @@ def cleanup_backend_services(args):
           try:
             # An error may be thrown if the backend service is used by a urlMap.
             response = backends.delete(project=args.project,
-                                     backendService=name).execute()
+                                       backendService=name).execute()
             logging.info("response = %r", response)
             expired.append(name)
           except Exception as e: # pylint: disable=broad-except
@@ -670,7 +666,7 @@ def cleanup_service_accounts(args):
   next_page_token = None
   while True:
     service_accounts = iam.projects().serviceAccounts().list(
-           name='projects/' + args.project, pageToken=next_page_token).execute()
+      name='projects/' + args.project, pageToken=next_page_token).execute()
     accounts.extend(service_accounts["accounts"])
     if not "nextPageToken" in service_accounts:
       break
@@ -841,7 +837,7 @@ def cleanup_deployments(args): # pylint: disable=too-many-statements,too-many-br
       try:
         op = deployments_client.delete(project=args.project, deployment=name).execute()
         delete_ops.append(op)
-      except Exception as e:
+      except Exception as e: # pylint: disable=broad-except
         # Keep going on error because we want to delete the other deployments.
         # TODO(jlewi): Do we need to handle cases by issuing delete with abandon?
         logging.error("There was a problem deleting deployment %s; error %s", name, e)
@@ -852,14 +848,14 @@ def cleanup_deployments(args): # pylint: disable=too-many-statements,too-many-br
       while datetime.datetime.now() < end_time and delete_ops:
         not_done = []
         for op in delete_ops:
-            op = dm.operations().get(project=args.project, operation=op["name"]).execute()
+          op = dm.operations().get(project=args.project, operation=op["name"]).execute()
 
-            status = op.get("status", "")
-            # Need to handle other status's
-            if status == "DONE":
-              logging.info("Final operation: %s", op)
-            else:
-              not_done.append(op)
+          status = op.get("status", "")
+          # Need to handle other status's
+          if status == "DONE":
+            logging.info("Final operation: %s", op)
+          else:
+            not_done.append(op)
 
         delete_ops = not_done
         time.sleep(30)
@@ -968,7 +964,7 @@ def cleanup_all(args):
 
 def add_workflow_args(parser):
   parser.add_argument(
-      "--namespace", default="kubeflow-test-infra",
+    "--namespace", default="kubeflow-test-infra",
       help="Namespace to cleanup.")
 
 def add_deployments_args(parser):

--- a/py/kubeflow/testing/e2e_tool.py
+++ b/py/kubeflow/testing/e2e_tool.py
@@ -15,7 +15,7 @@ from kubeflow.testing import util
 
 # TODO(jlewi): Can we automatically handle the case where py_func points
 # to a builder class? Then create the class and call build.
-class E2EToolMain(object): # pylint: disable=useless-object-inheritance
+class E2EToolMain:
   """A helper class to add some convenient entry points."""
 
   def show(self, py_func, name=None, namespace=None, output=None,

--- a/py/kubeflow/testing/prow_artifacts.py
+++ b/py/kubeflow/testing/prow_artifacts.py
@@ -120,13 +120,12 @@ def get_gcs_dir(bucket):
   # Based on the prow docs the variable is BUILD_ID
   # https://github.com/kubernetes/test-infra/blob/45246b09ed105698aa8fb928b7736d14480def29/prow/jobs.md#job-environment-variables
   # But it looks like the original version of this code was using BUILD_NUMBER.
-  # jlewi@ has some vague recollection of it changing at some point.
-  # It looks like both are actually set (to the same value) in prow but our workflows
-  # may not be setting both.
+  # BUILD_NUMBER is now deprecated.
+  # https://github.com/kubernetes/test-infra/blob/master/prow/ANNOUNCEMENTS.md
   # In effort to be defensive we try BUILD_ID and fall back to BUILD_NUMBER
   build = os.getenv("BUILD_ID")
   if not build:
-    logging.warning("BUILD_ID not set; trying BUILD_NUMBER")
+    logging.warning("BUILD_ID not set; trying BUILD_NUMBER; BUILD_NUMBER is deprecated")
     build = os.getenv("BUILD_NUMBER")
 
   if job_type == "presubmit":

--- a/py/kubeflow/testing/prow_artifacts.py
+++ b/py/kubeflow/testing/prow_artifacts.py
@@ -12,6 +12,12 @@ from google.cloud import storage  # pylint: disable=no-name-in-module
 from kubeflow.testing import test_util
 from kubeflow.testing import util
 
+
+# The default bucket where we should upload artifacts to in
+# prow. Currently test-grid and spyglass are looking at the kubernetes-jenkins
+# bucket and not a bucket in project kubelfow-ci
+PROW_RESULTS_BUCKET = "kubernetes-jenkins"
+
 # TODO(jlewi): Replace create_finished in tensorflow/k8s/py/prow.py with this
 # version. We should do that when we switch tensorflow/k8s to use Argo instead
 # of Airflow.
@@ -282,7 +288,7 @@ def main(unparsed_args=None):  # pylint: disable=too-many-locals
 
   parser_copy.add_argument(
     "--bucket",
-    default="",
+    default=PROW_RESULTS_BUCKET,
     type=str,
     help="Bucket to copy the artifacts to.")
 
@@ -303,9 +309,9 @@ def main(unparsed_args=None):  # pylint: disable=too-many-locals
 
   parser_link.add_argument(
     "--bucket",
-    default="",
+    default=PROW_RESULTS_BUCKET,
     type=str,
-    help="Bucket to copy the artifacts to.")
+    help="Bucket to copy the artifacts to")
 
   parser_link.set_defaults(func=create_pr_symlink)
 

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -87,7 +87,7 @@ def py_func_import(py_func, kwargs):
   met = getattr(mod, create_function)
   return met(**kwargs)
 
-class WorkflowComponent(object): # pylint: disable=too-many-instance-attributes
+class WorkflowComponent(object): # pylint: disable=too-many-instance-attributes,useless-object-inheritance
   """Datastructure to represent a component to submit a workflow."""
   def __init__(self, root_dir, data):
     self.name = data.get("name")

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -87,7 +87,7 @@ def py_func_import(py_func, kwargs):
   met = getattr(mod, create_function)
   return met(**kwargs)
 
-class WorkflowComponent(object): # pylint: disable=too-many-instance-attributes,useless-object-inheritance
+class WorkflowComponent(object): # pylint: disable=too-many-instance-attributes
   """Datastructure to represent a component to submit a workflow."""
   def __init__(self, root_dir, data):
     self.name = data.get("name")
@@ -197,7 +197,7 @@ def run(args, file_handler): # pylint: disable=too-many-statements,too-many-bran
     extra_py_paths.append(path)
 
   kf_test_path = os.path.join(args.repos_dir, "kubeflow/testing/py")
-  if not kf_test_path in extra_py_paths:
+  if kf_test_path not in extra_py_paths:
     logging.info("Adding %s to extra python paths", kf_test_path)
     extra_py_paths.append(kf_test_path)
 

--- a/py/kubeflow/testing/test_py_lint.py
+++ b/py/kubeflow/testing/test_py_lint.py
@@ -22,6 +22,12 @@ def parse_args():
     type=str,
     help=("The root directory of the source tree. Defaults to current "
           "directory."))
+
+  parser.add_argument(
+    "--rcfile",
+    default="",
+    type=str,
+    help=("Path to the rcfile."))
   args, _ = parser.parse_known_args()
   return args
 
@@ -48,7 +54,11 @@ def test_lint(test_case): # pylint: disable=redefined-outer-name
   # TODO(jlewi): Use pathlib once we switch to python3.
   includes = ["*.py"]
   failed_files = []
-  rc_file = os.path.join(args.src_dir, ".pylintrc")
+  if not args.rcfile:
+    rc_file = os.path.join(args.src_dir, ".pylintrc")
+  else:
+    rc_file = args.rcfile
+
   for root, dirs, files in os.walk(os.path.abspath(args.src_dir), topdown=True):
     # Exclude vendor directories and all sub files.
     if "vendor" in root.split(os.sep):


### PR DESCRIPTION
* Prow spyglass are still using kubernetes-jenkins; if we use kubeflow-ci_temp
  the results won't show up in spyglass.

* Also we don't need to set suffix to fakesuffix.

* related to kubeflow/kfctl#58

* Fix a bunch of lint errors
  * since junit results from lint weren't being surfaced in prow a bunch of issues crept in over time.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/488)
<!-- Reviewable:end -->
