### PR TITLE
Add TFJob and PyTorch controller to the list of applications for CD.

### DIFF
--- a/apps-cd/applications.yaml
+++ b/apps-cd/applications.yaml
@@ -73,6 +73,30 @@ applications:
       value: "gcr.io/kubeflow-images-public/profile-controller"
     # The name of the repo containing the source
     sourceRepo: kubeflow
+  - name: pytorch-operator
+    params:  
+    - name: "path_to_context"
+      value: ""
+    - name: "path_to_docker_file"
+      value: "Dockerfile"
+    - name: "path_to_manifests_dir"
+      value: "pytorch-job/pytorch-operator/base"
+    - name: "src_image_url"
+      value: "gcr.io/kubeflow-images-public/pytorch-operator"
+    # The name of the repo containing the source
+    sourceRepo: pytorch-operator
+  - name: tf-operator
+    params:  
+    - name: "path_to_context"
+      value: ""
+    - name: "path_to_docker_file"
+      value: "build/images/tf_operator/Dockerfile"
+    - name: "path_to_manifests_dir"
+      value: "tf-training/tf-job-operator/base"
+    - name: "src_image_url"
+      value: "gcr.io/kubeflow-images-public/tf_operator"
+    # The name of the repo containing the source
+    sourceRepo: tf-operator
 # The versions to build the applications at
 # Each version should consist of a list of repositories and the corresponding
 # branch and a tag
@@ -98,6 +122,22 @@ versions:
               value: master
             - name: url
               value: git@github.com:kubeflow/manifests.git
+      - name: pytorch-operator
+        resourceSpec:    
+          type: git
+          params:
+            - name: revision
+              value: master
+            - name: url
+              value: git@github.com:kubeflow/pytorch-operator.git
+      - name: tf-operator
+        resourceSpec:    
+          type: git
+          params:
+            - name: revision
+              value: master
+            - name: url
+              value: git@github.com:kubeflow/tf-operator.git
   # Define a v1-0 release
   - name: v1-0
     # A tag to prefix image names with
@@ -119,3 +159,19 @@ versions:
               value: v1.0-branch
             - name: url
               value: git@github.com:kubeflow/manifests.git
+      - name: pytorch-operator
+        resourceSpec:    
+          type: git
+          params:
+            - name: revision
+              value: v1.1-branch
+            - name: url
+              value: git@github.com:kubeflow/pytorch-operator.git
+      - name: tf-operator
+        resourceSpec:    
+          type: git
+          params:
+            - name: revision
+              value: v1.1-branch
+            - name: url
+              value: git@github.com:kubeflow/tf-operator.git

--- a/apps-cd/pipelines/base/config/app-pipeline.template.yaml
+++ b/apps-cd/pipelines/base/config/app-pipeline.template.yaml
@@ -21,7 +21,7 @@ spec:
     value: "gcr.io/kubeflow-releasing/update_kf_apps:d4b8243@sha256:656a4ad689b17715a287f09772cc48444a2190c353c5b84828db4fbf4ede4acc"
   resources:
   # The git resources that will be used
-  - name: kubeflow
+  - name: app-repo
     resourceSpec:    
       type: git
       params:

--- a/apps-cd/pipelines/base/pipeline.yaml
+++ b/apps-cd/pipelines/base/pipeline.yaml
@@ -30,10 +30,10 @@ spec:
     default: ""
   resources:
   # Pipeline has 3 git resources
-  # kubeflow - Repository containing the source code for the docke rimages to build
+  # app-repo - Repository containing the source code for the application repository
   # manifests - Repostory containing the manifests to update
   # ci-tools - Repository containing tools used in the CI/CD pipeline  
-  - name: kubeflow
+  - name: app-repo
     type: git
   - name: manifests
     type: git
@@ -54,8 +54,8 @@ spec:
       value: "$(params.path_to_docker_file)"
     resources:
       inputs:
-      - name: kubeflow
-        resource: kubeflow
+      - name: app-repo
+        resource: app-repo
       - name: image
         resource: image
     taskRef:
@@ -75,8 +75,8 @@ spec:
       inputs:
       - name: manifests
         resource: manifests
-      - name: kubeflow
-        resource: kubeflow        
+      - name: app-repo
+        resource: app-repo        
       - name: ci-tools
         resource: ci-tools
       - name: image

--- a/apps-cd/pipelines/base/task.yaml
+++ b/apps-cd/pipelines/base/task.yaml
@@ -21,7 +21,7 @@ spec:
       name: path_to_docker_file
       type: string
     resources:
-    - name: kubeflow
+    - name: app-repo
       type: git
     - name: image
       type: image  
@@ -30,10 +30,10 @@ spec:
     image: gcr.io/kaniko-project/executor:v0.11.0
     command:
     - /kaniko/executor
-    - --dockerfile=/workspace/$(inputs.resources.kubeflow.name)/$(inputs.params.path_to_docker_file)
+    - --dockerfile=/workspace/$(inputs.resources.app-repo.name)/$(inputs.params.path_to_docker_file)
     - --target=$(inputs.params.docker_target)
     - --destination=$(inputs.resources.image.url)
-    - --context=/workspace/$(inputs.resources.kubeflow.name)/$(inputs.params.path_to_context)
+    - --context=/workspace/$(inputs.resources.app-repo.name)/$(inputs.params.path_to_context)
     - --digest-file=/workspace/image-digest    
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -75,8 +75,8 @@ spec:
     resources:
     - name: manifests
       type: git
-    # We include the kubeflow repo just to get the commit at which the image is built.
-    - name: kubeflow
+    # We include the app-repo just to get the commit at which the image is built.
+    - name: app-repo
       type: git
     - name: ci-tools
       type: git

--- a/apps-cd/pipelines/overlays/dev/deployment.yaml
+++ b/apps-cd/pipelines/overlays/dev/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         # e.g. 
         # Extra arguments to be passed to update_kf_apps.py
         - --namespace=kf-releasing-dev
-        - --config=https://raw.githubusercontent.com/jlewi/testing/cicd_delete_old_prs/apps-cd/applications.yaml
+        - --config=https://raw.githubusercontent.com/jlewi/testing/cicd_operators/apps-cd/applications.yaml
         - --output_dir=/tmp/runs 
         - --src_dir=/src 
         - --template=/app/config/app-pipeline.template.yaml

--- a/py/kubeflow/testing/cd/test_data/notebook_controller.expected.yaml
+++ b/py/kubeflow/testing/cd/test_data/notebook_controller.expected.yaml
@@ -3,10 +3,14 @@ kind: PipelineRun
 metadata:
   # Generate a unique name for each run
   generateName: cd-notebook-controller-1234abcd
+  labels:
+    app: notebook-controller
+    image_tag: vmaster-g1234abcd
+    version: v1
 spec:
   pipelineRef:
     name: ci-pipeline
-  params:  
+  params:
   - name: "path_to_context"
     value: "components/notebook-controller"
   - name: "path_to_docker_file"
@@ -16,11 +20,11 @@ spec:
   - name: "src_image_url"
     value: "gcr.io/kubeflow-images-public/notebook-controller"
   - name: "container_image"
-    value: "gcr.io/kubeflow-releasing/test-worker@sha256:35138a42b57160a078e802b7d69aec3c3e79a3e2e55518af7798275ebcc84d25"    
+    value: "gcr.io/kubeflow-releasing/update_kf_apps:d4b8243@sha256:656a4ad689b17715a287f09772cc48444a2190c353c5b84828db4fbf4ede4acc"
   resources:
   # The git resources that will be used
-  - name: kubeflow
-    resourceSpec:    
+  - name: app-repo
+    resourceSpec:
       type: git
       params:
         - name: revision
@@ -28,20 +32,20 @@ spec:
         - name: url
           value: git@github.com:kubeflow/kubeflow.git
   - name: manifests
