### PR TITLE
Upgrade to go 1.14 (from 1.12) in the test worker image.

### DIFF
--- a/images/Dockerfile.py3
+++ b/images/Dockerfile.py3
@@ -25,7 +25,7 @@ RUN python3.8 -m pip install \
 
 # Install go
 RUN cd /tmp && \
-    wget -O /tmp/go.tar.gz https://redirector.gvt1.com/edgedl/go/go1.12.linux-amd64.tar.gz && \
+    wget -O /tmp/go.tar.gz https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz
 
 


### PR DESCRIPTION
* Go builds of started to break and this appears to be due to the use of
  1.12.

  * See kubeflow/manifests#1104

  * See kubeflow/kfctl#306

* New image is gcr.io/kubeflow-ci/test-worker-py3:e9afed1-dirty