### PR TITLE
Add pattern to match e2e test disk

### DIFF
--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -23,7 +23,8 @@ from oauth2client.client import GoogleCredentials
 AUTO_DEPLOY_PATTERNS = [re.compile(r"kf-vmaster-(?!n\d\d)")]
 
 E2E_PATTERNS = [re.compile(".*e2e-.*"), re.compile(".*kfctl.*"),
-                re.compile(".*z-.*"), re.compile(".*presubmit.*")]
+                re.compile(".*z-.*"), re.compile(".*presubmit.*"),
+                re.compile(".*unittest.*")]
 
 # Constants enumerating the different classes of infra
 # We currently have 2 types

--- a/py/kubeflow/testing/cleanup_ci_test.py
+++ b/py/kubeflow/testing/cleanup_ci_test.py
@@ -10,7 +10,11 @@ def test_match_endpoints():
   ]
 
   for s in service_names:
-    assert cleanup_ci.is_match(s, patterns=cleanup_ci.MATCHING)
+    assert cleanup_ci.is_match(s, patterns=cleanup_ci.E2E_PATTERNS)
+
+def test_match_disk():
+  pvc = "gke-zresubmit-unittest-pvc-e3bf5be4-987b-11e9-8266-42010a8e00e9"
+  assert cleanup_ci.is_match(pvc, patterns=cleanup_ci.E2E_PATTERNS)
 
 if __name__ == "__main__":
   logging.basicConfig(


### PR DESCRIPTION
Some PVCs in `kubeflow-ci` are not cleaned up by the cron job. This PR fixes the problem by adding more pattern to matches these PVCs.

sample log:
```
{
  "textPayload": "INFO|2019-11-08T18:00:39|/src/kubeflow/testing/py/kubeflow/testing/cleanup_ci.py|215|
 Skipping disk gke-zresubmit-unittest-pvc-e3bf5be4-987b-11e9-8266-42010a8e00e9; it does not match any infra type.\n",
  "insertId": "qvi653ke2jrzxfq5b",
  "resource": {
    "type": "k8s_container",
    "labels": {
      "location": "us-east1-d",
      "project_id": "kubeflow-ci",
      "cluster_name": "kubeflow-testing",
      "pod_name": "cleanup-ci-kubeflow-ci-1573236000-sfv94",
      "container_name": "label-sync",
      "namespace_name": "kubeflow-test-infra"
    }
  },
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/526)
<!-- Reviewable:end -->
