### PR TITLE
Fix cleanup logic for IAM policy bindings.

### DIFF
--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -1,6 +1,7 @@
 """Cleanup Kubeflow deployments in our ci system."""
 # pylint: disable=too-many-lines
 import argparse
+import collections
 import datetime
 from dateutil import parser as date_parser
 import logging
@@ -67,6 +68,31 @@ def is_match(name, patterns=None):
       return True
 
   return False
+
+SERVICE_ACCOUNT = collections.namedtuple("SERVICE_ACCOUNT",
+                                         ("name", "project", "suffix"))
+def parse_service_account_email(email):
+  """Take a string of the form serviceAccount:name@project.suffix
+
+  And returns a tuple with the various pieces
+  """
+  prefix = "serviceAccount:"
+
+  if not prefix in email:
+    return None
+
+  _, just_email = email.split(":", 1)
+
+  name, project_and_suffix = just_email.split("@", 1)
+
+  project, suffix = project_and_suffix.split(".", 1)
+
+  return SERVICE_ACCOUNT(name, project, suffix)
+
+def full_email(service_account):
+  """Generate the full email from service account"""
+  return "{0}@{1}.{2}".format(service_account.name, service_account.project,
+                              service_account.suffix)
 
 def is_retryable_exception(exception):
   """Return True if we consider the exception retryable"""
@@ -757,20 +783,54 @@ def cleanup_service_accounts(args):
   logging.info("expired emails:\n%s", "\n".join(expired_emails))
   logging.info("Finished cleanup service accounts")
 
-def trim_unused_bindings(iamPolicy, accounts):
+def trim_unused_bindings(iamPolicy, accounts, project):
+  """Trim unused bindings
+
+  Args:
+    iamPolicy:The iam policy from which to trim accounts
+    accounts: The list of service accounts that still exist
+    project: The project that owns the service accounts listed in service
+      accounts. Bindings associated with service accounts not owned by
+      this project are not eligible for deletion.
+  """
   keepBindings = []
+  kept_bindings = set()
+  deleted_bindings = set()
   for binding in iamPolicy['bindings']:
     members_to_keep = []
     members_to_delete = []
     for member in binding['members']:
-      if not member.startswith('serviceAccount:'):
+      # Parse the binding
+      service_account = parse_service_account_email(member)
+
+      if not service_account:
         members_to_keep.append(member)
-      else:
-        accountEmail = member[15:]
-        if (not is_match(accountEmail)) or (accountEmail in accounts):
-          members_to_keep.append(member)
-        else:
-          members_to_delete.append(member)
+        kept_bindings.add(member)
+        continue
+
+      # Accounts will only be for the service accounts owned by the
+      # project. So we can only delete a service account binding if it
+      # is associated with a service account that would be owned by
+      # that project; otherwise that service account wouldn't be listed
+      # in the set of service accounts
+      if service_account.project != project:
+        members_to_keep.append(member)
+        kept_bindings.add(member)
+        continue
+
+      if service_account.suffix != "iam.gserviceaccount.com":
+        members_to_keep.append(member)
+        kept_bindings.add(member)
+        continue
+
+      if full_email(service_account) in accounts:
+        members_to_keep.append(member)
+        kept_bindings.add(member)
+        continue
+
+      members_to_delete.append(member)
+      deleted_bindings.add(member)
+
     if members_to_keep:
       binding['members'] = members_to_keep
       keepBindings.append(binding)
@@ -778,6 +838,11 @@ def trim_unused_bindings(iamPolicy, accounts):
       logging.info("Delete binding for members:\n%s", "\n".join(
         members_to_delete))
   iamPolicy['bindings'] = keepBindings
+
+  logging.info("Removing bindings for following service accounts which "
+               "do not exist:\n%s", "\n".join(deleted_bindings))
+  logging.info("Keeping bindings for following service accounts which "
+               "still exist:\n%s", "\n".join(kept_bindings))
 
 def cleanup_service_account_bindings(args):
   logging.info("Cleanup service account bindings")
@@ -798,7 +863,7 @@ def cleanup_service_account_bindings(args):
   resourcemanager = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
   logging.info("Get IAM policy for project %s", args.project)
   iamPolicy = resourcemanager.projects().getIamPolicy(resource=args.project, body={}).execute()
-  trim_unused_bindings(iamPolicy, accounts)
+  trim_unused_bindings(iamPolicy, accounts, args.project)
 
   setBody = {'policy': iamPolicy}
   if not args.dryrun:

--- a/py/kubeflow/testing/cleanup_ci.py
+++ b/py/kubeflow/testing/cleanup_ci.py
@@ -11,6 +11,7 @@ import socket
 import sys
 import traceback
 import time
+import yaml
 
 from kubeflow.testing import argo_client
 from kubeflow.testing import util
@@ -868,7 +869,9 @@ def cleanup_service_account_bindings(args):
   setBody = {'policy': iamPolicy}
   if not args.dryrun:
     resourcemanager.projects().setIamPolicy(resource=args.project, body=setBody).execute()
-
+  else:
+    logging.info("Dryrun mode; policy not set; would set to policy;\n%s",
+                 yaml.safe_dump(iamPolicy))
   logging.info("Finished cleanup service account bindings")
 
 def getAge(tsInRFC3339):

--- a/py/kubeflow/testing/cleanup_ci_test.py
+++ b/py/kubeflow/testing/cleanup_ci_test.py
@@ -1,6 +1,8 @@
 from kubeflow.testing import cleanup_ci
 import logging
+import os
 import pytest
+import yaml
 
 def test_match_endpoints():
   """Verify that cloud endpoint service names match the regex"""
@@ -16,6 +18,65 @@ def test_match_disk():
   pvc = "gke-zresubmit-unittest-pvc-e3bf5be4-987b-11e9-8266-42010a8e00e9"
   assert cleanup_ci.is_match(pvc, patterns=cleanup_ci.E2E_PATTERNS)
 
+def test_match_service_accounts():
+  test_case = collections.namedtuple("test_case", ("input", "expected"))
+
+  cases = [
+    test_case("kf-vmaster-0121-b11-user@"
+              "kubeflow-ci-deployment.iam.gserviceaccount.com",
+              cleanup_ci.AUTO_INFRA)
+  ]
+
+  for c in cases:
+    actual = cleanup_ci.name_to_infra_type(c.input)
+
+    assert actual == c.expected
+
+def test_parse_service_account():
+  test_case = collections.namedtuple("test_case", ("input", "expected"))
+
+  cases = [
+    test_case("serviceAccount:kf-vmaster@"
+              "kubeflow-ci-deployment.iam.gserviceaccount.com",
+              cleanup_ci.SERVICE_ACCOUNT("kf-vmaster", "kubeflow-ci-deployment",
+                                         "iam.gserviceaccount.com")),
+    test_case("serviceAccount:kf-vmaster@"
+              "container-engine-robot.iam.gserviceaccount.com",
+              cleanup_ci.SERVICE_ACCOUNT("kf-vmaster", "container-engine-robot",
+                                         "iam.gserviceaccount.com")),
+    # No match because prefix isn't a serviceAccount
+    test_case("user:kf-vmaster@"
+              "container-engine-robot.iam.gserviceaccount.com",
+              None),
+  ]
+
+  for c in cases:
+    actual = cleanup_ci.parse_service_account_email(c.input)
+
+    assert actual == c.expected
+
+
+def test_trim_unused_bindings():
+  this_dir = os.path.dirname(__file__)
+  test_data_dir = os.path.join(this_dir, "test_data")
+  with open(os.path.join(test_data_dir, "trim_bindings.input.yaml")) as hf:
+    policy = yaml.load(hf)
+
+  accounts = ["existsaccount@someproject.iam.gserviceaccount.com"]
+
+  expected = set([
+    "serviceAccount:existsaccount@someproject.iam.gserviceaccount.com",
+    "serviceAccount:user2@nothisproject.iam.gserviceaccount.com",
+    "serviceAccount:gcp@cloudbuild.gserviceaccount.com",
+    "serviceAccount:kubeflow-releasing@kubeflow-releasing"
+    ".iam.gserviceaccount.com"])
+
+  project = "someproject"
+  cleanup_ci.trim_unused_bindings(policy, accounts, project)
+
+  actual_bindings = set(policy["bindings"][0]["members"])
+  assert actual_bindings == expected
+
 if __name__ == "__main__":
   logging.basicConfig(
       level=logging.INFO,
@@ -24,4 +85,5 @@ if __name__ == "__main__":
     datefmt='%Y-%m-%dT%H:%M:%S',
     )
   logging.getLogger().setLevel(logging.INFO)
-  pytest.main()
+  test_trim_unused_bindings()
+  #pytest.main()

--- a/py/kubeflow/testing/cleanup_ci_test.py
+++ b/py/kubeflow/testing/cleanup_ci_test.py
@@ -85,5 +85,4 @@ if __name__ == "__main__":
     datefmt='%Y-%m-%dT%H:%M:%S',
     )
   logging.getLogger().setLevel(logging.INFO)
