### PR TITLE
Revert "Don't use self signed certificates in auto-deployed KF instances (#637)"

### DIFF
--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -958,15 +958,8 @@ def use_self_signed_for_ingress(ingress_namespace, ingress_name,
   ingress = extensions.read_namespaced_ingress(ingress_name, ingress_namespace)
 
   # Delete GKE managed annotations
-  # See https://github.com/kubeflow/testing/issues/636
-  # We need to delete these annotations using kubectl; using patch
-  # doesn't seem to work. Also the order in which we delete them matters
-  for a in ["networking.gke.io/managed-certificates",
-            "ingress.gcp.kubernetes.io/pre-shared-cert"]:
-    # We add the - at the end of the annotation to delete it
-    # Deleting a non existent annotation is a null op
-    run(["kubectl", "-n", ingress_namespace, "annotate", "ingress",
-         ingress_name, "--overwrite=true", a + "-"])
+  for a in ["ingress.gcp.kubernetes.io/pre-shared-cert",
+            "networking.gke.io/managed-certificates"]:
     if a in ingress.metadata.annotations:
       del ingress.metadata.annotations[a]
 
@@ -979,10 +972,9 @@ def use_self_signed_for_ingress(ingress_namespace, ingress_name,
   ]
 
   logging.info("Updating ingress \n:%s", yaml.safe_dump(ingress.to_dict()))
-  result = extensions.patch_namespaced_ingress(ingress_name,
-                                               ingress_namespace,
-                                               ingress)
-  logging.info("Patched ingress \n:%s", result)
+  extensions.patch_namespaced_ingress(ingress_name,
+                                      ingress_namespace,
+                                      ingress)
 
 def is_in_cluster():
   """Check if we are running in cluster."""


### PR DESCRIPTION

Partial revert of commit afd9f952c4d34affbd2a6ec36849486c4dbbe556.

The change in the self-signed logic breaks presubmits with the following error

E           kubernetes.client.rest.ApiException: (409)
E           Reason: Conflict
E           HTTP response headers: HTTPHeaderDict({'Audit-Id': '85305103-054e-4795-a45e-f802de1ae4ea', 'Content-Type': 'application/json', 'Date': 'Wed, 15 Apr 2020 00:31:03 GMT', 'Content-Length': '352'})
E           HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Operation cannot be fulfilled on ingresses.extensions \"envoy-ingress\": the object has been modified; please apply your changes to the latest version and try again","reason":"Conflict","details":{"name":"envoy-ingress","group":"extensions","kind":"ingresses"},"code":409}

* Only changes to util.py in the original PR are reverted.