### PR TITLE
Use Anthos Config Management to continually sync the label config to the cluster

### DIFF
--- a/label_sync/README.md
+++ b/label_sync/README.md
@@ -3,9 +3,37 @@
 kubeflow_label.yml: containing rules to update or migrate github labels on repos in kubeflow org
 We use same tool from kubernetes: https://github.com/kubernetes/test-infra/tree/master/label_sync
 
-Want to edit kubeflow_label.yml? Take a look at [process_label.py](../hack/label_generate/process_label.py).
+## How to add or rename labels
 
-## Usage
+1. Modify kubeflow_label.yml
+
+   * Define new labels or add entries to rename labels
+
+1. Run
+
+   ```
+   hydrate.sh
+   ```
+
+   * This will run `kustomize build` to generate an updated configmap and update the cronjob to use the new config
+   * The hydrated manifests are written to the directory `acm_repo`
+
+1. Create a PR with the changes
+
+
+1. After the next succesful run of the cron job your changes should be applied to all repos.
+
+
+## How it works
+
+### Label sync binary
+
+[label_sync](https://github.com/kubernetes/test-infra/tree/master/label_sync) is a binary produced by the Kubernetes test infra
+team to sync labels in GitHub based on a YAML config file.
+
+Here's an example invocation of that binary
+
+
 ```sh
 # add or migrate labels on all repos in the kubeflow org
 # Under kubernetes/test-infra/label_sync, run:
@@ -15,7 +43,9 @@ bazel run //label_sync -- \
   --orgs kubeflow
 ```
 
-## Cron Job
+### Cron Job
+
+We use a Kubernetes cron job to periodically run label_sync.
 
 We currently run a cron job synchronize labels in
 
@@ -27,14 +57,17 @@ We use a separate cluster in a restricted project because modifying the labels r
 
 We have a CronJob to sync the labels, defined
 [here](https://github.com/kubeflow/testing/blob/master/label_sync/cluster/label_sync_job.yaml).
-After making changes to `kubeflow_label.yml`, we need to update the configmap
-[label-config-v2](https://github.com/kubeflow/testing/blob/master/label_sync/cluster/label_sync_job.yaml#L37):
-```
-# Setup kubectl to point to kubeflow-testing cluster in kubeflow-ci
-kubectl -n github-admin delete configmap label-config-v2
-kubectl -n github-admin create configmap label-config-v2 --from-file=kubeflow_label.yml
-```
-### Create a GitHub OAuth token
+
+### ACM to sync Kubernetes Resources
+
+We use Anthos Config Management(ACM) to continually sync changes to the kubernetes resources to the kubernetes cluster.
+
+Right now the user has to manually run `hydrate.sh` to generate hydrated manifests that get checked in as part of the PR.
+
+
+### GitHub OAuth token
+
+The label_sync binary depends on a GitHub OAuth token which is stored as a configmap. (We would like to change this to a GitHub App)
 
 Use GitHub to create an OAuth token
  
@@ -43,9 +76,4 @@ Use GitHub to create an OAuth token
 
 ```
 kubectl -n github-admin create secret generic bot-token-github --from-literal=bot-token=${GITHUB_TOKEN}
-```
-## Create the cron job
-
-```
-kubectl -n github-admin apply -f cluster/label_sync_cron_job.yaml
 ```

--- a/label_sync/acm_repo/README.md
+++ b/label_sync/acm_repo/README.md
@@ -1,0 +1,5 @@
+# Anthos Configuration Management Directory
+
+This is the root directory for Anthos Configuration Management.
+
+See [our documentation](https://cloud.google.com/anthos-config-management/docs/repo) for how to use each subdirectory.

--- a/label_sync/acm_repo/namespaces/batch_v1beta1_cronjob_label-sync-cron.yaml
+++ b/label_sync/acm_repo/namespaces/batch_v1beta1_cronjob_label-sync-cron.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: label-sync-cron
+spec:
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      labels:
+        app: label-sync
+    spec:
+      template:
+        spec:
+          containers:
+          - args:
+            - --config=/etc/config/kubeflow_label.yml
+            - --confirm=true
+            - --orgs=kubeflow
+            - --token=/etc/github/bot-token
+            image: gcr.io/k8s-testimages/label_sync:v20180921-f7ff24f34
+            name: label-sync
+            volumeMounts:
+            - mountPath: /etc/github
+              name: oauth
+              readOnly: true
+            - mountPath: /etc/config
+              name: config
+              readOnly: true
+          restartPolicy: Never
+          volumes:
+          - name: oauth
+            secret:
+              secretName: bot-token-github
+          - configMap:
+              name: label-sync-v2-89b54b7724
+            name: config
+  schedule: 0 */6 * * *

--- a/label_sync/acm_repo/namespaces/github-admin/github-admin.yaml
+++ b/label_sync/acm_repo/namespaces/github-admin/github-admin.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: github-admin

--- a/label_sync/acm_repo/namespaces/~g_v1_configmap_label-sync-v2-89b54b7724.yaml
+++ b/label_sync/acm_repo/namespaces/~g_v1_configmap_label-sync-v2-89b54b7724.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+data:
+  kubeflow_label.yml: "default:\n  labels:\n  - color: ef1ad6\n    name: area/0.2.0\n
+    \   previously:\n    - name: release/0.2.0\n  - color: ef1ad6\n    name: area/0.3.0\n
+    \   previously:\n    - name: release/0.3.0\n  - color: ef1ad6\n    name: area/0.4.0\n
+    \   previously:\n    - name: release/0.4.0\n  - color: ef1ad6\n    name: area/1.0.0\n
+    \   previously:\n    - name: release/1.0.0\n  - color: d2b48c\n    name: area/api\n
+    \ - color: d2b48c\n    name: area/engprod\n    previously:\n    - name: area/build-release\n
+    \   - name: area/release-eng\n    - name: area/releasing\n  - color: d2b48c\n
+    \   name: area/kfctl\n    previously:\n    - name: area/deployment\n    - name:
+    area/bootstrap\n  - color: d2b48c\n    name: area/docs\n  - color: d2b48c\n    name:
+    area/devices\n  - color: d2b48c\n    name: area/example\n  - color: d2b48c\n    name:
+    area/front-end\n    previously:\n    - name: area/ui\n  - color: fcd915\n    name:
+    area/gsoc\n  - color: d2b48c\n    name: area/lifecycle\n  - color: d2b48c\n    name:
+    area/logging\n  - color: d2b48c\n    name: area/operator\n  - color: d2b48c\n
+    \   name: area/inference\n    previously:\n    - name: inference  \n  - color:
+    d2b48c\n    name: area/usage\n  - color: 2515fc\n    name: effort/1-days\n  -
+    color: db1203\n    name: effort/3-days\n  - color: cb03cc\n    name: effort/5-days\n
+    \ - color: fc9915\n    name: effort/2-weeks\n  - color: fc2515\n    name: effort/2-weeks+\n
+    \ - color: ecfc15\n    name: kind/discussion\n    previously:\n    - name: community/discussion\n
+    \ - color: ecfc15\n    name: community/maintenance\n  - color: 2515fc\n    name:
+    kind/question\n    previously:\n    - name: community/question\n    - name: question\n
+    \ - color: 2515fc\n    name: kind/feature\n    previously:\n    - name: feature\n
+    \   - name: addition/feature\n    - name: improvement/enhancement\n  - color:
+    2515fc\n    name: kind/process  \n  - color: ecfc15\n    name: cuj/build-train-deploy\n
+    \ - color: 00daff\n    name: cuj/multi-user\n  - color: 00daff\n    name: do-not-merge\n
+    \ - color: 00daff\n    name: duplicate\n  - color: 2515fc\n    name: platform/aws\n
+    \   previously:\n    - name: area/platform/aws\n  - color: 2515fc\n    name: platform/azure\n
+    \   previously:\n    - name: area/platform/azure\n    - name: cloud/azure\n  -
+    color: 2515fc\n    name: platform/gcp\n    previously:\n    - name: area/platform/gke\n
+    \   - name: cloud/gke\n  - color: 2515fc\n    name: platform/minikube\n    previously:\n
+    \   - name: area/platform/minikube\n  - color: 2515fc\n    name: platform/other\n
+    \ - color: db1203\n    name: priority/p0\n  - color: cb03cc\n    name: priority/p1\n
+    \ - color: fc9915\n    name: priority/p2\n  - color: fc2515\n    name: kind/bug\n
+    \   previously:\n    - name: bug\n    - name: problem/bug\n  - color: 00daff\n
+    \   name: starter\n  - color: 03db12\n    name: approved\n    previously:\n    -
+    name: status/approved\n  - color: bc9090\n    name: status/backlog\n  - color:
+    fca42e\n    name: status/done\n  - color: '707070'\n    name: status/icebox\n
+    \ # Don't remove, this label is being used by prow\n  - color: ffa500\n    name:
+    do-not-merge/work-in-progress\n    previously:\n    - name: status/in progress\n
+    \ - color: 2efca4\n    name: lgtm\n    previously:\n    - name: status/lgtm\n
+    \ - color: 00daff\n    name: area/testing\n    previously:\n    - name: testing\n
+    \ - color: 00daff\n    name: wontfix\n  - color: 8cd2b4\n    name: sprint/2018-05-29-to-06-08\n
+    \ - color: 8cd2b4\n    name: sprint/2018-06-11-to-06-22\n  - color: 8cd2b4\n    name:
+    sprint/2018-06-25-to-07-06\n  - color: 8cd2b4\n    name: sprint/2018-07-09-to-07-20\n"
+kind: ConfigMap
+metadata:
+  name: label-sync-v2-89b54b7724

--- a/label_sync/acm_repo/system/README.md
+++ b/label_sync/acm_repo/system/README.md
@@ -1,0 +1,3 @@
+# System
+
+This directory contains system configs such as the repo version and how resources are synced.

--- a/label_sync/acm_repo/system/repo.yaml
+++ b/label_sync/acm_repo/system/repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: configmanagement.gke.io/v1
+kind: Repo
+metadata:
+  name: repo
+spec:
+  version: 1.0.0

--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -34,4 +34,4 @@ spec:
               secretName: bot-token-github
           - name: config
             configMap:
-              name: label-config-v2
+              name: label-sync-v2

--- a/label_sync/hydrate.sh
+++ b/label_sync/hydrate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# a simple script to generate hydrated manifests
+set -ex
+# Remove previous instances
+rm -f acm_repo/namespaces/*label-sync*
+#rm -f acm_repo/namespaces/*configmap_label-sync-v2*
+kustomize build -o acm_repo/namespaces

--- a/label_sync/hydrate.sh
+++ b/label_sync/hydrate.sh
@@ -3,5 +3,4 @@
 set -ex
 # Remove previous instances
 rm -f acm_repo/namespaces/*label-sync*
-#rm -f acm_repo/namespaces/*configmap_label-sync-v2*
 kustomize build -o acm_repo/namespaces

--- a/label_sync/kubeflow_label.yml
+++ b/label_sync/kubeflow_label.yml
@@ -77,6 +77,7 @@ default:
   - color: 2515fc
     name: kind/feature
     previously:
+    - name: feature
     - name: addition/feature
     - name: improvement/enhancement
   - color: 2515fc

--- a/label_sync/kustomization.yaml
+++ b/label_sync/kustomization.yaml
@@ -1,0 +1,11 @@
+# This package is primarily intended to generate the configmap
+# from the label file
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster/label_sync_cron_job.yaml
+configMapGenerator:
+- name: label-sync-v2
+  files:
+    # configfile is used as key
+    - kubeflow_label.yml    

--- a/label_sync/label_sync_acm_config.yaml
+++ b/label_sync/label_sync_acm_config.yaml
@@ -1,0 +1,17 @@
+# Synchronize the label sync config to the kubeflow-admin cluster
+apiVersion: configmanagement.gke.io/v1
+kind: ConfigManagement
+metadata:
+  # name: config-management
+  name: label-sync
+  # Does this need to be in the same namespace as the configmanagement system?
+  namespace: config-management-system
+spec:
+  # clusterName is required and must be unique among all managed clusters
+  clusterName: my-cluster
+  git:
+    # TODO(jlewi): Change to master before committing
+    syncRepo: https://github.com/kubeflow/testing.git
+    syncBranch: master
+    secretType: none
+    policyDir: "label_sync/acm_repo"

--- a/label_sync/label_sync_acm_config.yaml
+++ b/label_sync/label_sync_acm_config.yaml
@@ -10,7 +10,6 @@ spec:
   # clusterName is required and must be unique among all managed clusters
   clusterName: my-cluster
   git:
-    # TODO(jlewi): Change to master before committing
     syncRepo: https://github.com/kubeflow/testing.git
     syncBranch: master
     secretType: none


### PR DESCRIPTION
* Define a kustomize package to generate the config map from the labels

* ACM requires the directory structure follow a certain format so we
  created the directory label_sync/acm_repo

* A simple shell script runs kustomize to dump the manifests to the directory.

Related to #624

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/testing/625)
<!-- Reviewable:end -->