-    resourceSpec:    
+    resourceSpec:
       type: git
       params:
         - name: revision
-          value: master
+          value: v1.0-branch
         - name: url
           value: git@github.com:kubeflow/manifests.git
   # TODO(jlewi): Replace with kubeflw/kubeflow once the PR is checked in.
   - name: ci-tools
-    resourceSpec:    
+    resourceSpec:
       type: git
       params:
         - name: revision
-          value: tekton
+          value: cicd_delete_old_prs
         - name: url
           value: git@github.com:jlewi/testing.git
   # The image we want to build
@@ -49,6 +53,6 @@ spec:
     resourceSpec:
       type: image
       params:
-      - name: url  
+      - name: url
         value: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g1234abcd
   serviceAccountName: ci-pipeline-run-service-account

--- a/py/kubeflow/testing/cd/update_kf_apps_test.py
+++ b/py/kubeflow/testing/cd/update_kf_apps_test.py
@@ -12,7 +12,8 @@ import pytest
 def test_build_run():
   this_dir = os.path.dirname(__file__)
   template_file = os.path.abspath(os.path.join(this_dir, "..", "..", "..", "..",
-                                               "apps-cd", "runs",
+                                               "apps-cd", "pipelines", "base",
+                                               "config",
                                                "app-pipeline.template.yaml"))
 
   with open(template_file) as hf:
@@ -35,7 +36,7 @@ sourceRepo: kubeflow
 
   app = yaml.load(app_spec)
   version_spec = """
-name: master
+name: v1
 # A tag to prefix image names with
 tag: vmaster
 repos:
@@ -52,9 +53,17 @@ repos:
       type: git
       params:
         - name: revision
-          value: master
+          value: v1.0-branch
         - name: url
           value: git@github.com:kubeflow/manifests.git
+  - name: tf-operator
+    resourceSpec:
+      type: git
+      params:
+        - name: revision
+          value: master
+        - name: url
+          value: git@github.com:kubeflow/tf-operator.git
 """
   version = yaml.load(version_spec)
   commit = "1234abcd"

--- a/py/kubeflow/testing/kf_logging.py
+++ b/py/kubeflow/testing/kf_logging.py
@@ -1,0 +1,38 @@
+import datetime
+import logging
+import json
+import pytz
+
+import json_log_formatter
+
+# TODO(jlewi): Might be better to just write it
+# as a json list
+def write_items_to_json(output_file, results):
+  with open(output_file, "w") as hf:
+    for i in results:
+      json.dump(i, hf)
+      hf.write("\n")
+  logging.info("Wrote %s items to %s", len(results), output_file)
+
+
+pacific = pytz.timezone("US/Pacific")
+
+def now():
+  """Return the current time with timezone information."""
+  # see https://julien.danjou.info/python-and-timezones/
+  # Need to attach a time zone
+  return datetime.datetime.now(tz=pacific)
+
+class CustomisedJSONFormatter(json_log_formatter.JSONFormatter):
+  """A custom formatter to produce logs in json format."""
+  def json_record(self, message, extra, record):
+    extra['message'] = message
+
+    extra["filename"] = record.pathname
+    extra["line"] = record.lineno
+    extra["level"] = record.levelname
+    if "time" not in extra:
+      extra["time"] = now().isoformat()
+    extra["thread"] = record.thread
+    extra["thread_name"] = record.threadName
+    return extra


### PR DESCRIPTION
* Update the Tekton pipelines to support applications whose source
  code isn't in the kubeflow repository (e.g. TFJob controller and pytorch)

  * We need to generalize the name of the git resource containing
    the application to be app-repo.

* update_kf_apps.py needs to filter out repositories that aren't need for
  a particular application; attaching extra resources to a pipeline causes
  the run to fail.

* Update tests to work with assumption that source could be a different
  repository.

* Use structured logging to make it easier to find logs about a particular
  application

Related to #450

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/587)
<!-- Reviewable:end -->
