### PR TITLE
[WIP] Fix bug with getting credentials in bulk_deploy.py

### DIFF
--- a/codelabs/delete-codelab-endpoints.yaml
+++ b/codelabs/delete-codelab-endpoints.yaml
@@ -1,4 +1,4 @@
-# A Kubernetes job to launch a bunch of K8s jobs to setup codelab projects
+# A Kubernetes job to test the endpoints of a bunch of deployed instances
 #
 # This job runs the kubeflow.testing.bulk-deploy script and takes as input
 # a CSV file on GCS containing the GCS projects to test.
@@ -9,11 +9,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName:  test-codelab-
+  generateName:  codelabs-delete-
   # namespace should
   namespace: kubeflow-jlewi
   labels:
-    job: test-codelab
+    job: codelabs-delete
 spec:
   # TODO(jlewi): Should we add retries
   backoffLimit: 1
@@ -22,7 +22,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
       labels:
-        job: setup-codelab
+        job: codelabs-delete
     spec:
       initContainers:
       - command:        
@@ -54,12 +54,12 @@ spec:
         - python
         - -m
         - kubeflow.testing.bulk_deploy
-        - deploy
-        # Set project base name and the indexes for the projects to deploy
-        # end index is non-inclusive
-        - --project-base-name=kfkc19-san-
-        - --start-index=8851
-        - --end-index=8901
+        - delete
+        # Edit the following flags to control which projects to cleanup
+        - --kfname=kfv06
+        - --project-base-name=some-project-
+        - --start-index=8701
+        - --end-index=8708
         volumeMounts:
         - mountPath: /src
           name: src

--- a/codelabs/setup-codelab-project.yaml
+++ b/codelabs/setup-codelab-project.yaml
@@ -13,8 +13,8 @@ metadata:
   labels:
     job: setup-codelab
 spec:
-  # TODO(jlewi): Should we add retries
-  backoffLimit: 1
+  # We are seeing problems with network connectivity.
+  backoffLimit: 3
   template:
     metadata:
       annotations:
@@ -28,7 +28,7 @@ spec:
         - --depth=all
         # Keep repos in sync with other jobs
         # Suggest pinning to specific comits to avoid being broken  by changes
-        - --repos=kubeflow/kubeflow@9741891,kubeflow/testing@HEAD:523
+        - --repos=kubeflow/kubeflow@9741891,kubeflow/testing@HEAD:527
         - --src_dir=/src
         env:
         - name: PYTHONPATH
@@ -48,6 +48,13 @@ spec:
         env:
         - name: PYTHONPATH
           value: /src/kubeflow/testing/py
+        # TODO(jlewi): We aren't using workload identity because gcloud appears to be flaky.
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/user-gcp-sa.json
+        # We need to set the KUBECONFIG variable because some of the code uses the existence
+        # of this variable to determine how to authenticate to the cluster
+        - name: KUBECONFIG
+          value: /src/.kube
         command:
         - python
         - -m
@@ -60,20 +67,30 @@ spec:
         - --oauth_file=gs://kf-codelab-admin/test-project-iap.oauth.yaml
         # The remaining arguments customize how Kubeflow is setup.
         # You can change the values here in the template to change how bulk deploy will setup kubeflow instances
-        - --name=kflab            
+        - --name=kfv06            
         - --setup_project
-        - --zone=us-central1-a
+        - --zone=us-west1-b
         # uncomment for v0.7
         #- --kfctl_path=https://github.com/kubeflow/kubeflow/releases/download/v0.7.0/kfctl_v0.7.0_linux.tar.gz  
         #- --kfctl_config=https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_iap.0.7.0.yaml
         - --kfctl_path=https://github.com/kubeflow/kubeflow/releases/download/v0.6.2/kfctl_v0.6.2_linux.tar.gz
-        - --kfctl_config=https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
+        - --kfctl_config=https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml        
+        resources:
+          requests:
+            memory: "500Mi"
+            cpu: "1"  
         volumeMounts:
         - mountPath: /src
           name: src
+        - name: gcp-secret
+          mountPath: /var/secrets
+          readOnly: true
       # Use a Kubeflow service account which is mapped to a GSA
       serviceAccount: default-editor
       restartPolicy: Never
       volumes:
       - name: src
         emptyDir: {}
+      - name: gcp-secret
+        secret:
+          secretName: user-gcp-sa