-  test_trim_unused_bindings()
-  #pytest.main()
+  pytest.main()

--- a/py/kubeflow/testing/cleanup_ci_test.py
+++ b/py/kubeflow/testing/cleanup_ci_test.py
@@ -1,8 +1,10 @@
-from kubeflow.testing import cleanup_ci
+import collections
 import logging
 import os
 import pytest
 import yaml
+
+from kubeflow.testing import cleanup_ci
 
 def test_match_endpoints():
   """Verify that cloud endpoint service names match the regex"""

--- a/py/kubeflow/testing/test_data/trim_bindings.input.yaml
+++ b/py/kubeflow/testing/test_data/trim_bindings.input.yaml
@@ -1,0 +1,8 @@
+bindings:
+- members:
+  - serviceAccount:deletedaccount@someproject.iam.gserviceaccount.com
+  - serviceAccount:existsaccount@someproject.iam.gserviceaccount.com
+  - serviceAccount:user2@nothisproject.iam.gserviceaccount.com
+  - serviceAccount:gcp@cloudbuild.gserviceaccount.com
+  - serviceAccount:kubeflow-releasing@kubeflow-releasing.iam.gserviceaccount.com
+  role: roles/cloudbuild.builds.builder

--- a/py/kubeflow/tests/cleanup_ci_test.py
+++ b/py/kubeflow/tests/cleanup_ci_test.py
@@ -20,7 +20,8 @@ class CleanupCiTest(unittest.TestCase):
                   'kfctl-expired@kubeflow-ci.iam.gserviceaccount.com']:
         self.assertTrue('serviceAccount:' + act in members)
       cleanup_ci.trim_unused_bindings(iam_bindings,
-                                      ['kfctl-in-use@kubeflow-ci.iam.gserviceaccount.com'])
+                                      ['kfctl-in-use@kubeflow-ci.iam.gserviceaccount.com'],
+                                      "kubeflow-ci")
       # One binding is deleted as it lost all members.
       self.assertTrue(len(iam_bindings['bindings']) == 2)
       trimed_members = iam_bindings['bindings'][0]['members']

--- a/test-infra/cleanup-kubeflow-ci-deployment.yaml
+++ b/test-infra/cleanup-kubeflow-ci-deployment.yaml
@@ -24,8 +24,8 @@ spec:
         - /bin/sh
         - -xc
         # TODO(jlewi): Switch to using init container to check things out
-        - /usr/local/bin/checkout_repos.sh --repos=kubeflow/kubeflow@HEAD,kubeflow/testing@HEAD:512 --src_dir=/src; python -m kubeflow.testing.cleanup_ci --project=kubeflow-ci-deployment
-          --gc_backend_services=true --dryrun all 
+        - /usr/local/bin/checkout_repos.sh --repos=kubeflow/kubeflow@HEAD,kubeflow/testing@HEAD:566 --src_dir=/src; python -m kubeflow.testing.cleanup_ci --project=kubeflow-ci-deployment
+          --gc_backend_services=true --dryrun service_account_bindings
         env:
         - name: PYTHONPATH
           value: /src/kubeflow/testing/py

--- a/test-infra/cleanup-kubeflow-ci-deployment.yaml
+++ b/test-infra/cleanup-kubeflow-ci-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - /bin/sh
         - -xc
         # TODO(jlewi): Switch to using init container to check things out
-        - /usr/local/bin/checkout_repos.sh --repos=kubeflow/kubeflow@HEAD,kubeflow/testing@HEAD:566 --src_dir=/src; python -m kubeflow.testing.cleanup_ci --project=kubeflow-ci-deployment
+        - /usr/local/bin/checkout_repos.sh --repos=kubeflow/kubeflow@HEAD,kubeflow/testing@HEAD:570 --src_dir=/src; python -m kubeflow.testing.cleanup_ci --project=kubeflow-ci-deployment
           --gc_backend_services=true --dryrun service_account_bindings
         env:
         - name: PYTHONPATH


### PR DESCRIPTION
* We want to cleanup bindings for service accounts that don't exist
  as a way to GC any bindings that might otherwise accumulate.

* However, we only want to GC bindings for service accounts that are
  owned by that project because only those service accounts will be listed
  as service accounts for that project

  e.g. in the project kubeflow-ci-deployment; we should only delete bindings
  for the service accounts
  ${NAME}@kubeflow-ci-deployment.iam.gserviceaccount.com

  Any other bindings should be preserved.

* related to: #566

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/570)
<!-- Reviewable:end -->
