### PR TITLE
Create a Kubernetes deployment to continuously run update_kf_apps for CD

### DIFF
--- a/apps-cd/Dockerfile
+++ b/apps-cd/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -y && \
+    apt-get install -y curl git python3.8 python3-pip && \
+    ln -sf /usr/bin/python3.8 /usr/bin/python
+
+# Install the hub CLI for git
+RUN cd /tmp && \
+    curl -LO  https://github.com/github/hub/releases/download/v2.13.0/hub-linux-amd64-2.13.0.tgz && \
+    tar -xvf hub-linux-amd64-2.13.0.tgz && \
+    mv hub-linux-amd64-2.13.0 /usr/local && \
+    ln -sf /usr/local/hub-linux-amd64-2.13.0/bin/hub /usr/local/bin/hub
+
+RUN python -m pip install fire \
+     google-api-python-client \
+     google-cloud-storage \
+     kubernetes \
+     watchdog
+
+RUN mkdir -p /app
+COPY update_launcher.py /app
+COPY run_with_auto_restart.py /app

--- a/apps-cd/README.md
+++ b/apps-cd/README.md
@@ -43,6 +43,14 @@ and open PRs to update Kubeflow kustomize manifests to use the newly built image
 
  * The kubeflow-bot GitHub account is used to create the PRs
 
+ * Continuous building is achieved by running `update_launcher.py` in a Kubernetes deployment
+
+   * This script periodically fetches the latest code in `kubeflow/testing` to pick up any changes
+     to the code or config
+
+   * It then launches `update_kf_apps.py` to create Tekton PipelineRuns for any applications that
+     need to be updated.
+
 ### Adding Applications to continuous delivery
 
 Here are instructions for adding an application for continous delivery
@@ -139,6 +147,39 @@ This is a Kubeflow cluster (v0.6.2) and we rely on that to configure certain thi
    ```
    kustomize build pipelines/base/ | kubectl apply -f -
    ```
+
+## Developer Guide
+
+You can use skaffold to build a docker image and auto update the deployment running `update_launcher.py`
+
+1. Run skaffold
+
+   ```
+   skaffold dev -v info --cleanup=false --trigger=polling
+   ```
+
+1. During development you can take advantage of skaffold's continuous file sync mode to update
+   the code `update_launcher.py` without rebuilding the docker image or updating the deployment
+
+   * To take advantage of this modify `base/deployment.yaml` and uncomment the lines
+
+     ```
+     - python
+     - run_with_auto_restart.py
+     - --dir=/app
+     ```
+
+   * This runs update_launcher.py in a subprocess and restarts it everytime it detects a change in the file
+
+## Deploying Or Updating the Continuous run
+
+Use skaffold 
+
+```
+skaffold run --cleanup=False
+```
+
+* TODO(jlewi): Do we need to set cleanup to false.
 
 ## References
 

--- a/apps-cd/applications.yaml
+++ b/apps-cd/applications.yaml
@@ -31,7 +31,7 @@ applications:
     - name: "path_to_context"
       value: "components/access-management"
     - name: "path_to_docker_file"
-      value: "components/acess-management/Dockerfile"
+      value: "components/access-management/Dockerfile"
     - name: "path_to_manifests_dir"
       value: "profiles/base"
     - name: "src_image_url"

--- a/apps-cd/pipelines/base/deployment.yaml
+++ b/apps-cd/pipelines/base/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server
+spec:
+  # We only need and want a single replica.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: update-kfapps
+  template:
+    metadata:
+      labels:
+        app: update-kfapps
+    spec:
+      containers:
+      - name: app
+        image: gcr.io/kubeflow-releasing/update_kf_apps
+        command:
+        # Uncomment the following lines when running with skaffold 
+        # and you want to use skaffold's auto-sync feature wto pick up changes
+        # to update_launcher.
+        # Begin skaffold
+        - python
+        - run_with_auto_restart.py
+        - --dir=/app
+        - --
+        # End skaffold
+        #
+        - python
+        - update_launcher.py
+        - run
+        # repo_dir is the directory where kubeflow testing should be checked out to
+        - --repo_dir=/launcher_src/kubeflow/testing
+        - --repo=https://github.com/kubeflow/testing.git
+        # Extra arguments to be passed to update_kf_apps.py
+        - --namespace=kf-releasing 
+        - --config=/launcher_src/kubeflow/testing/apps-cd/applications.yaml 
+        - --output_dir=/tmp/runs 
+        - --src_dir=/src 
+        - --template=/launcher_src/kubeflow/testing/apps-cd/runs/app-pipeline.template.yaml 
+        env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-token
+              key: github_token
+        resources:
+          requests:
+            cpu: 4
+            memory: 8Gi
+        workingDir: /app

