### PR TITLE
Create a python3.8 version of the worker image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,7 @@
 # Docker image for running E2E tests using Argo.
-
+#
+# This image is obsolete
+# we should start using Dockerfile.py3 which has python3
 FROM ubuntu:xenial
 MAINTAINER Jeremy Lewi
 

--- a/images/Dockerfile.py3
+++ b/images/Dockerfile.py3
@@ -1,0 +1,64 @@
+# Build the docker image used to run the scripts
+# to continuously update our docker files.
+#
+# The context for this docker file should be the root of the kubeflow/testing repository.
+FROM ubuntu:18.04
+
+RUN apt-get update -y && \
+    apt-get install -y curl git python3.8 python3-pip wget && \
+    ln -sf /usr/bin/python3.8 /usr/bin/python
+
+RUN python3.8 -m pip install \
+    fire \
+    lint \
+    watchdog
+
+# Install go
+RUN cd /tmp && \
+    wget -O /tmp/go.tar.gz https://redirector.gvt1.com/edgedl/go/go1.12.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go.tar.gz
+
+# Install the hub CLI for git
+RUN cd /tmp && \
+    curl -LO  https://github.com/github/hub/releases/download/v2.13.0/hub-linux-amd64-2.13.0.tgz && \
+    tar -xvf hub-linux-amd64-2.13.0.tgz && \
+    mv hub-linux-amd64-2.13.0 /usr/local && \
+    ln -sf /usr/local/hub-linux-amd64-2.13.0/bin/hub /usr/local/bin/hub
+
+RUN export KUSTOMIZE_VERSION=3.2.0 && \
+    cd /tmp && \
+    curl -LO  https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
+    mv kustomize_${KUSTOMIZE_VERSION}_linux_amd64 /usr/local/bin/kustomize && \
+    chmod a+x /usr/local/bin/kustomize
+
+# Create go symlinks
+RUN ln -sf /usr/local/go/bin/go /usr/local/bin && \
+    ln -sf /usr/local/go/bin/gofmt /usr/local/bin && \
+    ln -sf /usr/local/go/bin/godoc /usr/local/bin
+
+RUN go get github.com/kelseyhightower/kube-rsa
+
+COPY checkout.sh /usr/local/bin
+COPY checkout_repos.sh /usr/local/bin
+COPY setup_ssh.sh /usr/local/bin
+RUN chmod a+x /usr/local/bin/checkout* /usr/local/bin/setup_ssh.sh
+
+COPY run_workflows.sh /usr/local/bin
+RUN chmod a+x /usr/local/bin/run_workflows.sh
+
+COPY run_release.sh /usr/local/bin
+RUN chmod a+x /usr/local/bin/run_release.sh
+
+# Install the hub CLI for git
+RUN cd /tmp && \
+    curl -LO  https://github.com/github/hub/releases/download/v2.11.2/hub-linux-amd64-2.11.2.tgz && \
+    tar -xvf hub-linux-amd64-2.11.2.tgz && \
+    mv hub-linux-amd64-2.11.2 /usr/local && \
+    ln -sf /usr/local/hub-linux-amd64-2.11.2/bin/hub /usr/local/bin/hub
+
+# Install kubectl
+# We don't install via gcloud because we want 1.10 which is newer than what's in gcloud.
+RUN  curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl && \
+    mv kubectl /usr/local/bin && \
+    chmod a+x /usr/local/bin/kubectl
+

--- a/images/Dockerfile.py3
+++ b/images/Dockerfile.py3
@@ -18,6 +18,23 @@ RUN cd /tmp && \
     wget -O /tmp/go.tar.gz https://redirector.gvt1.com/edgedl/go/go1.12.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz
 
+
+# Install gcloud
+ENV PATH=/root/go/bin:/usr/local/go/bin:/google-cloud-sdk/bin:/workspace:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+RUN go get github.com/kelseyhightower/kube-rsa
+
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
+    tar xzf google-cloud-sdk.tar.gz -C / && \
+    rm google-cloud-sdk.tar.gz && \
+    /google-cloud-sdk/install.sh \
+    --disable-installation-options \
+    --bash-completion=false \
+    --path-update=false \
+    --usage-reporting=false && \
+    gcloud components install alpha beta
+
 # Install the hub CLI for git
 RUN cd /tmp && \
     curl -LO  https://github.com/github/hub/releases/download/v2.13.0/hub-linux-amd64-2.13.0.tgz && \

