### PR TITLE
Move over the KF cd pipelines into kubeflow/testing and refactor

### DIFF
--- a/apps-cd/README.md
+++ b/apps-cd/README.md
@@ -1,0 +1,101 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Kubeflow CI with tektoncd pipelines](#kubeflow-ci-with-tektoncd-pipelines)
+  - [Use Cases](#use-cases)
+  - [Background information on TektonCD pipelineruns, pipelines and tasks](#background-information-on-tektoncd-pipelineruns-pipelines-and-tasks)
+  - [Parameterization](#parameterization)
+  - [Secrets](#secrets)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Kubeflow CD with tektoncd pipelines
+
+This directory contains Tekton pipelines intended to rebuild Kubeflow docker images 
+and open PRs to update Kubeflow kustomize manifests to use the newly built images.
+
+### How it works
+
+* pipelines/base/pipeline.yaml defines a reusable pipeline to:
+
+  1. Build a container image
+  1. Create a PR to update the Kubeflow manifests to use the newly built image
+
+* To launch a pipeline to build a specific application at a specific commit you create an instance of a pipeline run
+  that uses this pipeline
+
+  * runs/profile_controller_v1795828.yaml provides an example pipeline run to build and update the profile controller image
+
+  * [pipeline resources](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md) and [pipeline parameters](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#parameters) to specify what application to build and the image to create
+
+    * [Git Resources](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md#git-resource) are used to define
+
+      * The repo and commit containing the source code to build the image from
+      * The repo containing the manifests to update
+      * The repo and commit containing the tools used for CI/CD
+
+    * [Image Resource](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md#image-resource) is used to define
+      the docker image to use
+
+    * Parameters are used to define various values specific to each application such as the relative paths of the Docker file
+      in the source repository
+
+ * The kubeflow-bot GitHub account is used to create the PRs
+
+### Run a pipeline 
+
+To update a specific application
+
+1. Connect to the Kubeflow releasing cluster
+
+   * **project**: **kf-releasing**
+   * **cluster**: **kf-releasing-0-6-2**
+   * **namespace**: **kf-releasing**
+
+1. Create a PipelineRun file
+
+   * You can use one of the runs in runs/ as a baseline
+   * Set the Tekton PipelineRun parameters and resources as needed to build your
+     application at the desired commit 
+
+1. Run it
+    
+   ```
+   kubectl create -f ${PIPELINERUN_FILE}
+   ```
+
+### Setting up a cluster to run the pipelines
+
+The kustomize manifests are currently written so as to run in a Kubeflow releasing cluster.
+
+The current release cluster is
+
+* **project**: **kf-releasing**
+* **cluster**: **kf-releasing-0-6-2**
+* **namespace**: **kf-releasing**
+
+This is a Kubeflow cluster (v0.6.2) and we rely on that to configure certain things like the secrets and service accounts.
+
+1. Follow [Tektons' instructions](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#ssh-authentication-git) for
+   creating a secret containing ssh credentials for use with GitHub
+
+   * We are currently using the secret named **kubeflow-bot-github-ssh**
+
+
+1. Ensure the GCP service account used with Kaniko has storage admin permissions for the project
+   where the images are pushed.
+
+   * most likely **gcr.io/kubeflow-images-public**
+
+1. Create a secret named **github-token** containing a github token to be used by the hub CLI to create PRs.
+
+1. Create the Tekton resources
+
+   ```
+   kustomize build pipelines/base/ | kubectl apply -f -
+   ```
+
+## References
+
+1. [Design Doc](https://docs.google.com/document/d/1AwYVznJ0F5ZwVrClATff2wXUKE-OnygIlwY1NRTv-2I/edit#heading=h.9g4gb5dvlquq)

--- a/apps-cd/pipelines/README.md
+++ b/apps-cd/pipelines/README.md
@@ -1,0 +1,2 @@
+This directory contains kustomize manifests for defining the reusable Tekton Tasks and Pipelines
+used for creating continuous delivery pipelines for Kubeflow applications.

--- a/apps-cd/pipelines/base/README.md
+++ b/apps-cd/pipelines/base/README.md
@@ -1,0 +1,152 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Kubeflow CI with tektoncd pipelines](#kubeflow-ci-with-tektoncd-pipelines)
+  - [Use Cases](#use-cases)
+  - [Background information on TektonCD pipelineruns, pipelines and tasks](#background-information-on-tektoncd-pipelineruns-pipelines-and-tasks)
+  - [Parameterization](#parameterization)
+  - [Secrets](#secrets)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Kubeflow CD with tektoncd pipelines
+
+This directory contains Tekton pipelines intended to rebuild Kubeflow docker images 
+and open PRs to update Kubeflow kustomize manifests to use the newly built images.
+
+
+### Use Cases
+
+The following use cases can be run on the following components (should be run from the components directory):
+- `kustomize build --reorder none `*centraldashboard*`/ci   | kubectl apply -f -`
+- `kustomize build --reorder none `*jupyter-web-app*`/ci    | kubectl apply -f -`
+- `kustomize build --reorder none `*notebook-controller*`/ci | kubectl apply -f -`
+- `kustomize build --reorder none `*profile-controller*`/ci | kubectl apply -f -
+
+This uses TektonCD [pipelinerun](https://github.com/tektoncd/pipeline/blob/master/docs/pipelineruns.md) to enable the following use case:
+
+1. A PR is merged into kubeflow/kubeflow updating the component
+1. The merged commit is 1234
+1. This tekton pipelinerun is triggered to build the component image from commit @1234.
+1. The pipelinerun edits manifests/common/centraldashboard/base/kustomization.yaml (using kubeflow-bot repo) and adds the new image tag
+1. The pipelinerun calls `make generate; make test` 
+1. If successful then 
+1.   The pipeline checks in the changes 
+1.   Opens a PR with the updated kubeflow/manifests that uses the newly built image
+1.   Approvers LGTM the PR to kubeflow/manifests and it gets merged
+
+### Background information on TektonCD pipelineruns, pipelines and tasks
+
+A TektonCD PipelineRun takes 1 Pipeline and N PipelineResources.
+The PipelineResources can be git repos, git pull requests, docker images.
+These resources are made available to the Pipeline via PipelineRun.
+
+The general relationship between TektonCD resources is shown below:
+
+```
+── PipelineRun
+   ├── PipelineResources
+   └── Pipeline
+       └── Tasks
+```
+
+In this use case the following instance is created:
+
+```
+── ci-centraldashboard-pipeline-run
+   ├── resources
+   │   ├── image
+   │   │   └── component
+   │   └── git 
+   │       ├── kubeflow+revision
+   │       └── manifests+revision 
+   └── pipeline
+       └── tasks
+           ├── build-push      
+```
+
+The PipelineRun includes a Pipeline that has 1 tasks and 3 PipelineResources of type image (component) and git (kubeflow, manifests). The Tasks reference these resources in their inputs or outputs. 
+
+### Parameterization 
+
+The PipelineRun uses parameterized PipelineResources which are passed down to the the Pipeline and Tasks.
+The Pipeline uses parameterized Tasks.
+Reusing this pipeline only requires changing parameters in params.env in the target component
+
+The parameters are noted below, those with an asterix should change per component:
+Those parameters without an asterix allow different gcr.io locations and namespace.
+
+```
+  container_image=gcr.io/kubeflow-ci/test-worker:latest
+* docker_target=serve
+* image_name=centraldashboard
+  image_url=gcr.io/kubeflow_public_images
+* kubeflow_repo_revision=1234
+* kubeflow_repo_url=git@github.com:kubeflow/kubeflow.git
+* manifests_repo_revision=master
+* manifests_repo_url=git@github.com:kubeflow/manifests.git
+  namespace=kubeflow-test-infra
+* path_to_context=components/centraldashboard
+* path_to_docker_file=components/centraldashboard/Dockerfile
+* path_to_manifests_dir=common/centraldashboard/base
+  pvc_mount_path=/kubeflow
+```
+
+### Setting up a cluster to run the pipelines
+
+The kustomize manifests are currently written so as to run in a Kubeflow releasing cluster.
+
+The current release cluster is
+
+* **project**: **kf-releasing**
+* **cluster**: **kf-releasing-0-6-2**
+* **namespace**: **kf-releasing**
+
+This is a Kubeflow cluster (v0.6.2) and we rely on that to configure certain things like the secrets and service accounts.
+
+1. Follow [Tektons' instructions](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#ssh-authentication-git) for
+   creating a secret containing ssh credentials for use with GitHub
+
+   * We are currently using the secret named **kubeflow-bot-github-ssh**
+
+
+1. Ensure the GCP service account used with Kaniko has storage admin permissions for the project
+   where the images are pushed.
+
+   * most likely **gcr.io/kubeflow-images-public**
+
+1. Create a secret named **github-token** containing a github token to be used by the hub CLI to create PRs.
+
+### Run a pipeline
+
+1. Modify `base/params.env`
+
+   * set namespace to the namespace where it will run
+
+1. Run
+    
+   ```
+   kustomize build --reorder none `*profile-controller*`/ci | kubectl apply -f -
+   ```
+
+### Create a pipeline run for a specific commit
+
+Let `APPDIR` be the directory for the specific application e.g.
+
+```
+COMMIT=<commit to build at>
+APPDIR=components/profile-controller
+```
+
+1. Create the overlay directory
+    
+   ```
+   mkdir -p ${APPDIR}/ci-g${COMMIT}
+   ```
+
+1. Modify `${APPDIR}/ci-g${COMMIT}/params.env`
+
+ 
+   * **kubeflow_repo_revision**: Set this to the commit to build at.
+   * **image_url**: This to the full URL of the image e.g **gcr.io/kubeflow-images-public/profile-controller@vmaster-g1795828**

--- a/apps-cd/pipelines/base/kustomization.yaml
+++ b/apps-cd/pipelines/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- service-account.yaml
+- role-binding.yaml
+- task.yaml
+- pipeline.yaml
+namespace: kf-releasing

--- a/apps-cd/pipelines/base/pipeline.yaml
+++ b/apps-cd/pipelines/base/pipeline.yaml
@@ -1,0 +1,86 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: ci-pipeline
+spec:
+  params:
+  - description: docker target arg
+    name: docker_target
+    type: string
+    default: ""
+  - description: The build context used by Kaniko
+    name: path_to_context
+    type: string
+    default: ""
+  - description: The path to the dockerfile to build
+    name: path_to_docker_file
+    type: string
+    default: ""
+  - description: Directory of the application's kustomize manifest
+    name: path_to_manifests_dir
+    type: string
+    default: ""
+  - description: The path of the image in the kustomization file to change
+    name: src_image_url
+    type: string
+    default: ""
+  - description: The container image to use for running the steps
+    name: container_image
+    type: string  
+    default: ""
+  resources:
+  # Pipeline has 3 git resources
+  # kubeflow - Repository containing the source code for the docke rimages to build
+  # manifests - Repostory containing the manifests to update
+  # ci-tools - Repository containing tools used in the CI/CD pipeline  
+  - name: kubeflow
+    type: git
+  - name: manifests
+    type: git
+  - name: ci-tools
+    type: git
+
+  # Image resource defines the docker image to build
+  - name: image
+    type: image
+  tasks:
+  - name: build-push
+    params:
+    - name: docker_target
+      value: "$(params.docker_target)"
+    - name: path_to_context
+      value: "$(params.path_to_context)"
+    - name: path_to_docker_file
+      value: "$(params.path_to_docker_file)"
+    resources:
+      inputs:
+      - name: kubeflow
+        resource: kubeflow
+      - name: image
+        resource: image
+    taskRef:
+      name: build-push
+      kind: namespaced
+  - name: update-manifests
+    runAfter:
+    - build-push
+    params:
+    - name: src_image_url
+      value: "$(params.src_image_url)"
+    - name: path_to_manifests_dir
+      value: "$(params.path_to_manifests_dir)"
+    - name: container_image
+      value: "$(params.container_image)"
+    resources:
+      inputs:
+      - name: manifests
+        resource: manifests
+      - name: kubeflow
+        resource: kubeflow        
+      - name: ci-tools
+        resource: ci-tools
+      - name: image
+        resource: image
+    taskRef:
+      name: update-manifests
+      kind: namespaced

--- a/apps-cd/pipelines/base/role-binding.yaml
+++ b/apps-cd/pipelines/base/role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: ci-pipeline-run-role-binding
+roleRef:
+  # TODO use a weaker clusterrole or just a role if possible
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: ci-pipeline-run-service-account

--- a/apps-cd/pipelines/base/service-account.yaml
+++ b/apps-cd/pipelines/base/service-account.yaml
@@ -1,0 +1,12 @@
+# TODO(jlewi): When we switch to workload identity should we continue to use this service account
+# or use the default Kubeflow service account which is already bound to a GCP SA.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ci-pipeline-run-service-account
+secrets:
+# This is the name of the secret containing the ssh secret for the kubeflow-bot
+# This is used to create pull requests updating the manifests
+# For more info see the Tekton authentication docs
+# https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#ssh-authentication-git
+- name: kubeflow-bot-github-ssh

--- a/apps-cd/pipelines/base/task.yaml
+++ b/apps-cd/pipelines/base/task.yaml
@@ -1,0 +1,112 @@
+# TODO(jlewi): We should probably split this into two tasks now; one for building the image
+# and one for updating the image. Now that we know the URL of the image we no longer need to pass along
+# the digest between the steps using a volume mounted pod.
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: build-push
+  annotations:
+    # This gets passed down to the individual pods
+    sidecar.istio.io/inject: "false"
+spec:
+  inputs:
+    params:
+    - description: docker target arg
+      name: docker_target
+      type: string
+    - description: The build context used by Kaniko
+      name: path_to_context
+      type: string
+    - description: The path to the dockerfile to build
+      name: path_to_docker_file
+      type: string
+    resources:
+    - name: kubeflow
+      type: git
+    - name: image
+      type: image  
+  steps:
+  - name: build-push
+    image: gcr.io/kaniko-project/executor:v0.11.0
+    command:
+    - /kaniko/executor
+    - --dockerfile=/workspace/$(inputs.resources.kubeflow.name)/$(inputs.params.path_to_docker_file)
+    - --target=$(inputs.params.docker_target)
+    - --destination=$(inputs.resources.image.url)
+    - --context=/workspace/$(inputs.resources.kubeflow.name)/$(inputs.params.path_to_context)
+    - --digest-file=/workspace/image-digest      
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secret/user-gcp-sa.json     
+    volumeMounts:
+    - mountPath: /secret
+      name: gcp-credentials  
+  volumes:
+  - name: gcp-credentials
+    secret:
+      secretName: user-gcp-sa
+
+---
+
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: update-manifests
+  annotations:
+    # This gets passed down to the individual pods
+    sidecar.istio.io/inject: "false"
+spec:
+  inputs:
+    params:
+    - description: Directory of the application's kustomize manifest
+      name: path_to_manifests_dir
+      type: string
+    - description: The container image to use for running the steps
+      name: container_image
+      type: string
+    - description: The path of the image in the kustomization file to change
+      name: src_image_url
+      type: string 
+      default: ""     
+    resources:
+    - name: manifests
+      type: git
+    # We include the kubeflow repo just to get the commit at which the image is built.
+    - name: kubeflow
+      type: git
+    - name: ci-tools
+      type: git
+    - name: image
+      type: image  
+  steps:
+  - name: update-manifests
+    workingDir: /workspace/$(inputs.resources.manifests.name)/$(inputs.params.path_to_manifests_dir)
+    image: $(inputs.params.container_image)    
+    command:
+    - /workspace/$(inputs.resources.ci-tools.name)/py/kubeflow/testing/ci/rebuild-manifests.sh
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secret/gcp-credentials/user-gcp-sa.json
+    - name: GITHUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: github-token
+          key: github_token
+    - name: SRC_IMAGE_URL          
+      value: $(inputs.params.src_image_url)
+    - name: IMAGE_URL          
+      value: $(inputs.resources.image.url)
+    - name: MANIFESTS_REPO_REVISION
+      value: $(inputs.resources.manifests.revision)
+    - name: PATH_TO_MANIFESTS_DIR
+      value: $(inputs.params.path_to_manifests_dir)
+    volumeMounts:
+    - mountPath: /secret
+      name: gcp-credentials
+  volumes:
+  - name: gcp-credentials
+    secret:
+      secretName: user-gcp-sa
+  - name: github-token
+    secret:
+      secretName: github-token

--- a/apps-cd/runs/README.md
+++ b/apps-cd/runs/README.md
@@ -1,0 +1,4 @@
+This directory contains Tekton PipelineRuns to build kubeflow applications
+and update the Kubeflow kustomize manifests to use the newly built application.
+
+Each PipelineRun builds a specific application at a specific commit.

--- a/apps-cd/runs/profile_controller_v1795828.yaml
+++ b/apps-cd/runs/profile_controller_v1795828.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  # Generate a unique name for each run
+  generateName: ci-profile-controller-
+spec:
+  pipelineRef:
+    name: ci-pipeline
+  params:  
+  - name: "path_to_context"
+    value: "components/profile-controller"
+  - name: "path_to_docker_file"
+    value: "components/profile-controller/Dockerfile"
+  - name: "path_to_manifests_dir"
+    value: "profiles/base"
+  - name: "src_image_url"
+    value: "gcr.io/kubeflow-images-public/profile-controller"
+  - name: "container_image"
+    value: "gcr.io/kubeflow-releasing/test-worker@sha256:35138a42b57160a078e802b7d69aec3c3e79a3e2e55518af7798275ebcc84d25"    
+  resources:
+  # The git resources that will be used
+  - name: kubeflow
+    resourceSpec:    
+      type: git
+      params:
+        - name: revision
+          value: "1795828"
+        - name: url
+          value: git@github.com:kubeflow/kubeflow.git
+  - name: manifests
+    resourceSpec:    
+      type: git
+      params:
+        - name: revision
+          value: master
+        - name: url
+          value: git@github.com:kubeflow/manifests.git
+  # TODO(jlewi): Replace with kubeflw/kubeflow once the PR is checked in.
+  - name: ci-tools
+    resourceSpec:    
+      type: git
+      params:
+        - name: revision
+          value: tekton
+        - name: url
+          value: git@github.com:jlewi/testing.git
+  # The image we want to build
+  - name:  image
+    resourceSpec:
+      type: image
+      params:
+      - name: url  
+        value: gcr.io/kubeflow-images-public/profile-controller:vmaster-g1795828
+  serviceAccountName: ci-pipeline-run-service-account

--- a/py/kubeflow/testing/ci/rebuild-manifests.sh
+++ b/py/kubeflow/testing/ci/rebuild-manifests.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# 
+# this script assumes the following
+#  - PipelineResource of type git for kubeflow is mounted at /workspace/kubeflow
+#  - PipelineResource of type git for manifests is mounted at /workspace/manifests
+# 
+# and expects the following:
+# env-vars:
+#   namespace
+#   image_name (eg centraldashboard)
+#   kubeflow_repo_revision
+#   kubeflow_repo_url
+# secrets:
+#   gcp-credentials
+#   github-token
+#   github-ssh
+#   kubeflow-oauth
+# 
+# The script does the following in the kubeflow manifests repo
+# - edits the image tag in the kustomization.yaml (its workingdir is where the component's manifest is)
+# - calls `make generate; make test` under manifests/tests 
+# - if successful 
+#   - commits the changes 
+#   - creates a PR.
+#
+# how to set env vars from configmap if debugging
+# for i in $(kubectl get cm ci-pipeline-run-parameters -ojson | jq -r '.data | keys[] as $k | "\($k)=\(.[$k])"'); do echo export $i; export $i; done
+#
+set -ex
+
+# This is for debug
+echo '--env--'
+env | sort
+echo '--env--'
+
+# GitHub user to store the fork
+fork_user=kubeflow-bot
+
+# Get the commit for the kubeflow repository
+cd /workspace/kubeflow
+kubeflow_commit=$(git rev-parse HEAD)
+kubeflow_commit=${kubeflow_commit:0:8}
+
+image_tag=$(echo ${IMAGE_URL} | cut -d':' -f 2)
+new_branch_name='update_'$image_name'_'${image_tag}
+
+# Tekton will automatically mount the ssh private key and known hosts stored in the git secret
+# in /tekton/home/.ssh
+# however since this scriptt runs in our test worker image  it ends up using /root/.sssh
+ln -sf /tekton/home/.ssh /root/.ssh
+ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts
+cd /workspace/manifests
+
+# Do a full fetch to unshallow the clone
+# it looks like Tekton might do a shallow checkout
+git fetch --unshallow
+
+# Create a new branch for the pull request
+git checkout -b $new_branch_name origin/${MANIFESTS_REPO_REVISION}
+
+# Add the kubeflow-bot repo
+git remote add ${fork_user} git@github.com:${fork_user}/manifests.git
+
+cd /workspace/manifests/${PATH_TO_MANIFESTS_DIR}
+kustomize edit set image ${SRC_IMAGE_URL}=${IMAGE_URL}
+cd /workspace/manifests/tests
+
+make generate-changed-only 
+make test
+if (( $? == 0 )); then
+  git config --global user.email "kubeflow-bot@kubflow.org"
+  git config --global user.name "kubeflow-bot"
+  
+  tmpfile=$(mktemp)
+  
+  echo "[auto PR] Update the ${image_name} image to commit ${image_tag}" > $tmpfile
+  echo "" >> $tmpfile
+  echo "* image ${image_url}" >> $tmpfile  
+
+  echo "" >> $tmpfile
+  echo "" >> $tmpfile
+  # TODO(jlewi): We shouldn't hardcode the repository name. We can parse kubeflow_repo_url
+  # This will be easier to do once we rewrite this in python.
+  echo "* Image built from kubeflow/kubeflow@$(kubeflow_commit)" >> $tmpfile
+
+  git commit -a -F ${tmpfile}
+  
+  git push ${fork_user} $new_branch_name -f
+  hub pull-request -f -b 'kubeflow:master' -F $tmpfile
+else
+  echo 'make generate && make test' failed
+fi


### PR DESCRIPTION
* kubeflow/testing is the central repository where all reusable engprod
  code goes. As a result it makes sense for the reusable Tekton definitions
  and scripts related to continuous building and updating of Kubeflow
  applications to live here

* For now, we will also centralize the definition of pipelines for all
  applications in this repository (as opposed to having them live in
  the application repositories).

  * This should make it easier to manage and automatically update
    all applications.

* Per kubeflow/testing#544 redo how we use kustomize and Tekton to
  parameterize the pipelines.

  * Individual runs of pipelines will rely completely on Tekton parameter
    substitution to create a run to build an image for a specific
    application at a specific commit.

    * The image URL and git commit of source code will be Tekton
      PipelineResources that are inlined in the PipelineRun

    * For any parameters we will use Tekton parameters and inline the values
      in the PipelineRun

  * PipelineRuns will just be created as YAML files and not as kustomize
    overlays

  * Right now we have a single kustomize package which defines the reusable
    elements which are Tekton Tasks and Pipeline resources

    * Right now we have a single Pipeline for all applications but in the future
      we might have application specific pipelines

* rebuild_manifests.sh should use the image tag v0.x.y-${commit} rather
      than the digest.

   * This image tagging scheme will be the basis for determining whether
     the image is already up to date (kubeflow/testing#545)

   * since we now specify the full image_url rather than using image name
     we need a parameter for the src_image that is used with the kustomize
     edit function.

* Use a separate task for updating the manifests

  * Now that we are using image tags of the form "{TAG}-{COMMIT}" which
    is determined at pipeline construction time; we no longer
    need to pass the digest file between the build-push step and the
    update manifests task which makes it much easier to run
    them as separate task since we don't need a pod volume to share data.

Related to kubeflow/testing#450 - CD pipelines for Kubeflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/551)
<!-- Reviewable:end -->