--- a/codelabs/test-codelab-endpoints.yaml
+++ b/codelabs/test-codelab-endpoints.yaml
@@ -9,11 +9,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName:  test-codelab-
+  generateName:  test-endpoints-
   # namespace should
   namespace: kubeflow-jlewi
   labels:
-    job: test-codelab
+    job: test-endpoints
 spec:
   # TODO(jlewi): Should we add retries
   backoffLimit: 1
@@ -30,7 +30,7 @@ spec:
         - --depth=all
         # Keep repos in sync with other jobs
         # Suggest pinning to specific comits to avoid being broken  by changes
-        - --repos=kubeflow/kubeflow@9741891,kubeflow/testing@HEAD:518
+        - --repos=kubeflow/kubeflow@9741891,kubeflow/testing@HEAD:527
         - --src_dir=/src
         env:
         - name: PYTHONPATH
@@ -50,18 +50,30 @@ spec:
         env:
         - name: PYTHONPATH
           value: /src/kubeflow/testing/py:/src/kubeflow/kubeflow
+        # TODO(jlewi): We aren't using workload identity because gcloud appears to be flaky.
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/user-gcp-sa.json
         command:
         - python
         - -m
         - kubeflow.testing.bulk_deploy
         - check-endpoints
-        - --projects-path=gs://kf-codelab-admin/codelab.accounts.20191105.csv
+        - --kfname=kfv06
+        - --project-base-name=kfkc19-san-
+        - --start-index=8700
+        - --end-index=8901
         volumeMounts:
         - mountPath: /src
           name: src
+        - name: gcp-secret
+          mountPath: /var/secrets
+          readOnly: true
       # Use a Kubeflow service account which is mapped to a GSA
       serviceAccount: default-editor
       restartPolicy: Never
       volumes:
       - name: src
         emptyDir: {}
+      - name: gcp-secret
+        secret:
+          secretName: user-gcp-sa

--- a/py/kubeflow/testing/bulk_deploy.py
+++ b/py/kubeflow/testing/bulk_deploy.py
@@ -3,7 +3,6 @@
 This is primarily intended to setup Kubeflow instances in codelab projects.
 """
 
-import csv
 import datetime
 import logging
 import os
@@ -14,6 +13,7 @@ import yaml
 
 from google.cloud import storage
 from kubeflow.testing import util
+from kubernetes import config
 from kubernetes import client as k8s_client
 
 # Currently in the kubeflow/kubeflow repo
@@ -26,25 +26,10 @@ DEFAULT_NAMESPACE = "kubeflow-jlewi"
 
 DEFAULT_OAUTH_FILE = "gs://kf-codelab-admin/test-project-iap.oauth.yaml"
 
+# The format for user accounts
+USER_TEMPLATE = "devstar{0}@gcplab.me"
+
 class BulkDeploy:
-  def _read_csv_file(self, projects_path, admin_project, output_dir):
-    bucket, blob_path = util.split_gcs_uri(projects_path)
-
-    client = storage.Client(project=admin_project)
-    bucket = client.get_bucket(bucket)
-
-    blob = bucket.get_blob(blob_path)
-
-    csv_file = os.path.join(output_dir, os.path.basename(blob_path))
-    blob.download_to_filename(csv_file)
-
-    rows = []
-    with open(csv_file) as hf:
-      reader = csv.DictReader(hf)
-      rows = [r for r in reader]
-
-    return rows
-
   def _load_oauth_file(self, oauth_file, admin_project):
     bucket, blob_path = util.split_gcs_uri(oauth_file)
 
@@ -116,20 +101,63 @@ class BulkDeploy:
 
     return job
 
-  def deploy(self, projects_path, job_file=None, output_dir=None,
-             admin_project="kf-codelab-admin", namespace=DEFAULT_NAMESPACE):
+  def _create_delete_job_spec(self, job_file, group_label, project, kfname,
+                              namespace):
+    """Create the K8s job spec to delete a kubeflow deployment.
+
+    Args:
+      job_file: YAML file containing the job to use as a template
+      group_label: Label for the group of jobs
+      project: GCP project to deploy into
+      kfname: Name of the kubeflow deployment
+      namespace: Namespace where job should run.
+    """
+    # Load a new copy of the job template on each run
+    with open(job_file) as hf:
+      job = yaml.load(hf)
+
+    labels = {
+      "project": project,
+      "group": group_label,
+    }
+
+    job["metadata"]["generateName"] = "delete-codelab-"
+    job["metadata"]["namespace"] = namespace
+    job["metadata"]["labels"].update(labels)
+    job["spec"]["template"]["metadata"]["labels"].update(labels)
+
+    job["spec"]["template"]["spec"]["containers"][0]["command"] = [
+      "python",
+      "-m",
+      "kubeflow.testing.delete_kf_instance",
+      "delete_kf",
+      "--project=" + project,
+      "--name=" + kfname,
+    ]
+
+    logging.info("Job spec for project: %s\n%s", project,
+                 yaml.safe_dump(job))
+
+    return job
+
+  def deploy(self, project_base_name, start_index, end_index,  # pylint: disable=too-many-arguments
+             job_file=None, output_dir=None, namespace=DEFAULT_NAMESPACE):
     """Fire off a bunch of K8s jobs to deploy many Kubeflow instances.
 
     Args:
-      projects_path: The GCS path of a CSV file containing the list of projects
-        to deploy in.
+      project_base_name: The base name for the projects. Should end
+        with "-"
+      start_index: The start index
+      end_index: The index non inclusive
+      kfname: The name of the of the kubeflow app
 
       job_file: The path to the YAML file containing a K8s Job that serves
         as the template for the jobs to be launched.
 
       output_dir: Directory to write the job specs to.
     """
-    util.load_kube_config(persist_config=False)
+    util.load_kube_credentials()
+
     # Create an API client object to talk to the K8s master.
     api_client = k8s_client.ApiClient()
     batch_api = k8s_client.BatchV1Api(api_client)
@@ -147,24 +175,14 @@ class BulkDeploy:
 
     logging.info("output_dir: %s", output_dir)
 
-    rows = self._read_csv_file(projects_path, admin_project, output_dir)
-
     # Generate a common label for all the jobs. This way we can potentially
     # wait for all the jobs based on the label.
     group_label = (datetime.datetime.now().strftime("%Y%m%d-%H%M%S-") +
                    uuid.uuid4().hex[0:4])
-    for row in rows:
-      project = None
-      user = None
-      for k, v in row.items():
-        if k.lower() == "project":
-          project = v
-        if k.lower() == "username":
-          user = v
-
-      if not project or not user:
-        logging.info("Skipping row %s; could not get project and user", row)
-        continue
+    for index in range(start_index, end_index):
+      project = "{0}{1}".format(project_base_name, index)
+      user = USER_TEMPLATE.format(index)
+      logging.info("Processing project=%s user=%s", project, user)
 
       logging.info("Processing project=%s user=%s", project, user)
 
@@ -186,13 +204,77 @@ class BulkDeploy:
 
     self.wait_for_jobs(namespace, "group=" + group_label)
 
+  def delete(self, project_base_name, start_index, end_index, kfname, # pylint: disable=too-many-arguments
+             job_file=None, output_dir=None, namespace=DEFAULT_NAMESPACE):
+    """Fire off a bunch of K8s jobs to delete many Kubeflow instances.
+
+    Args:
+      project_base_name: The base name for the projects. Should end
+        with "-"
+      start_index: The start index
+      end_index: The index non inclusive
+      kfname: The name of the of the kubeflow app
+      job_file: The path to the YAML file containing a K8s Job that serves
+        as the template for the jobs to be launched.
+
+      output_dir: Directory to write the job specs to.
+    """
+    util.load_kube_credentials()
+
+    # Create an API client object to talk to the K8s master.
+    api_client = k8s_client.ApiClient()
+    batch_api = k8s_client.BatchV1Api(api_client)
+
+    if not job_file:
+      job_file = self._default_job_file()
+
+    if not os.path.exists(job_file):
+      raise ValueError("job file {0} does not exist".format(job_file))
+
+    logging.info("Job file: %s", job_file)
+
+    if not output_dir:
+      output_dir = tempfile.mkdtemp()
+
+    logging.info("output_dir: %s", output_dir)
+
+    # Generate a common label for all the jobs. This way we can potentially
+    # wait for all the jobs based on the label.
+    group_label = (datetime.datetime.now().strftime("%Y%m%d-%H%M%S-") +
+                   uuid.uuid4().hex[0:4])
+    for index in range(start_index, end_index):
+      project = "{0}{1}".format(project_base_name, index)
+
+      logging.info("Processing project=%s", project)
+
+      job = self._create_delete_job_spec(job_file, group_label, project,
+                                         kfname, namespace)
+      output_file = os.path.join(output_dir, "delete-{0}.yaml".format(project))
+      logging.info("Writing job spec to %s", output_file)
+      with open(output_file, "w") as hf:
+        yaml.safe_dump(job, hf)
+
+      # submit the job
+      logging.info("Creating job")
+      actual_job = batch_api.create_namespaced_job(job["metadata"]["namespace"],
+                                                   job)
+
+      logging.info("Created job %s.%s:\n%s", actual_job.metadata.namespace,
+                   actual_job.metadata.name, yaml.safe_dump(actual_job.to_dict()))
+
+    self.wait_for_jobs(namespace, "group=" + group_label)
+
   def wait_for_jobs(self, namespace, label_filter):
     """Wait for all the jobs with the specified label to finish.
 
     Args:
       label_filter: A label filter expression e.g. "group=mygroup"
     """
-    util.load_kube_config(persist_config=False)
+    if not util.is_in_cluster():
+      util.load_kube_config(persist_config=False)
+    else:
+      config.load_incluster_config()
+
     # Create an API client object to talk to the K8s master.
     api_client = k8s_client.ApiClient()
     jobs = util.wait_for_jobs_with_label(api_client, namespace, label_filter)
@@ -219,45 +301,22 @@ class BulkDeploy:
     logging.info("%s of %s jobs finished successfully", succeeded,
                  len(jobs.items))
 
-  def check_endpoints(self, projects_path, output_dir=None,
-                      admin_project="kf-codelab-admin", job_file=None,
+  def check_endpoints(self, project_base_name, start_index, end_index,
+                      kfname, admin_project="kf-codelab-admin",
                       oauth_file=DEFAULT_OAUTH_FILE):
     """Check whether the project endpoints are accessible.
 
     Args:
-      projects_path: The GCS path of the CSV file containing the list of
-        projects.
+      project_base_name: The base name for the projects. Should end
+        with "-"
+      start_index: The start index
+      end_index: The index non inclusive
+      kfname: The name of the of the kubeflow app
     """
+    if not kfname:
+      raise ValueError("kfname is required")
 
-    if not job_file:
-      job_file = self._default_job_file()
-
-    if not os.path.exists(job_file):
-      raise ValueError("job file {0} does not exist".format(job_file))
-
-    logging.info("Job file: %s", job_file)
-
-    # Read the job file to get the name of the kubeflow deployments
-    with open(job_file) as hf:
-      job = yaml.load(hf)
-
-    command = job["spec"]["template"]["spec"]["containers"][0]["command"]
-
-    app_name = None
-    for a in command:
-      if not a.startswith("--name"):
-        continue
-
-      app_name = a.rsplit("=", 1)[-1]
-      break
-
-    if not app_name:
-      raise ValueError("Could not determine the name of the Kubeflow "
-                       "deployments")
-
-    logging.info("Using Kubeflow app name: %s", app_name)
-    if not output_dir:
-      output_dir = tempfile.mkdtemp()
+    logging.info("Using Kubeflow app name: %s", kfname)
 
     logging.info("Reading OAuth file: %s", oauth_file)
     oauth_info = self._load_oauth_file(oauth_file, admin_project)
@@ -266,23 +325,14 @@ class BulkDeploy:
     os.environ["CLIENT_ID"] = oauth_info["CLIENT_ID"]
     os.environ["CLIENT_SECRET"] = oauth_info["CLIENT_SECRET"]
 
-    logging.info("output_dir: %s", output_dir)
-
-    rows = self._read_csv_file(projects_path, admin_project, output_dir)
-
-    ready = []
     not_ready = []
-    for row in rows:
-      project = None
-      for k, v in row.items():
-        if k.lower() == "project":
-          project = v
+    ready = []
+    for index in range(start_index, end_index):
+      project = "{0}{1}".format(project_base_name, index)
 
-      if not project:
-        logging.info("Skipping row %s; could not get project and user", row)
-        continue
+      logging.info("Processing project=%s", project)
 
-      url = "https://{0}.endpoints.{1}.cloud.goog/".format(app_name, project)
+      url = "https://{0}.endpoints.{1}.cloud.goog/".format(kfname, project)
 
       # We set a very short time because we don't want to wait very long for
       # each one.

--- a/py/kubeflow/testing/delete_kf_instance.py
+++ b/py/kubeflow/testing/delete_kf_instance.py
@@ -1,0 +1,61 @@
+"""Delete a kubeflow instance."""
+
+import fire
+import json
+import logging
+import retrying
+
+from googleapiclient import discovery
+from googleapiclient import errors
+from oauth2client.client import GoogleCredentials
+
+from kubeflow.testing import util
+
+@retrying.retry(stop_max_delay=10*60*1000)
+def delete_deployment(dm, project, name):
+  deployments_client = dm.deployments()
+  try:
+    op = deployments_client.delete(project=project, deployment=name).execute()
+  except errors.HttpError as e:
+    if not e.content:
+      raise
+    error_content = json.loads(e.content)
+    message = error_content.get('error', {}).get('message', "")
+    logging.info("delete deployment error %s", message)
+    code = error_content.get('error', {}).get('code', 0)
+    if code == 404:
+      logging.info("Project %s doesn't have deployment %s", project, name)
+      return
+    elif code == 409:
+      logging.info("Conflicting operation in progress")
+      raise ValueError("Can't delete deployment confliction operation in "
+                       "progress")
+    raise
+  zone = None
+  op = util.wait_for_gcp_operation(dm.operations(), project, zone, op["name"])
+  log.info("Final op: %s", op)
+
+class KFDeleter:
+  def delete_kf(self, project, name):
+    """Delete a KF instance with the specified name in the specified project."""
+    # TODO(jlewi): This is a bit of a hack due to the fact that kfctl
+    # doesn't properly handle deletion just given the name of a kubeflow
+    # deployment. Once that's fixed we should just use that.
+    util.maybe_activate_service_account()
+
+    credentials = GoogleCredentials.get_application_default()
+    dm = discovery.build("deploymentmanager", "v2", credentials=credentials)
+
+    for dm_name in [name, name + "-storage"]:
+      logging.info("Deleting project %s deployment %s", project, dm_name)
+      delete_deployment(dm, project, dm_name)
+    # TODO(jlewi): Cleanup other resources like certificates and backends
+
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO,
+                        format=('%(levelname)s|%(asctime)s'
+                              '|%(pathname)s|%(lineno)d| %(message)s'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                        )
+  logging.getLogger().setLevel(logging.INFO)
+  fire.Fire(KFDeleter)

--- a/py/kubeflow/testing/delete_kf_instance.py
+++ b/py/kubeflow/testing/delete_kf_instance.py
@@ -23,7 +23,7 @@ def delete_deployment(dm, project, name):
     message = error_content.get('error', {}).get('message', "")
     logging.info("delete deployment error %s", message)
     code = error_content.get('error', {}).get('code', 0)
-    if code == 404:
+    if code == 404: # pylint: disable=no-else-return
       logging.info("Project %s doesn't have deployment %s", project, name)
       return
     elif code == 409:
@@ -33,7 +33,7 @@ def delete_deployment(dm, project, name):
     raise
   zone = None
   op = util.wait_for_gcp_operation(dm.operations(), project, zone, op["name"])
-  log.info("Final op: %s", op)
+  logging.info("Final op: %s", op)
 
 class KFDeleter:
   def delete_kf(self, project, name):


### PR DESCRIPTION
Numerous fixes and improvements to bulk deploying Kubeflow with v06

Fix bug with getting credentials in bulk_deploy

* Need to support obtaining credentials to talk to K8s API servier using
  the pods service accounnt by calling load incluster config.

* With v06 deployments we need to handle the case where the DM API might
  not be enabled yet and enable it before checking if KF exists.

* Don't use workload identity because with workload identity we are seeing
  performance problems when issuing a lot of requests that hit the gke metadata
  server

Improve the ability to continue deploying v06 deployments that failed.

* With v06 applications check if the ingress actually exists and if
  not we will rerun deploy.

  * Delete istio-ingressgateway service if its not fully deployed to try to recover.

* Add a util method for getting Kubernetes credentials

  * When running in a pod there are two cases we need to handle
    * using the KSA to authenticate to the K8s APIServer the pod is running
    * Using a kubeconfig file to talk to a different cluster.

* Add resource requests to the create_unique_kf_instance jobs to better
  handle scheduling of many jobs

* Create code to delete Kubeflow deployments in bulk

* Don't use a CSV file to provide info about what deployments to create
  * Uploading CSV files to GCS turns out to be a lot of friction

  * instead just take command line arguments which specify the range of
    projects to iterate over.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/527)
<!-- Reviewable:end -->