--- a/images/manifest/README.md
+++ b/images/manifest/README.md
@@ -1,0 +1,3 @@
+A kustomization package.
+
+This just creates a stateful set running the py worker image. Mostly useful for debugging.

--- a/images/manifest/kustomization.yaml
+++ b/images/manifest/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow-test-infra
+namePrefix: dev-
+images:
+- name: gcr.io/kubeflow-ci/test-worker-py3
+resources:
+- statefulset.yaml

--- a/images/manifest/statefulset.yaml
+++ b/images/manifest/statefulset.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: worker
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: worker
+  serviceName: ""
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: worker
+    spec:
+      containers:
+      - command:
+        - tail
+        - -f
+        - /dev/null
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /secret/gcp-credentials/key.json
+        image: gcr.io/kubeflow-ci/test-worker-py3
+        imagePullPolicy: Always
+        name: test-container
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /mnt/test-data-volume
+          name: nfs-external
+        - mountPath: /secret/gcp-credentials
+          name: gcp-credentials
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: nfs-external
+        persistentVolumeClaim:
+          claimName: nfs-external
+      - name: gcp-credentials
+        secret:
+          defaultMode: 420
+          secretName: kubeflow-testing-credentials
+  updateStrategy:
+    type: RollingUpdate

--- a/images/skaffold.yaml
+++ b/images/skaffold.yaml
@@ -1,0 +1,55 @@
+# Reference: https://skaffold.dev/docs/references/yaml/
+apiVersion: skaffold/v2alpha1
+kind: Config
+metadata:
+  name: kf-apps-cd
+build:
+  artifacts:
+  - image: gcr.io/kubeflow-ci/test-worker-py3
+    # Set the context to the root directory. 
+    # All paths in the Dockerfile should be relative to this one.
+    context: .    
+    kaniko:
+      dockerfile: ./Dockerfile.py3
+      buildContext:
+        gcsBucket: kubeflow-ci_skaffold
+      env: 
+        # TODO(GoogleContainerTools/skaffold#3468) skaffold doesn't
+        # appear to work with workload identity
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /secret/user-gcp-sa.json
+      cache: {}
+  cluster:    
+    pullSecretName: user-gcp-sa
+    resources:
+      requests:
+        cpu: 6
+        memory: 16Gi
+profiles:
+  # Build on the kubeflow releasing cluster
+  - name: testing
+    activation:
+      - kubeContext: kubeflow-testing
+    patches:
+      - op: replace
+        path: /build/artifacts/0/image
+        value: gcr.io/kubeflow-ci/test-worker-py3
+      - op: replace
+        path: /build/artifacts/0/kaniko/buildContext/gcsBucket
+        value: kubeflow-ci_skaffold
+      - op: replace
+        path: /build/artifacts/0/kaniko/env/0/value
+        value: /secret/key.json
+    build:      
+      cluster:    
+        # Build in a namespace with ISTIO sidecar injection disabled
+        # see  GoogleContainerTools/skaffold#3442
+        namespace: kubeflow-test-infra
+        pullSecretName: gcp-credentials
+        resources:
+          requests:
+            cpu: 6
+            memory: 16Gi
+    deploy:
+      kustomize:
+        path: manifest


### PR DESCRIPTION
* Related to kubeflow/testing#560 - python3 lint
* We need this because we need a newer (3.8) version of pylint
  to allow for python3.8 syntax like f strings.

* In this pass we eschewed the following packages which I don't think we
  need anymore

  * ksonnet
  * helm
  * glide (should be using go modules and staged builds)
  * docker
  * nodejs (should be using staged builds)

* Create a skaffold config to build the image.

* Related to: kubeflow/kfctl#228 endpoint test is failing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/606)
<!-- Reviewable:end -->