--- a/apps-cd/pipelines/base/kustomization.yaml
+++ b/apps-cd/pipelines/base/kustomization.yaml
@@ -1,7 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+images:
+- name: gcr.io/kubeflow-releasing/update_kf_apps
+  newName: gcr.io/kubeflow-releasing/update_kf_apps
 resources:
 - service-account.yaml
+- deployment.yaml
 - role-binding.yaml
 - task.yaml
 - pipeline.yaml

--- a/apps-cd/run_with_auto_restart.py
+++ b/apps-cd/run_with_auto_restart.py
@@ -1,0 +1,82 @@
+"""Run a program in a subprocess. Automatically restart it when a file changes.
+
+This is a simple program that will launch another program in a subprocess
+and restart that program if any files are detected as changed.
+
+
+The primary use for this is with skaffold. Skaffold will automatically sync
+files to the container; but we need to restart the program in order to pick
+up those changes.
+
+Example usage
+run_with_auto_restart.py --directory=/src/dir1 --directory=/src/dir2 -- /program/to/run --arg1=b
+"""
+import argparse
+import subprocess
+import time
+import logging
+from watchdog.observers import Observer
+from watchdog.events import LoggingEventHandler
+
+class RestartEventHandler(LoggingEventHandler):
+  def __init__(self, command):
+    """Create the handler.
+
+    Args:
+      command: The command to run.
+    """
+    super(RestartEventHandler, self).__init__()
+    self._command = command
+    self._p = None
+    self.restart()
+
+  def restart(self):
+    if self._p:
+      logging.info("Terminating the current process")
+      self._p.terminate()
+
+
+    logging.info(f"Starting a proces to run command: {' '.join(self._command)}")
+    self._p = subprocess.Popen(self._command)
+
+  def on_any_event(self, event):
+    super().on_any_event(event)
+    self.restart()
+
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s - %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S')
+
+  parser = argparse.ArgumentParser(description="Run and auto restart.")
+  parser.add_argument('--directory', dest="directories",
+                        action="append",
+                        help="A directory to watch for changes.")
+
+  args, unparsed = parser.parse_known_args()
+
+  # Remove "--" as an argument
+  while True:
+    if unparsed[0].strip() == "--":
+      del unparsed[0]
+      continue
+    break
+
+  event_handler = RestartEventHandler(unparsed)
+  observer = Observer()
+  for d in args.directories:
+    logging.info(f"Watching {d}")
+    observer.schedule(event_handler, d, recursive=True)
+  observer.start()
+  try:
+    while True:
+      if event_handler._p:
+        if event_handler._p.poll() is not None:
+          # TODO(jlewi): would it be better to exit to force a container restart
+          logging.info("Process has terminated restarting it")
+          event_handler.restart()
+      time.sleep(1)
+  except KeyboardInterrupt:
+    observer.stop()
+  observer.join()
+

--- a/apps-cd/skaffold.yaml
+++ b/apps-cd/skaffold.yaml
@@ -1,0 +1,48 @@
+# Reference: https://skaffold.dev/docs/references/yaml/
+apiVersion: skaffold/v2alpha1
+kind: Config
+metadata:
+  name: label-microservice
+build:
+  artifacts:
+  - image: gcr.io/kubeflow-releasing/update_kf_apps
+    # Set the context to the root directory. 
+    # All paths in the Dockerfile should be relative to this one.
+    context: .
+    # Automatically sync python files to the container. This should avoid
+    # the need to rebuild and redeploy when the files change.
+    # TODO(https://github.com/GoogleContainerTools/skaffold/issues/3448): We use manual sync
+    # because inferred sync doesn't work
+    #
+    # This only works if we autorestart the program on changes.
+    #
+    # Important: Make sure you current context has the namespace
+    # set to the namespace where your pods are deployed otherwise
+    # the sync doesn't appear to work.
+    sync:
+        manual:
+        - src: 'update_launcher.py'
+          dest: '/app'
+    kaniko:
+      dockerfile: Dockerfile
+      buildContext:
+        gcsBucket: kubeflow-releasing_skaffold
+      env: 
+        # TODO(GoogleContainerTools/skaffold#3468) skaffold doesn't
+        # appear to work with workload identity
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /secret/user-gcp-sa.json
+      cache: {}
+  cluster:    
+    pullSecretName: user-gcp-sa
+    # Build in a namespace with ISTIO sidecar injection disabled
+    # see  GoogleContainerTools/skaffold#3442
+    namespace: kf-releasing
+    resources:
+      requests:
+        cpu: 8
+        memory: 16Gi
+
+deploy:
+  kustomize:
+    path: pipelines/base

