### PR TITLE
Fix casing for GitHub references

### DIFF
--- a/py/kubeflow/testing/go-license-tools/README.md
+++ b/py/kubeflow/testing/go-license-tools/README.md
@@ -77,7 +77,7 @@ $ python <license_tool>/setup.py install
     Fetching license for kubernetes-sigs/yaml
     Fetched github license info, 91 succeeded, 0 failed.
     ```
-    You have to create a `<github_token_file>` in order to access Github repositories, because it sends a lot of requests to github. Follow instructions in `get-github-license-info -h`.
+    You have to create a `<github_token_file>` in order to access GitHub repositories, because it sends a lot of requests to github. Follow instructions in `get-github-license-info -h`.
 
     For repositories that fails to fetch license, it's usually because their github repo
     doesn't have a github understandable license file. Check its readme and

--- a/py/kubeflow/testing/go-license-tools/get_github_license_info.py
+++ b/py/kubeflow/testing/go-license-tools/get_github_license_info.py
@@ -26,7 +26,7 @@ parser.add_argument(
   nargs='?',
   default='repo.txt',
   help=
-  'Github repo list file with one line per github repo. Format: org/repo. (default: %(default)s)',
+  'GitHub repo list file with one line per github repo. Format: org/repo. (default: %(default)s)',
 )
 parser.add_argument(
   '-o',
@@ -61,7 +61,7 @@ def main():
   except FileNotFoundError:
     raise Exception((
         'Please put a github api token file at {}, or specify a different token file path by '
-        +'--github-api-token-file. Github API token is needed because anonymous API access limit '
+        +'--github-api-token-file. GitHub API token is needed because anonymous API access limit '
         +'is not enough.'
       ).format(args.github_api_token_file))
 

--- a/py/kubeflow/testing/python-license-tools/README.md
+++ b/py/kubeflow/testing/python-license-tools/README.md
@@ -16,7 +16,7 @@ Download the Python files both in go-license-tools folder and this folder.
     - Run `pipenv install ...` to install all your direct dependencies.
     - Run `pipenv lock` to generate lock file `Pipfile.lock` in JSON for all transitive dependencies.
 
-2. Get Github source repositories for all the dependencies by running this script.
+2. Get GitHub source repositories for all the dependencies by running this script.
     ```
     python3 pipfile_to_github_repo.py
     ```
@@ -28,12 +28,12 @@ Download the Python files both in go-license-tools folder and this folder.
     cffi: None
     ......
     ```
-    Each line above is a Github repository name for a package. Unfortunately, not all packages have source repository information listed on PyPI. In this case, we use `<pakcage_name>: None` to denote such packages. In this example, `certifi` and `cffi` miss the source repository information and we have to manually search for source repositories and edit the information.
+    Each line above is a GitHub repository name for a package. Unfortunately, not all packages have source repository information listed on PyPI. In this case, we use `<pakcage_name>: None` to denote such packages. In this example, `certifi` and `cffi` miss the source repository information and we have to manually search for source repositories and edit the information.
 
 3. Manually edit source repository information. Once we find all the package source repositories, we need to update `repo.txt`. For example, we can replace
-line `certifi: None` with its Github source repository `certifi/python-certifi`.
+line `certifi: None` with its GitHub source repository `certifi/python-certifi`.
 
-    However, we can't update `repo.txt` for `cffi` directly, because it is not hosted on Github but . We have to remember to update its license URI and type in the final `license_info.csv`, which is produced in the next step.
+    However, we can't update `repo.txt` for `cffi` directly, because it is not hosted on GitHub but . We have to remember to update its license URI and type in the final `license_info.csv`, which is produced in the next step.
 
 ### III. Get all license URLs and types
-This step is the same as [the one](https://github.com/kubeflow/testing/blob/master/py/kubeflow/testing/go-license-tools/README.md#iii-get-all-license-urls-and-types) described in the Go license tools guide, but you have to manually add the license information for code not hosted on Github.
+This step is the same as [the one](https://github.com/kubeflow/testing/blob/master/py/kubeflow/testing/go-license-tools/README.md#iii-get-all-license-urls-and-types) described in the Go license tools guide, but you have to manually add the license information for code not hosted on GitHub.


### PR DESCRIPTION
Simple change with two purpose:
* verify the Prow _presubmit_ is functional for this repo.
* update grammar in string literals:  Git~h~Hub (once merged will verify _postsubmit_)
