### PR TITLE
Revert test_py_lint.py

### DIFF
--- a/py/kubeflow/testing/ci/kf_unittests.py
+++ b/py/kubeflow/testing/ci/kf_unittests.py
@@ -215,7 +215,7 @@ class Builder: # pylint: disable=too-many-instance-attributes
 
     py_lint["name"] = "py-lint"
     py_lint["container"]["command"] = ["pytest",
-                                       "test_py_lint.py",
+                                       "py_lint_test.py",
                                        # I think -s mean stdout/stderr will
                                        # print out to aid in debugging.
                                        # Failures still appear to be captured

--- a/py/kubeflow/testing/py_lint_test.py
+++ b/py/kubeflow/testing/py_lint_test.py
@@ -1,12 +1,19 @@
-"""TODO(jlewi): This is deprecated. New code should use py_lint_test.py"""
-import argparse
 import fnmatch
 import logging
 import os
 import subprocess
 
-from kubeflow.testing import test_helper, util
+from kubeflow.testing import util
 
+import pytest
+
+logging.basicConfig(
+    level=logging.INFO,
+    format=('%(levelname)s|%(asctime)s'
+            '|%(pathname)s|%(lineno)d| %(message)s'),
+    datefmt='%Y-%m-%dT%H:%M:%S',
+)
+logging.getLogger().setLevel(logging.INFO)
 
 def should_exclude(root, full_dir_excludes):
   for e in full_dir_excludes:
@@ -15,28 +22,13 @@ def should_exclude(root, full_dir_excludes):
   return False
 
 
-def parse_args():
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-    "--src_dir",
-    default=os.getcwd(),
-    type=str,
-    help=("The root directory of the source tree. Defaults to current "
-          "directory."))
+def test_lint(record_xml_attribute, src_dir, rcfile): # pylint: disable=redefined-outer-name
+  # Override the classname attribute in the junit file.
+  # This makes it easy to group related tests in test grid.
+  # http://doc.pytest.org/en/latest/usage.html#record-xml-attribute
+  util.set_pytest_junit(record_xml_attribute, "test_py_lint")
 
-  parser.add_argument(
-    "--rcfile",
-    default="",
-    type=str,
-    help=("Path to the rcfile."))
-  args, _ = parser.parse_known_args()
-  return args
-
-
-def test_lint(test_case): # pylint: disable=redefined-outer-name
-  logging.warning('test_py_lint.py is deprecated in favor of '
-                  'py_lint_test.py which uses pytest')
-  args = parse_args()
+  logging.info('Running test_lint')
   # Print out the pylint version because different versions can produce
   # different results.
   util.run(["pylint", "--version"])
@@ -50,18 +42,16 @@ def test_lint(test_case): # pylint: disable=redefined-outer-name
     "release-infra",
   ]
   full_dir_excludes = [
-    os.path.join(os.path.abspath(args.src_dir), f) for f in dir_excludes
+    os.path.join(os.path.abspath(src_dir), f) for f in dir_excludes
   ]
 
   # TODO(jlewi): Use pathlib once we switch to python3.
   includes = ["*.py"]
   failed_files = []
-  if not args.rcfile:
-    rc_file = os.path.join(args.src_dir, ".pylintrc")
-  else:
-    rc_file = args.rcfile
+  if not rcfile:
+    rcfile = os.path.join(src_dir, ".pylintrc")
 
-  for root, dirs, files in os.walk(os.path.abspath(args.src_dir), topdown=True):
+  for root, dirs, files in os.walk(os.path.abspath(src_dir), topdown=True):
     # Exclude vendor directories and all sub files.
     if "vendor" in root.split(os.sep):
       continue
@@ -77,20 +67,24 @@ def test_lint(test_case): # pylint: disable=redefined-outer-name
         full_path = os.path.join(root, f)
         try:
           util.run(
-            ["pylint", "--rcfile=" + rc_file, full_path], cwd=args.src_dir)
+            ["pylint", "--rcfile=" + rcfile, full_path], cwd=src_dir)
         except subprocess.CalledProcessError:
-          failed_files.append(full_path[len(args.src_dir):])
+          failed_files.append(full_path[len(src_dir):])
   if failed_files:
     failed_files.sort()
-    test_case.add_failure_info("Files with lint issues: {0}".format(
-      ", ".join(failed_files)))
     logging.error("%s files had lint errors:\n%s", len(failed_files),
                   "\n".join(failed_files))
   else:
     logging.info("No lint issues.")
 
+  assert not failed_files
 
 if __name__ == "__main__":
-  test_case = test_helper.TestCase(name='test_lint', test_func=test_lint)
-  test_suite = test_helper.init(name='py_lint', test_cases=[test_case])
-  test_suite.run()
+  logging.basicConfig(
+      level=logging.INFO,
+      format=('%(levelname)s|%(asctime)s'
+              '|%(pathname)s|%(lineno)d| %(message)s'),
+      datefmt='%Y-%m-%dT%H:%M:%S',
+  )
+  logging.getLogger().setLevel(logging.INFO)
+  pytest.main()


### PR DESCRIPTION
* Other workflows are using test_py_lint and making it a pytest breaks them.

* Create a new version py_lint_test.py for people that want to migrate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/496)
<!-- Reviewable:end -->
