### PR TITLE
upgrade kubectl to v1.14.0 in test-worker

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -182,7 +182,7 @@ RUN curl  https://get.docker.com/ | sh
 
 # Install kubectl
 # We don't install via gcloud because we want 1.10 which is newer than what's in gcloud.
-RUN  curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && \
+RUN  curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl && \
     mv kubectl /usr/local/bin && \
     chmod a+x /usr/local/bin/kubectl
 


### PR DESCRIPTION
upgrade kubectl to v1.14.0 in test-worker, the currect new V1.10.0 is too old so caused the porblem beflow.
```
error: SchemaError(io.k8s.api.certificates.v1beta1.CertificateSigningRequestList): invalid object doesn't have additional properties
```
See more in https://github.com/kubeflow/examples/pull/668 and https://github.com/kubeflow/examples/issues/665

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/500)
<!-- Reviewable:end -->
