### PR TITLE
bulk_deploy support v0.6

### DIFF
--- a/codelabs/setup-codelab-project.yaml
+++ b/codelabs/setup-codelab-project.yaml
@@ -28,7 +28,7 @@ spec:
         - --depth=all
         # Keep repos in sync with other jobs
         # Suggest pinning to specific comits to avoid being broken  by changes
-        - --repos=kubeflow/kubeflow@9741891,kubeflow/testing@HEAD:518
+        - --repos=kubeflow/kubeflow@9741891,kubeflow/testing@HEAD:523
         - --src_dir=/src
         env:
         - name: PYTHONPATH
@@ -60,11 +60,14 @@ spec:
         - --oauth_file=gs://kf-codelab-admin/test-project-iap.oauth.yaml
         # The remaining arguments customize how Kubeflow is setup.
         # You can change the values here in the template to change how bulk deploy will setup kubeflow instances
-        - --name=kflab
-        - --kfctl_path=https://github.com/kubeflow/kubeflow/releases/download/v0.7.0/kfctl_v0.7.0_linux.tar.gz        
+        - --name=kflab            
         - --setup_project
         - --zone=us-central1-a
-        - --kfctl_config=https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_iap.0.7.0.yaml
+        # uncomment for v0.7
+        #- --kfctl_path=https://github.com/kubeflow/kubeflow/releases/download/v0.7.0/kfctl_v0.7.0_linux.tar.gz  
+        #- --kfctl_config=https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_iap.0.7.0.yaml
+        - --kfctl_path=https://github.com/kubeflow/kubeflow/releases/download/v0.6.2/kfctl_v0.6.2_linux.tar.gz
+        - --kfctl_config=https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
         volumeMounts:
         - mountPath: /src
           name: src

--- a/py/kubeflow/testing/bulk_deploy.py
+++ b/py/kubeflow/testing/bulk_deploy.py
@@ -89,7 +89,7 @@ class BulkDeploy:
     job["spec"]["template"]["metadata"]["labels"].update(labels)
 
     # Process the command line
-    remove_args = ["--project", "--extra_users"]
+    remove_args = ["--project", "--extra_users", "--email"]
     command = []
     for a in job["spec"]["template"]["spec"]["containers"][0]["command"]:
       keep = True
@@ -103,7 +103,8 @@ class BulkDeploy:
 
       command.append(a)
 
-    extra_users = ["user:" + user, "serviceAccount:" + ADMIN_ACCOUNT]
+    command.append("--email=" + user)
+    extra_users = ["serviceAccount:" + ADMIN_ACCOUNT]
     command.append("--project=" + project)
     command.append("--extra_users=" + ",".join(extra_users))
 


### PR DESCRIPTION
bulk_deploy support Kubeflow v0.6

* For bulk deployments support deploying a v0.6.2 version of Kubeflow
  in addition to v0.7

* For v0.6 kfctl apply won't succeed for an already deployed cluster so
  we need to check if the deployment already exists and if it does
  not redeploy


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/523)
<!-- Reviewable:end -->