--- a/apps-cd/update_launcher.py
+++ b/apps-cd/update_launcher.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+
+"""A program to continuously launch Tekton pipelines.
+
+This is a simple script to run update_kf_apps.py. The script does the following
+
+1. Fetch the latest code from GitHub
+2. Run update_kf_apps.py to submit Tekton PipelineRuns to update any apps
+   that need it.
+3. Sleep
+4. Go back to step 1.
+
+
+The reason for not calling update_kf_apps.py directly is that we want to
+run a git sync to pick up the latest code.
+
+The reason the code is not in py is because we don't want this script to
+have any dependencies on the code in py since its just intended to be a
+simple shell script
+"""
+import fire
+import logging
+import os
+import subprocess
+import time
+from urllib import parse
+
+DEFAULT_REPO = "https://github.com/kubeflow/testing.git"
+
+class Launcher:
+  @staticmethod
+  def run(repo=DEFAULT_REPO, repo_dir= "/app/src/kubeflow/testing",
+          sync_time_seconds=600, **update_args):
+    """Run the program.
+
+    Args:
+    repo: Git URL to fetch the code. This should be a kubeflow/testing repo
+      (or fork) and container the update_kf_apps.py code as well as the
+      configs used with update_kf_appss.py. To specify a particular branch
+      add a query arg "?ref=<branch_name>
+    app_src_dir: Directory where repo should be checked out.
+    sync_time_seconds: Time in seconds to wait between launches.
+    update_args: Arguments for update_kf_apps
+    """
+
+    parent_dir = os.path.dirname(repo_dir)
+    if not os.path.exists(parent_dir):
+      os.makedirs(parent_dir)
+
+    # Parse out the query args to look for a branch
+    p = parse.urlparse(repo)
+    query = p.query
+
+    repo_url = p._replace(query="").geturl()
+
+    ref = "master"
+    if query:
+      logging.info(f"URL has query string {query}")
+      q = parse.parse_qs(p.query)
+      logging.info(f"Parsed query {q}")
+      if "ref" in q:
+        ref = q["ref"][-1]
+
+    logging.info(f"Using ref {ref}")
+    while True:
+      if not os.path.exists(repo_dir):
+        logging.info(f"Cloning {repo}")
+        subprocess.check_call(["git", "clone", repo_url, repo_dir])
+      logging.info(f"Fetching latest code")
+      subprocess.check_call(["git", "fetch", "origin"], cwd=repo_dir)
+
+      logging.info(f"Checking out origin/{ref}")
+      subprocess.check_call(["git", "checkout", f"origin/{ref}"], cwd=repo_dir)
+
+      commit = subprocess.check_output(["git", "describe", "--tags",
+                                        "--always", "--dirty"], cwd=repo_dir)
+
+      logging.info(f"using update_kf_apps.py from {p.geturl()} "
+                   f"at commit: {commit}")
+
+      logging.info("Launching update_kf_apps")
+
+      command = ["python", "-m", "kubeflow.testing.cd.update_kf_apps", "apply"]
+
+      extra = [f"--{k}={v}" for k,v in update_args.items()]
+      command.extend(extra)
+      py_dir = os.path.join(repo_dir, "py")
+      subprocess.check_call(command, cwd=py_dir)
+
+      logging.info("Wait before rerunning")
+      time.sleep(sync_time_seconds)
+
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(pathname)s|%(lineno)d| %(message)s'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+  logging.getLogger().setLevel(logging.INFO)
+  fire.Fire(Launcher)


### PR DESCRIPTION
* Run update_kf_apps.py continuously in a K8s deployment so that
  Tekton pipelineruns are continuously created as needed.

* The server uses update_launcher.py to update a clone of kubeflow/testing
  before calling update_kf_apps.py. This way it picks up the latest code
  and config before running update_kf_apps.py

* Create a skaffold config for running the launcher to create the CD pipelines.

  * Useful for debugging and deployment.

Related to #450 continuous updating of Kubeflow applications.

Related to #533 Trigger tekton workflows periodically and in response to GitHub events

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/564)
<!-- Reviewable:end -->
