### PR TITLE
Fix context for notebook-controller.

### DIFF
--- a/apps-cd/applications.yaml
+++ b/apps-cd/applications.yaml
@@ -40,7 +40,7 @@ applications:
   - name: notebook-controller
     params:  
     - name: "path_to_context"
-      value: "components/notebook-controller"
+      value: "components"
     - name: "path_to_docker_file"
       value: "components/notebook-controller/Dockerfile"
     - name: "path_to_manifests_dir"


### PR DESCRIPTION
* Context should be the components directory see

Related to kubeflow/kubeflow#4582

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/567)
<!-- Reviewable:end -->
