### PR TITLE
Revert "Fix cleanup logic for IAM policy bindings (#566)"

### DIFF
--- a/py/kubeflow/testing/cleanup_ci_test.py
+++ b/py/kubeflow/testing/cleanup_ci_test.py
@@ -1,5 +1,4 @@
 from kubeflow.testing import cleanup_ci
-import collections
 import logging
 import pytest
 
@@ -16,21 +15,6 @@ def test_match_endpoints():
 def test_match_disk():
   pvc = "gke-zresubmit-unittest-pvc-e3bf5be4-987b-11e9-8266-42010a8e00e9"
   assert cleanup_ci.is_match(pvc, patterns=cleanup_ci.E2E_PATTERNS)
-
-
-def test_match_service_accounts():
-  test_case = collections.namedtuple("test_case", ("input", "expected"))
-
-  cases = [
-    test_case("kf-vmaster-0121-b11-user@"
-              "kubeflow-ci-deployment.iam.gserviceaccount.com",
-              cleanup_ci.AUTO_INFRA)
-  ]
-
-  for c in cases:
-    actual = cleanup_ci.name_to_infra_type(c.input)
-
-    assert actual == c.expected
 
 if __name__ == "__main__":
   logging.basicConfig(


### PR DESCRIPTION
This reverts commit 4ebe57134446afe6aa5bbd33494d91831035a30f.

The list of service accounts only includes service accounts owned by the
project. So we ended up deleting bindings for service accounts owned by
other projects such as the service accounts.

related to: #566

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/568)
<!-- Reviewable:end -->
