### PR TITLE
Create a management cluster for GCP blueprints and other test infra.

### DIFF
--- a/test-infra/management/.build/cluster/cnrm.cloud.google.com_v1alpha1_cloudservice_gke.yaml
+++ b/test-infra/management/.build/cluster/cnrm.cloud.google.com_v1alpha1_cloudservice_gke.yaml
@@ -1,0 +1,7 @@
+apiVersion: cnrm.cloud.google.com/v1alpha1
+kind: CloudService
+metadata:
+  name: gke
+  namespace: kubeflow-ci
+spec:
+  service: container.googleapis.com

--- a/test-infra/management/.build/cluster/container.cnrm.cloud.google.com_v1alpha2_containercluster_kf-ci-management.yaml
+++ b/test-infra/management/.build/cluster/container.cnrm.cloud.google.com_v1alpha2_containercluster_kf-ci-management.yaml
@@ -1,0 +1,16 @@
+apiVersion: container.cnrm.cloud.google.com/v1alpha2
+kind: ContainerCluster
+metadata:
+  clusterName: kubeflow-ci/us-central1/kf-ci-management
+  name: kf-ci-management
+  namespace: kubeflow-ci
+spec:
+  clusterTelemetry:
+    type: enabled
+  ipAllocationPolicy:
+    useIpAliases: true
+  location: us-central1
+  releaseChannel:
+    channel: RAPID
+  workloadIdentity:
+    identityNamespace: default

--- a/test-infra/management/.build/cluster/container.cnrm.cloud.google.com_v1alpha2_containernodepool_kf-ci-management-pool.yaml
+++ b/test-infra/management/.build/cluster/container.cnrm.cloud.google.com_v1alpha2_containernodepool_kf-ci-management-pool.yaml
@@ -1,0 +1,29 @@
+apiVersion: container.cnrm.cloud.google.com/v1alpha2
+kind: ContainerNodePool
+metadata:
+  clusterName: kubeflow-ci/us-central1/kf-ci-management
+  name: kf-ci-management-pool
+  namespace: kubeflow-ci
+spec:
+  autoscaling:
+    maxNodeCount: 3
+    minNodeCount: 1
+  clusterRef:
+    name: kf-ci-management
+  management:
+    autoRepair: true
+    autoUpgrade: true
+  nodeConfig:
+    diskSizeGb: 100
+    diskType: pd-standard
+    machineType: n1-standard-4
+    metadata:
+      disable-legacy-endpoints: "true"
+    oauthScopes:
+    - https://www.googleapis.com/auth/devstorage.read_only
+    - https://www.googleapis.com/auth/logging.write
+    - https://www.googleapis.com/auth/monitoring
+    - https://www.googleapis.com/auth/servicecontrol
+    - https://www.googleapis.com/auth/service.management.readonly
+    - https://www.googleapis.com/auth/trace.append
+    preemptible: false

--- a/test-infra/management/.build/cluster/identity.cnrm.cloud.google.com_v1alpha2_identitynamespace_default.yaml
+++ b/test-infra/management/.build/cluster/identity.cnrm.cloud.google.com_v1alpha2_identitynamespace_default.yaml
@@ -1,0 +1,6 @@
+apiVersion: identity.cnrm.cloud.google.com/v1alpha2
+kind: IdentityNamespace
+metadata:
+  name: default
+  namespace: kubeflow-ci
+spec: {}

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com.yaml
@@ -1,0 +1,272 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com
+spec:
+  group: accesscontextmanager.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: AccessContextManagerAccessLevel
+    plural: accesscontextmanageraccesslevels
+    shortNames:
+    - gcpaccesscontextmanageraccesslevel
+    - gcpaccesscontextmanageraccesslevels
+    singular: accesscontextmanageraccesslevel
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            accessPolicyRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            basic:
+              description: A set of predefined conditions for the access level and
+                a combining function.
+              properties:
+                combiningFunction:
+                  description: |-
+                    How the conditions list should be combined to determine if a request
+                    is granted this AccessLevel. If AND is used, each Condition in
+                    conditions must be satisfied for the AccessLevel to be applied. If
+                    OR is used, at least one Condition in conditions must be satisfied
+                    for the AccessLevel to be applied. Defaults to AND if unspecified.
+                  type: string
+                conditions:
+                  description: A set of requirements for the AccessLevel to be granted.
+                  items:
+                    properties:
+                      devicePolicy:
+                        description: |-
+                          Device specific restrictions, all restrictions must hold for
+                          the Condition to be true. If not specified, all devices are
+                          allowed.
+                        properties:
+                          allowedDeviceManagementLevels:
+                            description: |-
+                              A list of allowed device management levels.
+                              An empty list allows all management levels.
+                            items:
+                              type: string
+                            type: array
+                          allowedEncryptionStatuses:
+                            description: |-
+                              A list of allowed encryptions statuses.
+                              An empty list allows all statuses.
+                            items:
+                              type: string
+                            type: array
+                          osConstraints:
+                            description: |-
+                              A list of allowed OS versions.
+                              An empty list allows all types and all versions.
+                            items:
+                              properties:
+                                minimumVersion:
+                                  description: |-
+                                    The minimum allowed OS version. If not set, any version
+                                    of this OS satisfies the constraint.
+                                    Format: "major.minor.patch" such as "10.5.301", "9.2.1".
+                                  type: string
+                                osType:
+                                  description: The operating system type of the device.
+                                  type: string
+                              required:
+                              - osType
+                              type: object
+                            type: array
+                          requireAdminApproval:
+                            description: Whether the device needs to be approved by
+                              the customer admin.
+                            type: boolean
+                          requireCorpOwned:
+                            description: Whether the device needs to be corp owned.
+                            type: boolean
+                          requireScreenLock:
+                            description: |-
+                              Whether or not screenlock is required for the DevicePolicy
+                              to be true. Defaults to false.
+                            type: boolean
+                        type: object
+                      ipSubnetworks:
+                        description: |-
+                          A list of CIDR block IP subnetwork specification. May be IPv4
+                          or IPv6.
+                          Note that for a CIDR IP address block, the specified IP address
+                          portion must be properly truncated (i.e. all the host bits must
+                          be zero) or the input is considered malformed. For example,
+                          "192.0.2.0/24" is accepted but "192.0.2.1/24" is not. Similarly,
+                          for IPv6, "2001:db8::/32" is accepted whereas "2001:db8::1/32"
+                          is not. The originating IP of a request must be in one of the
+                          listed subnets in order for this Condition to be true.
+                          If empty, all IP addresses are allowed.
+                        items:
+                          type: string
+                        type: array
+                      members:
+                        items:
+                          properties:
+                            group:
+                              type: string
+                            serviceAccountRef:
+                              oneOf:
+                              - not:
+                                  required:
+                                  - external
+                                required:
+                                - name
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - name
+                                  - required:
+                                    - namespace
+                                required:
+                                - external
+                              properties:
+                                external:
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                              type: object
+                            user:
+                              type: string
+                          type: object
+                        type: array
+                      negate:
+                        description: |-
+                          Whether to negate the Condition. If true, the Condition becomes
+                          a NAND over its non-empty fields, each field must be false for
+                          the Condition overall to be satisfied. Defaults to false.
+                        type: boolean
+                      requiredAccessLevels:
+                        items:
+                          oneOf:
+                          - not:
+                              required:
+                              - external
+                            required:
+                            - name
+                          - not:
+                              anyOf:
+                              - required:
+                                - name
+                              - required:
+                                - namespace
+                            required:
+                            - external
+                          properties:
+                            external:
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+              required:
+              - conditions
+              type: object
+            description:
+              description: Description of the AccessLevel and its use. Does not affect
+                behavior.
+              type: string
+            title:
+              description: Human readable title. Must be unique within the Policy.
+              type: string
+          required:
+          - accessPolicyRef
+          - title
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_accesscontextmanageraccesspolicies.accesscontextmanager.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_accesscontextmanageraccesspolicies.accesscontextmanager.cnrm.cloud.google.com.yaml
@@ -1,0 +1,94 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: accesscontextmanageraccesspolicies.accesscontextmanager.cnrm.cloud.google.com
+spec:
+  group: accesscontextmanager.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: AccessContextManagerAccessPolicy
+    plural: accesscontextmanageraccesspolicies
+    shortNames:
+    - gcpaccesscontextmanageraccesspolicy
+    - gcpaccesscontextmanageraccesspolicies
+    singular: accesscontextmanageraccesspolicy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            title:
+              description: Human readable title. Does not affect behavior.
+              type: string
+          required:
+          - title
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            createTime:
+              description: Time the AccessPolicy was created in UTC.
+              type: string
+            name:
+              description: 'Resource name of the AccessPolicy. Format: {policy_id}'
+              type: string
+            updateTime:
+              description: Time the AccessPolicy was updated in UTC.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_bigquerydatasets.bigquery.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_bigquerydatasets.bigquery.cnrm.cloud.google.com.yaml
@@ -1,0 +1,261 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: bigquerydatasets.bigquery.cnrm.cloud.google.com
+spec:
+  group: bigquery.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: BigQueryDataset
+    plural: bigquerydatasets
+    shortNames:
+    - gcpbigquerydataset
+    - gcpbigquerydatasets
+    singular: bigquerydataset
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            access:
+              description: An array of objects that define dataset access for one
+                or more entities.
+              items:
+                properties:
+                  domain:
+                    description: |-
+                      A domain to grant access to. Any users signed in with the
+                      domain specified will be granted the specified access
+                    type: string
+                  groupByEmail:
+                    description: An email address of a Google Group to grant access
+                      to.
+                    type: string
+                  role:
+                    description: |-
+                      Describes the rights granted to the user specified by the other
+                      member of the access object. Primitive, Predefined and custom
+                      roles are supported. Predefined roles that have equivalent
+                      primitive roles are swapped by the API to their Primitive
+                      counterparts, and will show a diff post-create. See
+                      [official docs](https://cloud.google.com/bigquery/docs/access-control).
+                    type: string
+                  specialGroup:
+                    description: |-
+                      A special group to grant access to. Possible values include:
+
+
+                      * 'projectOwners': Owners of the enclosing project.
+
+
+                      * 'projectReaders': Readers of the enclosing project.
+
+
+                      * 'projectWriters': Writers of the enclosing project.
+
+
+                      * 'allAuthenticatedUsers': All authenticated BigQuery users.
+                    type: string
+                  userByEmail:
+                    description: |-
+                      An email address of a user to grant access to. For example:
+                      fred@example.com
+                    type: string
+                  view:
+                    description: |-
+                      A view from a different dataset to grant access to. Queries
+                      executed against that view will have read access to tables in
+                      this dataset. The role field is not required when this field is
+                      set. If that view is updated by any user, access to the view
+                      needs to be granted again via an update operation.
+                    properties:
+                      datasetId:
+                        description: The ID of the dataset containing this table.
+                        type: string
+                      projectId:
+                        description: The ID of the project containing this table.
+                        type: string
+                      tableId:
+                        description: |-
+                          The ID of the table. The ID must contain only letters (a-z,
+                          A-Z), numbers (0-9), or underscores (_). The maximum length
+                          is 1,024 characters.
+                        type: string
+                    required:
+                    - datasetId
+                    - projectId
+                    - tableId
+                    type: object
+                type: object
+              type: array
+            defaultEncryptionConfiguration:
+              description: |-
+                The default encryption key for all tables in the dataset. Once this property is set,
+                all newly-created partitioned tables in the dataset will have encryption key set to
+                this value, unless table creation request (or query) overrides the key.
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              required:
+              - kmsKeyRef
+              type: object
+            defaultPartitionExpirationMs:
+              description: |-
+                The default partition expiration for all partitioned tables in
+                the dataset, in milliseconds.
+
+
+                Once this property is set, all newly-created partitioned tables in
+                the dataset will have an 'expirationMs' property in the 'timePartitioning'
+                settings set to this value, and changing the value will only
+                affect new tables, not existing ones. The storage in a partition will
+                have an expiration time of its partition time plus this value.
+                Setting this property overrides the use of 'defaultTableExpirationMs'
+                for partitioned tables: only one of 'defaultTableExpirationMs' and
+                'defaultPartitionExpirationMs' will be used for any new partitioned
+                table. If you provide an explicit 'timePartitioning.expirationMs' when
+                creating or updating a partitioned table, that value takes precedence
+                over the default partition expiration time indicated by this property.
+              type: integer
+            defaultTableExpirationMs:
+              description: |-
+                The default lifetime of all tables in the dataset, in milliseconds.
+                The minimum value is 3600000 milliseconds (one hour).
+
+
+                Once this property is set, all newly-created tables in the dataset
+                will have an 'expirationTime' property set to the creation time plus
+                the value in this property, and changing the value will only affect
+                new tables, not existing ones. When the 'expirationTime' for a given
+                table is reached, that table will be deleted automatically.
+                If a table's 'expirationTime' is modified or removed before the
+                table expires, or if you provide an explicit 'expirationTime' when
+                creating a table, that value takes precedence over the default
+                expiration time indicated by this property.
+              type: integer
+            description:
+              description: A user-friendly description of the dataset
+              type: string
+            friendlyName:
+              description: A descriptive name for the dataset
+              type: string
+            location:
+              description: |-
+                The geographic location where the dataset should reside.
+                See [official docs](https://cloud.google.com/bigquery/docs/dataset-locations).
+
+
+                There are two types of locations, regional or multi-regional. A regional
+                location is a specific geographic place, such as Tokyo, and a multi-regional
+                location is a large geographic area, such as the United States, that
+                contains at least two geographic places.
+
+
+                Possible regional values include: 'asia-east1', 'asia-northeast1',
+                'asia-southeast1', 'australia-southeast1', 'europe-north1',
+                'europe-west2' and 'us-east4'.
+
+
+                Possible multi-regional values: 'EU' and 'US'.
+
+
+                The default value is multi-regional location 'US'.
+                Changing this forces a new resource to be created.
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTime:
+              description: |-
+                The time when this dataset was created, in milliseconds since the
+                epoch.
+              type: integer
+            etag:
+              description: A hash of the resource.
+              type: string
+            lastModifiedTime:
+              description: |-
+                The date when this dataset or any of its tables was last modified, in
+                milliseconds since the epoch.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_bigquerytables.bigquery.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_bigquerytables.bigquery.cnrm.cloud.google.com.yaml
@@ -1,0 +1,234 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: bigquerytables.bigquery.cnrm.cloud.google.com
+spec:
+  group: bigquery.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: BigQueryTable
+    plural: bigquerytables
+    shortNames:
+    - gcpbigquerytable
+    - gcpbigquerytables
+    singular: bigquerytable
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clustering:
+              items:
+                type: string
+              type: array
+            datasetRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            description:
+              type: string
+            encryptionConfiguration:
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              required:
+              - kmsKeyRef
+              type: object
+            expirationTime:
+              type: integer
+            externalDataConfiguration:
+              properties:
+                autodetect:
+                  type: boolean
+                compression:
+                  type: string
+                csvOptions:
+                  properties:
+                    allowJaggedRows:
+                      type: boolean
+                    allowQuotedNewlines:
+                      type: boolean
+                    encoding:
+                      type: string
+                    fieldDelimiter:
+                      type: string
+                    quote:
+                      type: string
+                    skipLeadingRows:
+                      type: integer
+                  required:
+                  - quote
+                  type: object
+                googleSheetsOptions:
+                  properties:
+                    range:
+                      type: string
+                    skipLeadingRows:
+                      type: integer
+                  type: object
+                ignoreUnknownValues:
+                  type: boolean
+                maxBadRecords:
+                  type: integer
+                sourceFormat:
+                  type: string
+                sourceUris:
+                  items:
+                    type: string
+                  type: array
+              required:
+              - autodetect
+              - sourceFormat
+              - sourceUris
+              type: object
+            friendlyName:
+              type: string
+            schema:
+              type: string
+            timePartitioning:
+              properties:
+                expirationMs:
+                  type: integer
+                field:
+                  type: string
+                requirePartitionFilter:
+                  type: boolean
+                type:
+                  type: string
+              required:
+              - type
+              type: object
+            view:
+              properties:
+                query:
+                  type: string
+                useLegacySql:
+                  type: boolean
+              required:
+              - query
+              type: object
+          required:
+          - datasetRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTime:
+              type: integer
+            etag:
+              type: string
+            lastModifiedTime:
+              type: integer
+            location:
+              type: string
+            numBytes:
+              type: integer
+            numLongTermBytes:
+              type: integer
+            numRows:
+              type: integer
+            selfLink:
+              type: string
+            type:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_bigtableinstances.bigtable.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_bigtableinstances.bigtable.cnrm.cloud.google.com.yaml
@@ -1,0 +1,98 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: bigtableinstances.bigtable.cnrm.cloud.google.com
+spec:
+  group: bigtable.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: BigtableInstance
+    plural: bigtableinstances
+    shortNames:
+    - gcpbigtableinstance
+    - gcpbigtableinstances
+    singular: bigtableinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            cluster:
+              items:
+                properties:
+                  clusterId:
+                    type: string
+                  numNodes:
+                    type: integer
+                  storageType:
+                    type: string
+                  zone:
+                    type: string
+                required:
+                - clusterId
+                - zone
+                type: object
+              type: array
+            displayName:
+              type: string
+            instanceType:
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com.yaml
@@ -1,0 +1,398 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com
+spec:
+  group: cloudbuild.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: CloudBuildTrigger
+    plural: cloudbuildtriggers
+    shortNames:
+    - gcpcloudbuildtrigger
+    - gcpcloudbuildtriggers
+    singular: cloudbuildtrigger
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            build:
+              description: Contents of the build template. Either a filename or build
+                template must be provided.
+              properties:
+                images:
+                  description: |-
+                    A list of images to be pushed upon the successful completion of all build steps.
+                    The images are pushed using the builder service account's credentials.
+                    The digests of the pushed images will be stored in the Build resource's results field.
+                    If any of the images fail to be pushed, the build status is marked FAILURE.
+                  items:
+                    type: string
+                  type: array
+                step:
+                  description: The operations to be performed on the workspace.
+                  items:
+                    properties:
+                      args:
+                        description: |-
+                          A list of arguments that will be presented to the step when it is started.
+
+                          If the image used to run the step's container has an entrypoint, the args
+                          are used as arguments to that entrypoint. If the image does not define an
+                          entrypoint, the first element in args is used as the entrypoint, and the
+                          remainder will be used as arguments.
+                        items:
+                          type: string
+                        type: array
+                      dir:
+                        description: |-
+                          Working directory to use when running this step's container.
+
+                          If this value is a relative path, it is relative to the build's working
+                          directory. If this value is absolute, it may be outside the build's working
+                          directory, in which case the contents of the path may not be persisted
+                          across build step executions, unless a 'volume' for that path is specified.
+
+                          If the build specifies a 'RepoSource' with 'dir' and a step with a
+                          'dir',
+                          which specifies an absolute path, the 'RepoSource' 'dir' is ignored
+                          for the step's execution.
+                        type: string
+                      entrypoint:
+                        description: |-
+                          Entrypoint to be used instead of the build step image's
+                          default entrypoint.
+                          If unset, the image's default entrypoint is used
+                        type: string
+                      env:
+                        description: |-
+                          A list of environment variable definitions to be used when
+                          running a step.
+
+                          The elements are of the form "KEY=VALUE" for the environment variable
+                          "KEY" being given the value "VALUE".
+                        items:
+                          type: string
+                        type: array
+                      id:
+                        description: |-
+                          Unique identifier for this build step, used in 'wait_for' to
+                          reference this build step as a dependency.
+                        type: string
+                      name:
+                        description: |-
+                          The name of the container image that will run this particular build step.
+
+                          If the image is available in the host's Docker daemon's cache, it will be
+                          run directly. If not, the host will attempt to pull the image first, using
+                          the builder service account's credentials if necessary.
+
+                          The Docker daemon's cache will already have the latest versions of all of
+                          the officially supported build steps (https://github.com/GoogleCloudPlatform/cloud-builders).
+                          The Docker daemon will also have cached many of the layers for some popular
+                          images, like "ubuntu", "debian", but they will be refreshed at the time
+                          you attempt to use them.
+
+                          If you built an image in a previous build step, it will be stored in the
+                          host's Docker daemon's cache and is available to use as the name for a
+                          later build step.
+                        type: string
+                      secretEnv:
+                        description: |-
+                          A list of environment variables which are encrypted using
+                          a Cloud Key
+                          Management Service crypto key. These values must be specified in
+                          the build's 'Secret'.
+                        items:
+                          type: string
+                        type: array
+                      timeout:
+                        description: |-
+                          Time limit for executing this build step. If not defined,
+                          the step has no
+                          time limit and will be allowed to continue to run until either it
+                          completes or the build itself times out.
+                        type: string
+                      timing:
+                        description: |-
+                          Output only. Stores timing information for executing this
+                          build step.
+                        type: string
+                      volumes:
+                        description: |-
+                          List of volumes to mount into the build step.
+
+                          Each volume is created as an empty volume prior to execution of the
+                          build step. Upon completion of the build, volumes and their contents
+                          are discarded.
+
+                          Using a named volume in only one step is not valid as it is
+                          indicative of a build request with an incorrect configuration.
+                        items:
+                          properties:
+                            name:
+                              description: |-
+                                Name of the volume to mount.
+
+                                Volume names must be unique per build step and must be valid names for
+                                Docker volumes. Each named volume must be used by at least two build steps.
+                              type: string
+                            path:
+                              description: |-
+                                Path at which to mount the volume.
+
+                                Paths must be absolute and cannot conflict with other volume paths on
+                                the same build step or with certain reserved volume paths.
+                              type: string
+                          required:
+                          - name
+                          - path
+                          type: object
+                        type: array
+                      waitFor:
+                        description: |-
+                          The ID(s) of the step(s) that this build step depends on.
+
+                          This build step will not start until all the build steps in 'wait_for'
+                          have completed successfully. If 'wait_for' is empty, this build step
+                          will start when all previous build steps in the 'Build.Steps' list
+                          have completed successfully.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - name
+                    type: object
+                  type: array
+                tags:
+                  description: Tags for annotation of a Build. These are not docker
+                    tags.
+                  items:
+                    type: string
+                  type: array
+                timeout:
+                  description: |-
+                    Amount of time that this build should be allowed to run, to second granularity.
+                    If this amount of time elapses, work on the build will cease and the build status will be TIMEOUT.
+                    This timeout must be equal to or greater than the sum of the timeouts for build steps within the build.
+                    The expected format is the number of seconds followed by s.
+                    Default time is ten minutes (600s).
+                  type: string
+              required:
+              - step
+              type: object
+            description:
+              description: Human-readable description of the trigger.
+              type: string
+            disabled:
+              description: Whether the trigger is disabled or not. If true, the trigger
+                will never result in a build.
+              type: boolean
+            filename:
+              description: Path, from the source root, to a file whose contents is
+                used for the template. Either a filename or build template must be
+                provided.
+              type: string
+            github:
+              description: |-
+                Describes the configuration of a trigger that creates a build whenever a GitHub event is received.
+
+                One of 'trigger_template' or 'github' must be provided.
+              properties:
+                name:
+                  description: |-
+                    Name of the repository. For example: The name for
+                    https://github.com/googlecloudplatform/cloud-builders is "cloud-builders".
+                  type: string
+                owner:
+                  description: |-
+                    Owner of the repository. For example: The owner for
+                    https://github.com/googlecloudplatform/cloud-builders is "googlecloudplatform".
+                  type: string
+                pullRequest:
+                  description: filter to match changes in pull requests.  Specify
+                    only one of pullRequest or push.
+                  properties:
+                    branch:
+                      description: Regex of branches to match.
+                      type: string
+                    commentControl:
+                      description: Whether to block builds on a "/gcbrun" comment
+                        from a repository owner or collaborator.
+                      type: string
+                  required:
+                  - branch
+                  type: object
+                push:
+                  description: filter to match changes in refs, like branches or tags.  Specify
+                    only one of pullRequest or push.
+                  properties:
+                    branch:
+                      description: Regex of branches to match.  Specify only one of
+                        branch or tag.
+                      type: string
+                    tag:
+                      description: Regex of tags to match.  Specify only one of branch
+                        or tag.
+                      type: string
+                  type: object
+              type: object
+            ignoredFiles:
+              description: |-
+                ignoredFiles and includedFiles are file glob matches using http://godoc/pkg/path/filepath#Match
+                extended with support for '**'.
+
+                If ignoredFiles and changed files are both empty, then they are not
+                used to determine whether or not to trigger a build.
+
+                If ignoredFiles is not empty, then we ignore any files that match any
+                of the ignored_file globs. If the change has no files that are outside
+                of the ignoredFiles globs, then we do not trigger a build.
+              items:
+                type: string
+              type: array
+            includedFiles:
+              description: |-
+                ignoredFiles and includedFiles are file glob matches using http://godoc/pkg/path/filepath#Match
+                extended with support for '**'.
+
+                If any of the files altered in the commit pass the ignoredFiles filter
+                and includedFiles is empty, then as far as this filter is concerned, we
+                should trigger the build.
+
+                If any of the files altered in the commit pass the ignoredFiles filter
+                and includedFiles is not empty, then we make sure that at least one of
+                those files matches a includedFiles glob. If not, then we do not trigger
+                a build.
+              items:
+                type: string
+              type: array
+            substitutions:
+              additionalProperties:
+                type: string
+              description: Substitutions data for Build resource.
+              type: object
+            triggerTemplate:
+              description: |-
+                Template describing the types of source changes to trigger a build.
+
+                Branch and tag names in trigger templates are interpreted as regular
+                expressions. Any branch or tag change that matches that regular
+                expression will trigger a build.
+
+                One of 'trigger_template' or 'github' must be provided.
+              properties:
+                branchName:
+                  description: |-
+                    Name of the branch to build. Exactly one a of branch name, tag, or commit SHA must be provided.
+                    This field is a regular expression.
+                  type: string
+                commitSha:
+                  description: Explicit commit SHA to build. Exactly one of a branch
+                    name, tag, or commit SHA must be provided.
+                  type: string
+                dir:
+                  description: |-
+                    Directory, relative to the source root, in which to run the build.
+
+                    This must be a relative path. If a step's dir is specified and
+                    is an absolute path, this value is ignored for that step's
+                    execution.
+                  type: string
+                repoRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                tagName:
+                  description: |-
+                    Name of the tag to build. Exactly one of a branch name, tag, or commit SHA must be provided.
+                    This field is a regular expression.
+                  type: string
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            createTime:
+              description: Time when the trigger was created.
+              type: string
+            triggerId:
+              description: The unique identifier for the trigger.
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeaddresses.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeaddresses.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,191 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeaddresses.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeAddress
+    plural: computeaddresses
+    shortNames:
+    - gcpcomputeaddress
+    - gcpcomputeaddresses
+    singular: computeaddress
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            address:
+              description: |-
+                The static external IP address represented by this resource. Only
+                IPv4 is supported. An address may only be specified for INTERNAL
+                address types. The IP address must be inside the specified subnetwork,
+                if any.
+              type: string
+            addressType:
+              description: |-
+                The type of address to reserve, either INTERNAL or EXTERNAL.
+                If unspecified, defaults to EXTERNAL.
+              type: string
+            description:
+              description: An optional description of this resource.
+              type: string
+            ipVersion:
+              description: |-
+                The IP Version that will be used by this address. Valid options are
+                'IPV4' or 'IPV6'. The default value is 'IPV4'.
+              type: string
+            location:
+              description: 'Location represents the geographical location of the ComputeAddress.
+                Specify a region name or "global" for global resources. Reference:
+                GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            networkTier:
+              description: |-
+                The networking tier used for configuring this address. This field can
+                take the following values: PREMIUM or STANDARD. If this field is not
+                specified, it is assumed to be PREMIUM.
+              type: string
+            prefixLength:
+              description: |-
+                The prefix length of the IP range. If not present, it means the
+                address field is a single IP address.
+
+                This field is not applicable to addresses with addressType=EXTERNAL.
+              type: integer
+            purpose:
+              description: |-
+                The purpose of this resource, which can be one of the following values:
+
+                - GCE_ENDPOINT for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
+
+                This should only be set when using an Internal address.
+              type: string
+            subnetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource.  Used
+                internally during updates.
+              type: string
+            selfLink:
+              type: string
+            users:
+              description: The URLs of the resources that are using this address.
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computebackendbuckets.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computebackendbuckets.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,137 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computebackendbuckets.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeBackendBucket
+    plural: computebackendbuckets
+    shortNames:
+    - gcpcomputebackendbucket
+    - gcpcomputebackendbuckets
+    singular: computebackendbucket
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bucketRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            cdnPolicy:
+              description: Cloud CDN configuration for this Backend Bucket.
+              properties:
+                signedUrlCacheMaxAgeSec:
+                  description: |-
+                    Maximum number of seconds the response to a signed URL request will
+                    be considered fresh. After this time period,
+                    the response will be revalidated before being served.
+                    When serving responses to signed URL requests,
+                    Cloud CDN will internally behave as though
+                    all responses from this backend had a "Cache-Control: public,
+                    max-age=[TTL]" header, regardless of any existing Cache-Control
+                    header. The actual headers served in responses will not be altered.
+                  type: integer
+              required:
+              - signedUrlCacheMaxAgeSec
+              type: object
+            description:
+              description: |-
+                An optional textual description of the resource; provided by the
+                client when the resource is created.
+              type: string
+            enableCdn:
+              description: If true, enable Cloud CDN for this BackendBucket.
+              type: boolean
+          required:
+          - bucketRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computebackendservices.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computebackendservices.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,810 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computebackendservices.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeBackendService
+    plural: computebackendservices
+    shortNames:
+    - gcpcomputebackendservice
+    - gcpcomputebackendservices
+    singular: computebackendservice
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            affinityCookieTtlSec:
+              description: |-
+                Lifetime of cookies in seconds if session_affinity is
+                GENERATED_COOKIE. If set to 0, the cookie is non-persistent and lasts
+                only until the end of the browser session (or equivalent). The
+                maximum allowed value for TTL is one day.
+
+                When the load balancing scheme is INTERNAL, this field is not used.
+              type: integer
+            backend:
+              description: The set of backends that serve this BackendService.
+              items:
+                properties:
+                  balancingMode:
+                    description: |-
+                      Specifies the balancing mode for this backend.
+
+                      For global HTTP(S) or TCP/SSL load balancing, the default is
+                      UTILIZATION. Valid values are UTILIZATION, RATE (for HTTP(S))
+                      and CONNECTION (for TCP/SSL).
+                    type: string
+                  capacityScaler:
+                    description: |-
+                      A multiplier applied to the group's maximum servicing capacity
+                      (based on UTILIZATION, RATE or CONNECTION).
+
+                      Default value is 1, which means the group will serve up to 100%
+                      of its configured capacity (depending on balancingMode). A
+                      setting of 0 means the group is completely drained, offering
+                      0% of its available Capacity. Valid range is [0.0,1.0].
+                    type: number
+                  description:
+                    description: |-
+                      An optional description of this resource.
+                      Provide this property when you create the resource.
+                    type: string
+                  group:
+                    properties:
+                      instanceGroupRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                      networkEndpointGroupRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                    type: object
+                  maxConnections:
+                    description: |-
+                      The max number of simultaneous connections for the group. Can
+                      be used with either CONNECTION or UTILIZATION balancing modes.
+
+                      For CONNECTION mode, either maxConnections or one
+                      of maxConnectionsPerInstance or maxConnectionsPerEndpoint,
+                      as appropriate for group type, must be set.
+                    type: integer
+                  maxConnectionsPerEndpoint:
+                    description: |-
+                      The max number of simultaneous connections that a single backend
+                      network endpoint can handle. This is used to calculate the
+                      capacity of the group. Can be used in either CONNECTION or
+                      UTILIZATION balancing modes.
+
+                      For CONNECTION mode, either
+                      maxConnections or maxConnectionsPerEndpoint must be set.
+                    type: integer
+                  maxConnectionsPerInstance:
+                    description: |-
+                      The max number of simultaneous connections that a single
+                      backend instance can handle. This is used to calculate the
+                      capacity of the group. Can be used in either CONNECTION or
+                      UTILIZATION balancing modes.
+
+                      For CONNECTION mode, either maxConnections or
+                      maxConnectionsPerInstance must be set.
+                    type: integer
+                  maxRate:
+                    description: |-
+                      The max requests per second (RPS) of the group.
+
+                      Can be used with either RATE or UTILIZATION balancing modes,
+                      but required if RATE mode. For RATE mode, either maxRate or one
+                      of maxRatePerInstance or maxRatePerEndpoint, as appropriate for
+                      group type, must be set.
+                    type: integer
+                  maxRatePerEndpoint:
+                    description: |-
+                      The max requests per second (RPS) that a single backend network
+                      endpoint can handle. This is used to calculate the capacity of
+                      the group. Can be used in either balancing mode. For RATE mode,
+                      either maxRate or maxRatePerEndpoint must be set.
+                    type: number
+                  maxRatePerInstance:
+                    description: |-
+                      The max requests per second (RPS) that a single backend
+                      instance can handle. This is used to calculate the capacity of
+                      the group. Can be used in either balancing mode. For RATE mode,
+                      either maxRate or maxRatePerInstance must be set.
+                    type: number
+                  maxUtilization:
+                    description: |-
+                      Used when balancingMode is UTILIZATION. This ratio defines the
+                      CPU utilization target for the group. The default is 0.8. Valid
+                      range is [0.0, 1.0].
+                    type: number
+                required:
+                - group
+                type: object
+              type: array
+            cdnPolicy:
+              description: Cloud CDN configuration for this BackendService.
+              properties:
+                cacheKeyPolicy:
+                  description: The CacheKeyPolicy for this CdnPolicy.
+                  properties:
+                    includeHost:
+                      description: If true requests to different hosts will be cached
+                        separately.
+                      type: boolean
+                    includeProtocol:
+                      description: If true, http and https requests will be cached
+                        separately.
+                      type: boolean
+                    includeQueryString:
+                      description: |-
+                        If true, include query string parameters in the cache key
+                        according to query_string_whitelist and
+                        query_string_blacklist. If neither is set, the entire query
+                        string will be included.
+
+                        If false, the query string will be excluded from the cache
+                        key entirely.
+                      type: boolean
+                    queryStringBlacklist:
+                      description: |-
+                        Names of query string parameters to exclude in cache keys.
+
+                        All other parameters will be included. Either specify
+                        query_string_whitelist or query_string_blacklist, not both.
+                        '&' and '=' will be percent encoded and not treated as
+                        delimiters.
+                      items:
+                        type: string
+                      type: array
+                    queryStringWhitelist:
+                      description: |-
+                        Names of query string parameters to include in cache keys.
+
+                        All other parameters will be excluded. Either specify
+                        query_string_whitelist or query_string_blacklist, not both.
+                        '&' and '=' will be percent encoded and not treated as
+                        delimiters.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                signedUrlCacheMaxAgeSec:
+                  description: |-
+                    Maximum number of seconds the response to a signed URL request
+                    will be considered fresh, defaults to 1hr (3600s). After this
+                    time period, the response will be revalidated before
+                    being served.
+
+                    When serving responses to signed URL requests, Cloud CDN will
+                    internally behave as though all responses from this backend had a
+                    "Cache-Control: public, max-age=[TTL]" header, regardless of any
+                    existing Cache-Control header. The actual headers served in
+                    responses will not be altered.
+                  type: integer
+              type: object
+            circuitBreakers:
+              description: |-
+                Settings controlling the volume of connections to a backend service. This field
+                is applicable only when the load_balancing_scheme is set to INTERNAL_SELF_MANAGED.
+              properties:
+                connectTimeout:
+                  description: The timeout for new network connections to hosts.
+                  properties:
+                    nanos:
+                      description: |-
+                        Span of time that's a fraction of a second at nanosecond
+                        resolution. Durations less than one second are represented
+                        with a 0 seconds field and a positive nanos field. Must
+                        be from 0 to 999,999,999 inclusive.
+                      type: integer
+                    seconds:
+                      description: |-
+                        Span of time at a resolution of a second.
+                        Must be from 0 to 315,576,000,000 inclusive.
+                      type: integer
+                  required:
+                  - seconds
+                  type: object
+                maxConnections:
+                  description: |-
+                    The maximum number of connections to the backend cluster.
+                    Defaults to 1024.
+                  type: integer
+                maxPendingRequests:
+                  description: |-
+                    The maximum number of pending requests to the backend cluster.
+                    Defaults to 1024.
+                  type: integer
+                maxRequests:
+                  description: |-
+                    The maximum number of parallel requests to the backend cluster.
+                    Defaults to 1024.
+                  type: integer
+                maxRequestsPerConnection:
+                  description: |-
+                    Maximum requests for a single backend connection. This parameter
+                    is respected by both the HTTP/1.1 and HTTP/2 implementations. If
+                    not specified, there is no limit. Setting this parameter to 1
+                    will effectively disable keep alive.
+                  type: integer
+                maxRetries:
+                  description: |-
+                    The maximum number of parallel retries to the backend cluster.
+                    Defaults to 3.
+                  type: integer
+              type: object
+            connectionDrainingTimeoutSec:
+              description: |-
+                Time for which instance will be drained (not accept new
+                connections, but still work to finish started).
+              type: integer
+            consistentHash:
+              description: |-
+                Consistent Hash-based load balancing can be used to provide soft session
+                affinity based on HTTP headers, cookies or other properties. This load balancing
+                policy is applicable only for HTTP connections. The affinity to a particular
+                destination host will be lost when one or more hosts are added/removed from the
+                destination service. This field specifies parameters that control consistent
+                hashing. This field only applies if the load_balancing_scheme is set to
+                INTERNAL_SELF_MANAGED. This field is only applicable when locality_lb_policy is
+                set to MAGLEV or RING_HASH.
+              properties:
+                httpCookie:
+                  description: |-
+                    Hash is based on HTTP Cookie. This field describes a HTTP cookie
+                    that will be used as the hash key for the consistent hash load
+                    balancer. If the cookie is not present, it will be generated.
+                    This field is applicable if the sessionAffinity is set to HTTP_COOKIE.
+                  properties:
+                    name:
+                      description: Name of the cookie.
+                      type: string
+                    path:
+                      description: Path to set for the cookie.
+                      type: string
+                    ttl:
+                      description: Lifetime of the cookie.
+                      properties:
+                        nanos:
+                          description: |-
+                            Span of time that's a fraction of a second at nanosecond
+                            resolution. Durations less than one second are represented
+                            with a 0 seconds field and a positive nanos field. Must
+                            be from 0 to 999,999,999 inclusive.
+                          type: integer
+                        seconds:
+                          description: |-
+                            Span of time at a resolution of a second.
+                            Must be from 0 to 315,576,000,000 inclusive.
+                          type: integer
+                      required:
+                      - seconds
+                      type: object
+                  type: object
+                httpHeaderName:
+                  description: |-
+                    The hash based on the value of the specified header field.
+                    This field is applicable if the sessionAffinity is set to HEADER_FIELD.
+                  type: string
+                minimumRingSize:
+                  description: |-
+                    The minimum number of virtual nodes to use for the hash ring.
+                    Larger ring sizes result in more granular load
+                    distributions. If the number of hosts in the load balancing pool
+                    is larger than the ring size, each host will be assigned a single
+                    virtual node.
+                    Defaults to 1024.
+                  type: integer
+              type: object
+            customRequestHeaders:
+              description: |-
+                Headers that the HTTP/S load balancer should add to proxied
+                requests.
+              items:
+                type: string
+              type: array
+            description:
+              description: An optional description of this resource.
+              type: string
+            enableCdn:
+              description: If true, enable Cloud CDN for this BackendService.
+              type: boolean
+            failoverPolicy:
+              description: Policy for failovers.
+              properties:
+                disableConnectionDrainOnFailover:
+                  description: |-
+                    On failover or failback, this field indicates whether connection drain
+                    will be honored. Setting this to true has the following effect: connections
+                    to the old active pool are not drained. Connections to the new active pool
+                    use the timeout of 10 min (currently fixed). Setting to false has the
+                    following effect: both old and new connections will have a drain timeout
+                    of 10 min.
+                    This can be set to true only if the protocol is TCP.
+                    The default is false.
+                  type: boolean
+                dropTrafficIfUnhealthy:
+                  description: |-
+                    This option is used only when no healthy VMs are detected in the primary
+                    and backup instance groups. When set to true, traffic is dropped. When
+                    set to false, new connections are sent across all VMs in the primary group.
+                    The default is false.
+                  type: boolean
+                failoverRatio:
+                  description: |-
+                    The value of the field must be in [0, 1]. If the ratio of the healthy
+                    VMs in the primary backend is at or below this number, traffic arriving
+                    at the load-balanced IP will be directed to the failover backend.
+                    In case where 'failoverRatio' is not set or all the VMs in the backup
+                    backend are unhealthy, the traffic will be directed back to the primary
+                    backend in the "force" mode, where traffic will be spread to the healthy
+                    VMs with the best effort, or to all VMs when no VM is healthy.
+                    This field is only used with l4 load balancing.
+                  type: number
+              type: object
+            healthChecks:
+              items:
+                properties:
+                  healthCheckRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  httpHealthCheckRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                type: object
+              type: array
+            iap:
+              description: Settings for enabling Cloud Identity Aware Proxy
+              properties:
+                oauth2ClientId:
+                  description: OAuth2 Client ID for IAP
+                  type: string
+                oauth2ClientSecret:
+                  description: OAuth2 Client Secret for IAP
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                oauth2ClientSecretSha256:
+                  description: OAuth2 Client Secret SHA-256 for IAP
+                  type: string
+              required:
+              - oauth2ClientId
+              - oauth2ClientSecret
+              type: object
+            loadBalancingScheme:
+              description: |-
+                Indicates whether the backend service will be used with internal or
+                external load balancing. A backend service created for one type of
+                load balancing cannot be used with the other. Must be 'EXTERNAL' or
+                'INTERNAL_SELF_MANAGED' for a global backend service. Defaults to 'EXTERNAL'.
+              type: string
+            localityLbPolicy:
+              description: |-
+                The load balancing algorithm used within the scope of the locality.
+                The possible values are -
+
+                ROUND_ROBIN - This is a simple policy in which each healthy backend
+                              is selected in round robin order.
+
+                LEAST_REQUEST - An O(1) algorithm which selects two random healthy
+                                hosts and picks the host which has fewer active requests.
+
+                RING_HASH - The ring/modulo hash load balancer implements consistent
+                            hashing to backends. The algorithm has the property that the
+                            addition/removal of a host from a set of N hosts only affects
+                            1/N of the requests.
+
+                RANDOM - The load balancer selects a random healthy host.
+
+                ORIGINAL_DESTINATION - Backend host is selected based on the client
+                                       connection metadata, i.e., connections are opened
+                                       to the same address as the destination address of
+                                       the incoming connection before the connection
+                                       was redirected to the load balancer.
+
+                MAGLEV - used as a drop in replacement for the ring hash load balancer.
+                         Maglev is not as stable as ring hash but has faster table lookup
+                         build times and host selection times. For more information about
+                         Maglev, refer to https://ai.google/research/pubs/pub44824
+
+                This field is applicable only when the load_balancing_scheme is set to
+                INTERNAL_SELF_MANAGED.
+              type: string
+            location:
+              description: 'Location represents the geographical location of the ComputeBackendService.
+                Specify a region name or "global" for global resources. Reference:
+                GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            logConfig:
+              description: |-
+                This field denotes the logging options for the load balancer traffic served by this backend service.
+                If logging is enabled, logs will be exported to Stackdriver.
+              properties:
+                enable:
+                  description: Whether to enable logging for the load balancer traffic
+                    served by this backend service.
+                  type: boolean
+                sampleRate:
+                  description: |-
+                    This field can only be specified if logging is enabled for this backend service. The value of
+                    the field must be in [0, 1]. This configures the sampling rate of requests to the load balancer
+                    where 1.0 means all logged requests are reported and 0.0 means no logged requests are reported.
+                    The default value is 1.0.
+                  type: number
+              type: object
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            outlierDetection:
+              description: |-
+                Settings controlling eviction of unhealthy hosts from the load balancing pool.
+                This field is applicable only when the load_balancing_scheme is set
+                to INTERNAL_SELF_MANAGED.
+              properties:
+                baseEjectionTime:
+                  description: |-
+                    The base time that a host is ejected for. The real time is equal to the base
+                    time multiplied by the number of times the host has been ejected. Defaults to
+                    30000ms or 30s.
+                  properties:
+                    nanos:
+                      description: |-
+                        Span of time that's a fraction of a second at nanosecond resolution. Durations
+                        less than one second are represented with a 0 'seconds' field and a positive
+                        'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                      type: integer
+                    seconds:
+                      description: |-
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                        inclusive.
+                      type: integer
+                  required:
+                  - seconds
+                  type: object
+                consecutiveErrors:
+                  description: |-
+                    Number of errors before a host is ejected from the connection pool. When the
+                    backend host is accessed over HTTP, a 5xx return code qualifies as an error.
+                    Defaults to 5.
+                  type: integer
+                consecutiveGatewayFailure:
+                  description: |-
+                    The number of consecutive gateway failures (502, 503, 504 status or connection
+                    errors that are mapped to one of those status codes) before a consecutive
+                    gateway failure ejection occurs. Defaults to 5.
+                  type: integer
+                enforcingConsecutiveErrors:
+                  description: |-
+                    The percentage chance that a host will be actually ejected when an outlier
+                    status is detected through consecutive 5xx. This setting can be used to disable
+                    ejection or to ramp it up slowly. Defaults to 100.
+                  type: integer
+                enforcingConsecutiveGatewayFailure:
+                  description: |-
+                    The percentage chance that a host will be actually ejected when an outlier
+                    status is detected through consecutive gateway failures. This setting can be
+                    used to disable ejection or to ramp it up slowly. Defaults to 0.
+                  type: integer
+                enforcingSuccessRate:
+                  description: |-
+                    The percentage chance that a host will be actually ejected when an outlier
+                    status is detected through success rate statistics. This setting can be used to
+                    disable ejection or to ramp it up slowly. Defaults to 100.
+                  type: integer
+                interval:
+                  description: |-
+                    Time interval between ejection sweep analysis. This can result in both new
+                    ejections as well as hosts being returned to service. Defaults to 10 seconds.
+                  properties:
+                    nanos:
+                      description: |-
+                        Span of time that's a fraction of a second at nanosecond resolution. Durations
+                        less than one second are represented with a 0 'seconds' field and a positive
+                        'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                      type: integer
+                    seconds:
+                      description: |-
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                        inclusive.
+                      type: integer
+                  required:
+                  - seconds
+                  type: object
+                maxEjectionPercent:
+                  description: |-
+                    Maximum percentage of hosts in the load balancing pool for the backend service
+                    that can be ejected. Defaults to 10%.
+                  type: integer
+                successRateMinimumHosts:
+                  description: |-
+                    The number of hosts in a cluster that must have enough request volume to detect
+                    success rate outliers. If the number of hosts is less than this setting, outlier
+                    detection via success rate statistics is not performed for any host in the
+                    cluster. Defaults to 5.
+                  type: integer
+                successRateRequestVolume:
+                  description: |-
+                    The minimum number of total requests that must be collected in one interval (as
+                    defined by the interval duration above) to include this host in success rate
+                    based outlier detection. If the volume is lower than this setting, outlier
+                    detection via success rate statistics is not performed for that host. Defaults
+                    to 100.
+                  type: integer
+                successRateStdevFactor:
+                  description: |-
+                    This factor is used to determine the ejection threshold for success rate outlier
+                    ejection. The ejection threshold is the difference between the mean success
+                    rate, and the product of this factor and the standard deviation of the mean
+                    success rate: mean - (stdev * success_rate_stdev_factor). This factor is divided
+                    by a thousand to get a double. That is, if the desired factor is 1.9, the
+                    runtime value should be 1900. Defaults to 1900.
+                  type: integer
+              type: object
+            portName:
+              description: |-
+                Name of backend port. The same name should appear in the instance
+                groups referenced by this service. Required when the load balancing
+                scheme is EXTERNAL.
+              type: string
+            protocol:
+              description: |-
+                The protocol this BackendService uses to communicate with backends.
+                Possible values are HTTP, HTTPS, HTTP2, TCP, and SSL. The default is
+                HTTP. **NOTE**: HTTP2 is only valid for beta HTTP/2 load balancer
+                types and may result in errors if used with the GA API.
+              type: string
+            securityPolicyRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            sessionAffinity:
+              description: |-
+                Type of session affinity to use. The default is NONE. Session affinity is
+                not applicable if the protocol is UDP.
+              type: string
+            timeoutSec:
+              description: |-
+                How many seconds to wait for the backend before considering it a
+                failed request. Default is 30 seconds. Valid range is [1, 86400].
+              type: integer
+          required:
+          - healthChecks
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            fingerprint:
+              description: |-
+                Fingerprint of this resource. A hash of the contents stored in this
+                object. This field is used in optimistic locking.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computedisks.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computedisks.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,405 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computedisks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeDisk
+    plural: computedisks
+    shortNames:
+    - gcpcomputedisk
+    - gcpcomputedisks
+    singular: computedisk
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            diskEncryptionKey:
+              description: |-
+                Encrypts the disk using a customer-supplied encryption key.
+
+                After you encrypt a disk with a customer-supplied key, you must
+                provide the same key if you use the disk later (e.g. to create a disk
+                snapshot or an image, or to attach the disk to a virtual machine).
+
+                Customer-supplied encryption keys do not protect access to metadata of
+                the disk.
+
+                If you do not provide an encryption key when creating the disk, then
+                the disk will be encrypted using an automatically generated key and
+                you do not need to provide a key to use the disk later.
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                rawKey:
+                  description: |-
+                    Specifies a 256-bit customer-supplied encryption key, encoded in
+                    RFC 4648 base64 to either encrypt or decrypt this resource.
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                sha256:
+                  description: |-
+                    The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
+                    encryption key that protects this resource.
+                  type: string
+              type: object
+            imageRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            location:
+              description: 'Location represents the geographical location of the ComputeDisk.
+                Specify a region name or a zone name. Reference: GCP definition of
+                regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            physicalBlockSizeBytes:
+              description: |-
+                Physical block size of the persistent disk, in bytes. If not present
+                in a request, a default value is used. Currently supported sizes
+                are 4096 and 16384, other sizes may be added in the future.
+                If an unsupported value is requested, the error message will list
+                the supported values for the caller's project.
+              type: integer
+            replicaZones:
+              description: URLs of the zones where the disk should be replicated to.
+              items:
+                type: string
+              type: array
+            resourcePolicies:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            size:
+              description: |-
+                Size of the persistent disk, specified in GB. You can specify this
+                field when creating a persistent disk using the 'image' or
+                'snapshot' parameter, or specify it alone to create an empty
+                persistent disk.
+
+                If you specify this field along with 'image' or 'snapshot',
+                the value must not be less than the size of the image
+                or the size of the snapshot.
+              type: integer
+            snapshotRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            sourceImageEncryptionKey:
+              description: |-
+                The customer-supplied encryption key of the source image. Required if
+                the source image is protected by a customer-supplied encryption key.
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                rawKey:
+                  description: |-
+                    Specifies a 256-bit customer-supplied encryption key, encoded in
+                    RFC 4648 base64 to either encrypt or decrypt this resource.
+                  type: string
+                sha256:
+                  description: |-
+                    The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
+                    encryption key that protects this resource.
+                  type: string
+              type: object
+            sourceSnapshotEncryptionKey:
+              description: |-
+                The customer-supplied encryption key of the source snapshot. Required
+                if the source snapshot is protected by a customer-supplied encryption
+                key.
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                rawKey:
+                  description: |-
+                    Specifies a 256-bit customer-supplied encryption key, encoded in
+                    RFC 4648 base64 to either encrypt or decrypt this resource.
+                  type: string
+                sha256:
+                  description: |-
+                    The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
+                    encryption key that protects this resource.
+                  type: string
+              type: object
+            type:
+              description: |-
+                URL of the disk type resource describing which disk type to use to
+                create the disk. Provide this when creating the disk.
+              type: string
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource.  Used
+                internally during updates.
+              type: string
+            lastAttachTimestamp:
+              description: Last attach timestamp in RFC3339 text format.
+              type: string
+            lastDetachTimestamp:
+              description: Last detach timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+            sourceImageId:
+              description: |-
+                The ID value of the image used to create this disk. This value
+                identifies the exact image that was used to create this persistent
+                disk. For example, if you created the persistent disk from an image
+                that was later deleted and recreated under the same name, the source
+                image ID would identify the exact version of the image that was used.
+              type: string
+            sourceSnapshotId:
+              description: |-
+                The unique ID of the snapshot used to create this disk. This value
+                identifies the exact snapshot that was used to create this persistent
+                disk. For example, if you created the persistent disk from a snapshot
+                that was later deleted and recreated under the same name, the source
+                snapshot ID would identify the exact version of the snapshot that was
+                used.
+              type: string
+            users:
+              description: |-
+                Links to the users of the disk (attached instances) in form:
+                project/zones/zone/instances/instance
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeexternalvpngateways.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeexternalvpngateways.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,107 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeexternalvpngateways.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeExternalVPNGateway
+    plural: computeexternalvpngateways
+    shortNames:
+    - gcpcomputeexternalvpngateway
+    - gcpcomputeexternalvpngateways
+    singular: computeexternalvpngateway
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            interface:
+              description: A list of interfaces on this external VPN gateway.
+              items:
+                properties:
+                  id:
+                    description: |-
+                      The numberic ID for this interface. Allowed values are based on the redundancy type
+                      of this external VPN gateway
+                      * '0 - SINGLE_IP_INTERNALLY_REDUNDANT'
+                      * '0, 1 - TWO_IPS_REDUNDANCY'
+                      * '0, 1, 2, 3 - FOUR_IPS_REDUNDANCY'
+                    type: integer
+                  ipAddress:
+                    description: |-
+                      IP address of the interface in the external VPN gateway.
+                      Only IPv4 is supported. This IP address can be either from
+                      your on-premise gateway or another Cloud provider’s VPN gateway,
+                      it cannot be an IP address from Google Compute Engine.
+                    type: string
+                type: object
+              type: array
+            redundancyType:
+              description: Indicates the redundancy type of this external VPN gateway
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computefirewalls.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computefirewalls.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,303 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computefirewalls.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeFirewall
+    plural: computefirewalls
+    shortNames:
+    - gcpcomputefirewall
+    - gcpcomputefirewalls
+    singular: computefirewall
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            allow:
+              description: |-
+                The list of ALLOW rules specified by this firewall. Each rule
+                specifies a protocol and port-range tuple that describes a permitted
+                connection.
+              items:
+                properties:
+                  ports:
+                    description: |-
+                      An optional list of ports to which this rule applies. This field
+                      is only applicable for UDP or TCP protocol. Each entry must be
+                      either an integer or a range. If not specified, this rule
+                      applies to connections through any port.
+
+                      Example inputs include: ["22"], ["80","443"], and
+                      ["12345-12349"].
+                    items:
+                      type: string
+                    type: array
+                  protocol:
+                    description: |-
+                      The IP protocol to which this rule applies. The protocol type is
+                      required when creating a firewall rule. This value can either be
+                      one of the following well known protocol strings (tcp, udp,
+                      icmp, esp, ah, sctp), or the IP protocol number.
+                    type: string
+                required:
+                - protocol
+                type: object
+              type: array
+            deny:
+              description: |-
+                The list of DENY rules specified by this firewall. Each rule specifies
+                a protocol and port-range tuple that describes a denied connection.
+              items:
+                properties:
+                  ports:
+                    description: |-
+                      An optional list of ports to which this rule applies. This field
+                      is only applicable for UDP or TCP protocol. Each entry must be
+                      either an integer or a range. If not specified, this rule
+                      applies to connections through any port.
+
+                      Example inputs include: ["22"], ["80","443"], and
+                      ["12345-12349"].
+                    items:
+                      type: string
+                    type: array
+                  protocol:
+                    description: |-
+                      The IP protocol to which this rule applies. The protocol type is
+                      required when creating a firewall rule. This value can either be
+                      one of the following well known protocol strings (tcp, udp,
+                      icmp, esp, ah, sctp), or the IP protocol number.
+                    type: string
+                required:
+                - protocol
+                type: object
+              type: array
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            destinationRanges:
+              description: |-
+                If destination ranges are specified, the firewall will apply only to
+                traffic that has destination IP address in these ranges. These ranges
+                must be expressed in CIDR format. Only IPv4 is supported.
+              items:
+                type: string
+              type: array
+            direction:
+              description: |-
+                Direction of traffic to which this firewall applies; default is
+                INGRESS. Note: For INGRESS traffic, it is NOT supported to specify
+                destinationRanges; For EGRESS traffic, it is NOT supported to specify
+                sourceRanges OR sourceTags.
+              type: string
+            disabled:
+              description: |-
+                Denotes whether the firewall rule is disabled, i.e not applied to the
+                network it is associated with. When set to true, the firewall rule is
+                not enforced and the network behaves as if it did not exist. If this
+                is unspecified, the firewall rule will be enabled.
+              type: boolean
+            enableLogging:
+              description: |-
+                This field denotes whether to enable logging for a particular
+                firewall rule. If logging is enabled, logs will be exported to
+                Stackdriver.
+              type: boolean
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            priority:
+              description: |-
+                Priority for this rule. This is an integer between 0 and 65535, both
+                inclusive. When not specified, the value assumed is 1000. Relative
+                priorities determine precedence of conflicting rules. Lower value of
+                priority implies higher precedence (eg, a rule with priority 0 has
+                higher precedence than a rule with priority 1). DENY rules take
+                precedence over ALLOW rules having equal priority.
+              type: integer
+            sourceRanges:
+              description: |-
+                If source ranges are specified, the firewall will apply only to
+                traffic that has source IP address in these ranges. These ranges must
+                be expressed in CIDR format. One or both of sourceRanges and
+                sourceTags may be set. If both properties are set, the firewall will
+                apply to traffic that has source IP address within sourceRanges OR the
+                source IP that belongs to a tag listed in the sourceTags property. The
+                connection does not need to match both properties for the firewall to
+                apply. Only IPv4 is supported.
+              items:
+                type: string
+              type: array
+            sourceServiceAccounts:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            sourceTags:
+              description: |-
+                If source tags are specified, the firewall will apply only to traffic
+                with source IP that belongs to a tag listed in source tags. Source
+                tags cannot be used to control traffic to an instance's external IP
+                address. Because tags are associated with an instance, not an IP
+                address. One or both of sourceRanges and sourceTags may be set. If
+                both properties are set, the firewall will apply to traffic that has
+                source IP address within sourceRanges OR the source IP that belongs to
+                a tag listed in the sourceTags property. The connection does not need
+                to match both properties for the firewall to apply.
+              items:
+                type: string
+              type: array
+            targetServiceAccounts:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            targetTags:
+              description: |-
+                A list of instance tags indicating sets of instances located in the
+                network that may make network connections as specified in allowed[].
+                If no targetTags are specified, the firewall rule applies to all
+                instances on the specified network.
+              items:
+                type: string
+              type: array
+          required:
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeforwardingrules.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeforwardingrules.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,440 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeforwardingrules.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeForwardingRule
+    plural: computeforwardingrules
+    shortNames:
+    - gcpcomputeforwardingrule
+    - gcpcomputeforwardingrules
+    singular: computeforwardingrule
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            allPorts:
+              description: |-
+                For internal TCP/UDP load balancing (i.e. load balancing scheme is
+                INTERNAL and protocol is TCP/UDP), set this to true to allow packets
+                addressed to any ports to be forwarded to the backends configured
+                with this forwarding rule. Used with backend service. Cannot be set
+                if port or portRange are set.
+              type: boolean
+            allowGlobalAccess:
+              description: |-
+                If true, clients can access ILB from all regions.
+                Otherwise only allows from the local region the ILB is located at.
+              type: boolean
+            backendServiceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            ipAddress:
+              properties:
+                addressRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                ip:
+                  type: string
+              type: object
+            ipProtocol:
+              description: |-
+                The IP protocol to which this rule applies. Valid options are TCP,
+                UDP, ESP, AH, SCTP or ICMP.
+
+                When the load balancing scheme is INTERNAL, only TCP and UDP are
+                valid.
+              type: string
+            ipVersion:
+              description: |-
+                The IP Version that will be used by this global forwarding rule.
+                Valid options are IPV4 or IPV6.
+              type: string
+            loadBalancingScheme:
+              description: |-
+                This signifies what the ForwardingRule will be used for and can be
+                EXTERNAL, INTERNAL, or INTERNAL_MANAGED. EXTERNAL is used for Classic
+                Cloud VPN gateways, protocol forwarding to VMs from an external IP address,
+                and HTTP(S), SSL Proxy, TCP Proxy, and Network TCP/UDP load balancers.
+                INTERNAL is used for protocol forwarding to VMs from an internal IP address,
+                and internal TCP/UDP load balancers.
+                INTERNAL_MANAGED is used for internal HTTP(S) load balancers.
+              type: string
+            location:
+              description: 'Location represents the geographical location of the ComputeForwardingRule.
+                Specify a region name or "global" for global resources. Reference:
+                GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            metadataFilters:
+              description: |-
+                Opaque filter criteria used by Loadbalancer to restrict routing
+                configuration to a limited set xDS compliant clients. In their xDS
+                requests to Loadbalancer, xDS clients present node metadata. If a
+                match takes place, the relevant routing configuration is made available
+                to those proxies.
+
+                For each metadataFilter in this list, if its filterMatchCriteria is set
+                to MATCH_ANY, at least one of the filterLabels must match the
+                corresponding label provided in the metadata. If its filterMatchCriteria
+                is set to MATCH_ALL, then all of its filterLabels must match with
+                corresponding labels in the provided metadata.
+
+                metadataFilters specified here can be overridden by those specified in
+                the UrlMap that this ForwardingRule references.
+
+                metadataFilters only applies to Loadbalancers that have their
+                loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+              items:
+                properties:
+                  filterLabels:
+                    description: |-
+                      The list of label value pairs that must match labels in the
+                      provided metadata based on filterMatchCriteria
+
+                      This list must not be empty and can have at the most 64 entries.
+                    items:
+                      properties:
+                        name:
+                          description: |-
+                            Name of the metadata label. The length must be between
+                            1 and 1024 characters, inclusive.
+                          type: string
+                        value:
+                          description: |-
+                            The value that the label must match. The value has a maximum
+                            length of 1024 characters.
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  filterMatchCriteria:
+                    description: |-
+                      Specifies how individual filterLabel matches within the list of
+                      filterLabels contribute towards the overall metadataFilter match.
+
+                      MATCH_ANY - At least one of the filterLabels must have a matching
+                      label in the provided metadata.
+                      MATCH_ALL - All filterLabels must have matching labels in the
+                      provided metadata.
+                    type: string
+                required:
+                - filterLabels
+                - filterMatchCriteria
+                type: object
+              type: array
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            networkTier:
+              description: |-
+                The networking tier used for configuring this address. This field can
+                take the following values: PREMIUM or STANDARD. If this field is not
+                specified, it is assumed to be PREMIUM.
+              type: string
+            portRange:
+              description: |-
+                This field is used along with the target field for TargetHttpProxy,
+                TargetHttpsProxy, TargetSslProxy, TargetTcpProxy, TargetVpnGateway,
+                TargetPool, TargetInstance.
+
+                Applicable only when IPProtocol is TCP, UDP, or SCTP, only packets
+                addressed to ports in the specified range will be forwarded to target.
+                Forwarding rules with the same [IPAddress, IPProtocol] pair must have
+                disjoint port ranges.
+
+                Some types of forwarding target have constraints on the acceptable
+                ports:
+
+                * TargetHttpProxy: 80, 8080
+                * TargetHttpsProxy: 443
+                * TargetTcpProxy: 25, 43, 110, 143, 195, 443, 465, 587, 700, 993, 995,
+                                  1883, 5222
+                * TargetSslProxy: 25, 43, 110, 143, 195, 443, 465, 587, 700, 993, 995,
+                                  1883, 5222
+                * TargetVpnGateway: 500, 4500
+              type: string
+            ports:
+              description: |-
+                This field is used along with the backend_service field for internal
+                load balancing.
+
+                When the load balancing scheme is INTERNAL, a single port or a comma
+                separated list of ports can be configured. Only packets addressed to
+                these ports will be forwarded to the backends configured with this
+                forwarding rule.
+
+                You may specify a maximum of up to 5 ports.
+              items:
+                type: string
+              type: array
+            serviceLabel:
+              description: |-
+                An optional prefix to the service name for this Forwarding Rule.
+                If specified, will be the first label of the fully qualified service
+                name.
+
+                The label must be 1-63 characters long, and comply with RFC1035.
+                Specifically, the label must be 1-63 characters long and match the
+                regular expression '[a-z]([-a-z0-9]*[a-z0-9])?' which means the first
+                character must be a lowercase letter, and all following characters
+                must be a dash, lowercase letter, or digit, except the last
+                character, which cannot be a dash.
+
+                This field is only used for INTERNAL load balancing.
+              type: string
+            subnetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            target:
+              properties:
+                targetHTTPProxyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                targetHTTPSProxyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                targetVPNGatewayRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              type: object
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource.  Used
+                internally during updates.
+              type: string
+            selfLink:
+              type: string
+            serviceName:
+              description: |-
+                The internal fully qualified service name for this Forwarding Rule.
+                This field is only used for INTERNAL load balancing.
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computehealthchecks.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computehealthchecks.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,377 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computehealthchecks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeHealthCheck
+    plural: computehealthchecks
+    shortNames:
+    - gcpcomputehealthcheck
+    - gcpcomputehealthchecks
+    singular: computehealthcheck
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            checkIntervalSec:
+              description: |-
+                How often (in seconds) to send a health check. The default value is 5
+                seconds.
+              type: integer
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            healthyThreshold:
+              description: |-
+                A so-far unhealthy instance will be marked healthy after this many
+                consecutive successes. The default value is 2.
+              type: integer
+            http2HealthCheck:
+              description: A nested object resource
+              properties:
+                host:
+                  description: |-
+                    The value of the host header in the HTTP2 health check request.
+                    If left empty (default value), the public IP on behalf of which this health
+                    check is performed will be used.
+                  type: string
+                port:
+                  description: |-
+                    The TCP port number for the HTTP2 health check request.
+                    The default value is 443.
+                  type: integer
+                portName:
+                  description: |-
+                    Port name as defined in InstanceGroup#NamedPort#name. If both port and
+                    port_name are defined, port takes precedence.
+                  type: string
+                portSpecification:
+                  description: |-
+                    Specifies how port is selected for health checking, can be one of the
+                    following values:
+
+                      * 'USE_FIXED_PORT': The port number in 'port' is used for health checking.
+
+                      * 'USE_NAMED_PORT': The 'portName' is used for health checking.
+
+                      * 'USE_SERVING_PORT': For NetworkEndpointGroup, the port specified for each
+                      network endpoint is used for health checking. For other backends, the
+                      port or named port specified in the Backend Service is used for health
+                      checking.
+
+                    If not specified, HTTP2 health check follows behavior specified in 'port' and
+                    'portName' fields.
+                  type: string
+                proxyHeader:
+                  description: |-
+                    Specifies the type of proxy header to append before sending data to the
+                    backend, either NONE or PROXY_V1. The default is NONE.
+                  type: string
+                requestPath:
+                  description: |-
+                    The request path of the HTTP2 health check request.
+                    The default value is /.
+                  type: string
+                response:
+                  description: |-
+                    The bytes to match against the beginning of the response data. If left empty
+                    (the default value), any response will indicate health. The response data
+                    can only be ASCII.
+                  type: string
+              type: object
+            httpHealthCheck:
+              description: A nested object resource
+              properties:
+                host:
+                  description: |-
+                    The value of the host header in the HTTP health check request.
+                    If left empty (default value), the public IP on behalf of which this health
+                    check is performed will be used.
+                  type: string
+                port:
+                  description: |-
+                    The TCP port number for the HTTP health check request.
+                    The default value is 80.
+                  type: integer
+                portName:
+                  description: |-
+                    Port name as defined in InstanceGroup#NamedPort#name. If both port and
+                    port_name are defined, port takes precedence.
+                  type: string
+                portSpecification:
+                  description: |-
+                    Specifies how port is selected for health checking, can be one of the
+                    following values:
+
+                      * 'USE_FIXED_PORT': The port number in 'port' is used for health checking.
+
+                      * 'USE_NAMED_PORT': The 'portName' is used for health checking.
+
+                      * 'USE_SERVING_PORT': For NetworkEndpointGroup, the port specified for each
+                      network endpoint is used for health checking. For other backends, the
+                      port or named port specified in the Backend Service is used for health
+                      checking.
+
+                    If not specified, HTTP health check follows behavior specified in 'port' and
+                    'portName' fields.
+                  type: string
+                proxyHeader:
+                  description: |-
+                    Specifies the type of proxy header to append before sending data to the
+                    backend, either NONE or PROXY_V1. The default is NONE.
+                  type: string
+                requestPath:
+                  description: |-
+                    The request path of the HTTP health check request.
+                    The default value is /.
+                  type: string
+                response:
+                  description: |-
+                    The bytes to match against the beginning of the response data. If left empty
+                    (the default value), any response will indicate health. The response data
+                    can only be ASCII.
+                  type: string
+              type: object
+            httpsHealthCheck:
+              description: A nested object resource
+              properties:
+                host:
+                  description: |-
+                    The value of the host header in the HTTPS health check request.
+                    If left empty (default value), the public IP on behalf of which this health
+                    check is performed will be used.
+                  type: string
+                port:
+                  description: |-
+                    The TCP port number for the HTTPS health check request.
+                    The default value is 443.
+                  type: integer
+                portName:
+                  description: |-
+                    Port name as defined in InstanceGroup#NamedPort#name. If both port and
+                    port_name are defined, port takes precedence.
+                  type: string
+                portSpecification:
+                  description: |-
+                    Specifies how port is selected for health checking, can be one of the
+                    following values:
+
+                      * 'USE_FIXED_PORT': The port number in 'port' is used for health checking.
+
+                      * 'USE_NAMED_PORT': The 'portName' is used for health checking.
+
+                      * 'USE_SERVING_PORT': For NetworkEndpointGroup, the port specified for each
+                      network endpoint is used for health checking. For other backends, the
+                      port or named port specified in the Backend Service is used for health
+                      checking.
+
+                    If not specified, HTTPS health check follows behavior specified in 'port' and
+                    'portName' fields.
+                  type: string
+                proxyHeader:
+                  description: |-
+                    Specifies the type of proxy header to append before sending data to the
+                    backend, either NONE or PROXY_V1. The default is NONE.
+                  type: string
+                requestPath:
+                  description: |-
+                    The request path of the HTTPS health check request.
+                    The default value is /.
+                  type: string
+                response:
+                  description: |-
+                    The bytes to match against the beginning of the response data. If left empty
+                    (the default value), any response will indicate health. The response data
+                    can only be ASCII.
+                  type: string
+              type: object
+            location:
+              description: 'Location represents the geographical location of the ComputeHealthCheck.
+                Specify a region name or "global" for global resources. Reference:
+                GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            sslHealthCheck:
+              description: A nested object resource
+              properties:
+                port:
+                  description: |-
+                    The TCP port number for the SSL health check request.
+                    The default value is 443.
+                  type: integer
+                portName:
+                  description: |-
+                    Port name as defined in InstanceGroup#NamedPort#name. If both port and
+                    port_name are defined, port takes precedence.
+                  type: string
+                portSpecification:
+                  description: |-
+                    Specifies how port is selected for health checking, can be one of the
+                    following values:
+
+                      * 'USE_FIXED_PORT': The port number in 'port' is used for health checking.
+
+                      * 'USE_NAMED_PORT': The 'portName' is used for health checking.
+
+                      * 'USE_SERVING_PORT': For NetworkEndpointGroup, the port specified for each
+                      network endpoint is used for health checking. For other backends, the
+                      port or named port specified in the Backend Service is used for health
+                      checking.
+
+                    If not specified, SSL health check follows behavior specified in 'port' and
+                    'portName' fields.
+                  type: string
+                proxyHeader:
+                  description: |-
+                    Specifies the type of proxy header to append before sending data to the
+                    backend, either NONE or PROXY_V1. The default is NONE.
+                  type: string
+                request:
+                  description: |-
+                    The application data to send once the SSL connection has been
+                    established (default value is empty). If both request and response are
+                    empty, the connection establishment alone will indicate health. The request
+                    data can only be ASCII.
+                  type: string
+                response:
+                  description: |-
+                    The bytes to match against the beginning of the response data. If left empty
+                    (the default value), any response will indicate health. The response data
+                    can only be ASCII.
+                  type: string
+              type: object
+            tcpHealthCheck:
+              description: A nested object resource
+              properties:
+                port:
+                  description: |-
+                    The TCP port number for the TCP health check request.
+                    The default value is 443.
+                  type: integer
+                portName:
+                  description: |-
+                    Port name as defined in InstanceGroup#NamedPort#name. If both port and
+                    port_name are defined, port takes precedence.
+                  type: string
+                portSpecification:
+                  description: |-
+                    Specifies how port is selected for health checking, can be one of the
+                    following values:
+
+                      * 'USE_FIXED_PORT': The port number in 'port' is used for health checking.
+
+                      * 'USE_NAMED_PORT': The 'portName' is used for health checking.
+
+                      * 'USE_SERVING_PORT': For NetworkEndpointGroup, the port specified for each
+                      network endpoint is used for health checking. For other backends, the
+                      port or named port specified in the Backend Service is used for health
+                      checking.
+
+                    If not specified, TCP health check follows behavior specified in 'port' and
+                    'portName' fields.
+                  type: string
+                proxyHeader:
+                  description: |-
+                    Specifies the type of proxy header to append before sending data to the
+                    backend, either NONE or PROXY_V1. The default is NONE.
+                  type: string
+                request:
+                  description: |-
+                    The application data to send once the TCP connection has been
+                    established (default value is empty). If both request and response are
+                    empty, the connection establishment alone will indicate health. The request
+                    data can only be ASCII.
+                  type: string
+                response:
+                  description: |-
+                    The bytes to match against the beginning of the response data. If left empty
+                    (the default value), any response will indicate health. The response data
+                    can only be ASCII.
+                  type: string
+              type: object
+            timeoutSec:
+              description: |-
+                How long (in seconds) to wait before claiming failure.
+                The default value is 5 seconds.  It is invalid for timeoutSec to have
+                greater value than checkIntervalSec.
+              type: integer
+            unhealthyThreshold:
+              description: |-
+                A so-far healthy instance will be marked unhealthy after this many
+                consecutive failures. The default value is 2.
+              type: integer
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+            type:
+              description: The type of the health check. One of HTTP, HTTPS, TCP,
+                or SSL.
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computehttphealthchecks.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computehttphealthchecks.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,125 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computehttphealthchecks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeHTTPHealthCheck
+    plural: computehttphealthchecks
+    shortNames:
+    - gcpcomputehttphealthcheck
+    - gcpcomputehttphealthchecks
+    singular: computehttphealthcheck
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            checkIntervalSec:
+              description: |-
+                How often (in seconds) to send a health check. The default value is 5
+                seconds.
+              type: integer
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            healthyThreshold:
+              description: |-
+                A so-far unhealthy instance will be marked healthy after this many
+                consecutive successes. The default value is 2.
+              type: integer
+            host:
+              description: |-
+                The value of the host header in the HTTP health check request. If
+                left empty (default value), the public IP on behalf of which this
+                health check is performed will be used.
+              type: string
+            port:
+              description: |-
+                The TCP port number for the HTTP health check request.
+                The default value is 80.
+              type: integer
+            requestPath:
+              description: |-
+                The request path of the HTTP health check request.
+                The default value is /.
+              type: string
+            timeoutSec:
+              description: |-
+                How long (in seconds) to wait before claiming failure.
+                The default value is 5 seconds.  It is invalid for timeoutSec to have
+                greater value than checkIntervalSec.
+              type: integer
+            unhealthyThreshold:
+              description: |-
+                A so-far healthy instance will be marked unhealthy after this many
+                consecutive failures. The default value is 2.
+              type: integer
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computehttpshealthchecks.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computehttpshealthchecks.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,125 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computehttpshealthchecks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeHTTPSHealthCheck
+    plural: computehttpshealthchecks
+    shortNames:
+    - gcpcomputehttpshealthcheck
+    - gcpcomputehttpshealthchecks
+    singular: computehttpshealthcheck
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            checkIntervalSec:
+              description: |-
+                How often (in seconds) to send a health check. The default value is 5
+                seconds.
+              type: integer
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            healthyThreshold:
+              description: |-
+                A so-far unhealthy instance will be marked healthy after this many
+                consecutive successes. The default value is 2.
+              type: integer
+            host:
+              description: |-
+                The value of the host header in the HTTPS health check request. If
+                left empty (default value), the public IP on behalf of which this
+                health check is performed will be used.
+              type: string
+            port:
+              description: |-
+                The TCP port number for the HTTPS health check request.
+                The default value is 80.
+              type: integer
+            requestPath:
+              description: |-
+                The request path of the HTTPS health check request.
+                The default value is /.
+              type: string
+            timeoutSec:
+              description: |-
+                How long (in seconds) to wait before claiming failure.
+                The default value is 5 seconds.  It is invalid for timeoutSec to have
+                greater value than checkIntervalSec.
+              type: integer
+            unhealthyThreshold:
+              description: |-
+                A so-far healthy instance will be marked unhealthy after this many
+                consecutive failures. The default value is 2.
+              type: integer
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeimages.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeimages.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,179 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeimages.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeImage
+    plural: computeimages
+    shortNames:
+    - gcpcomputeimage
+    - gcpcomputeimages
+    singular: computeimage
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            diskRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            diskSizeGb:
+              description: Size of the image when restored onto a persistent disk
+                (in GB).
+              type: integer
+            family:
+              description: |-
+                The name of the image family to which this image belongs. You can
+                create disks by specifying an image family instead of a specific
+                image name. The image family always returns its latest image that is
+                not deprecated. The name of the image family must comply with
+                RFC1035.
+              type: string
+            guestOsFeatures:
+              description: |-
+                A list of features to enable on the guest operating system.
+                Applicable only for bootable images.
+              items:
+                properties:
+                  type:
+                    description: The type of supported feature. Read [Enabling guest
+                      operating system features](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features)
+                      to see a list of available options.
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
+            licenses:
+              description: Any applicable license URI.
+              items:
+                type: string
+              type: array
+            rawDisk:
+              description: The parameters of the raw disk image.
+              properties:
+                containerType:
+                  description: |-
+                    The format used to encode and transmit the block device, which
+                    should be TAR. This is just a container and transmission format
+                    and not a runtime format. Provided by the client when the disk
+                    image is created.
+                  type: string
+                sha1:
+                  description: |-
+                    An optional SHA1 checksum of the disk image before unpackaging.
+                    This is provided by the client when the disk image is created.
+                  type: string
+                source:
+                  description: |-
+                    The full Google Cloud Storage URL where disk storage is stored
+                    You must provide either this property or the sourceDisk property
+                    but not both.
+                  type: string
+              required:
+              - source
+              type: object
+          type: object
+        status:
+          properties:
+            archiveSizeBytes:
+              description: |-
+                Size of the image tar.gz archive stored in Google Cloud Storage (in
+                bytes).
+              type: integer
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource. Used
+                internally during updates.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeinstancegroups.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeinstancegroups.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,150 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeinstancegroups.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeInstanceGroup
+    plural: computeinstancegroups
+    shortNames:
+    - gcpcomputeinstancegroup
+    - gcpcomputeinstancegroups
+    singular: computeinstancegroup
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            instances:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            namedPort:
+              items:
+                properties:
+                  name:
+                    type: string
+                  port:
+                    type: integer
+                required:
+                - name
+                - port
+                type: object
+              type: array
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            zone:
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+            size:
+              type: integer
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeinstances.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeinstances.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,578 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeinstances.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeInstance
+    plural: computeinstances
+    shortNames:
+    - gcpcomputeinstance
+    - gcpcomputeinstances
+    singular: computeinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          anyOf:
+          - required:
+            - bootDisk
+            - machineType
+            - networkInterface
+          - required:
+            - instanceTemplateRef
+          properties:
+            attachedDisk:
+              items:
+                properties:
+                  deviceName:
+                    type: string
+                  diskEncryptionKeyRaw:
+                    oneOf:
+                    - not:
+                        required:
+                        - valueFrom
+                      required:
+                      - value
+                    - not:
+                        required:
+                        - value
+                      required:
+                      - valueFrom
+                    properties:
+                      value:
+                        description: Value of the field. Cannot be used if 'valueFrom'
+                          is specified.
+                        type: string
+                      valueFrom:
+                        description: Source for the field's value. Cannot be used
+                          if 'value' is specified.
+                        properties:
+                          secretKeyRef:
+                            description: Reference to a value with the given key in
+                              the given Secret in the resource's namespace.
+                            properties:
+                              key:
+                                description: Key that identifies the value to be extracted.
+                                type: string
+                              name:
+                                description: Name of the Secret to extract a value
+                                  from.
+                                type: string
+                            required:
+                            - name
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  diskEncryptionKeySha256:
+                    type: string
+                  kmsKeyRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  mode:
+                    type: string
+                  sourceDiskRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                required:
+                - sourceDiskRef
+                type: object
+              type: array
+            bootDisk:
+              properties:
+                autoDelete:
+                  type: boolean
+                deviceName:
+                  type: string
+                diskEncryptionKeyRaw:
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                diskEncryptionKeySha256:
+                  type: string
+                initializeParams:
+                  properties:
+                    labels:
+                      type: object
+                    size:
+                      type: integer
+                    sourceImageRef:
+                      oneOf:
+                      - not:
+                          required:
+                          - external
+                        required:
+                        - name
+                      - not:
+                          anyOf:
+                          - required:
+                            - name
+                          - required:
+                            - namespace
+                        required:
+                        - external
+                      properties:
+                        external:
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                      type: object
+                    type:
+                      type: string
+                  type: object
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                mode:
+                  type: string
+                sourceDiskRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              type: object
+            canIpForward:
+              type: boolean
+            deletionProtection:
+              type: boolean
+            description:
+              type: string
+            enableDisplay:
+              type: boolean
+            guestAccelerator:
+              items:
+                properties:
+                  count:
+                    type: integer
+                  type:
+                    type: string
+                required:
+                - count
+                - type
+                type: object
+              type: array
+            hostname:
+              type: string
+            instanceTemplateRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            machineType:
+              type: string
+            metadata:
+              items:
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
+                required:
+                - key
+                - value
+                type: object
+              type: array
+            metadataStartupScript:
+              type: string
+            minCpuPlatform:
+              type: string
+            networkInterface:
+              items:
+                properties:
+                  accessConfig:
+                    items:
+                      properties:
+                        natIpRef:
+                          oneOf:
+                          - not:
+                              required:
+                              - external
+                            required:
+                            - name
+                          - not:
+                              anyOf:
+                              - required:
+                                - name
+                              - required:
+                                - namespace
+                            required:
+                            - external
+                          properties:
+                            external:
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                          type: object
+                        networkTier:
+                          type: string
+                        publicPtrDomainName:
+                          type: string
+                      type: object
+                    type: array
+                  aliasIpRange:
+                    items:
+                      properties:
+                        ipCidrRange:
+                          type: string
+                        subnetworkRangeName:
+                          type: string
+                      required:
+                      - ipCidrRange
+                      type: object
+                    type: array
+                  name:
+                    type: string
+                  networkIp:
+                    type: string
+                  networkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  subnetworkProject:
+                    type: string
+                  subnetworkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                type: object
+              type: array
+            scheduling:
+              properties:
+                automaticRestart:
+                  type: boolean
+                nodeAffinities:
+                  items:
+                    properties:
+                      value:
+                        type: object
+                    type: object
+                  type: array
+                onHostMaintenance:
+                  type: string
+                preemptible:
+                  type: boolean
+              type: object
+            scratchDisk:
+              items:
+                properties:
+                  interface:
+                    type: string
+                required:
+                - interface
+                type: object
+              type: array
+            serviceAccount:
+              properties:
+                scopes:
+                  items:
+                    type: string
+                  type: array
+                serviceAccountRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              required:
+              - scopes
+              type: object
+            shieldedInstanceConfig:
+              properties:
+                enableIntegrityMonitoring:
+                  type: boolean
+                enableSecureBoot:
+                  type: boolean
+                enableVtpm:
+                  type: boolean
+              type: object
+            tags:
+              items:
+                type: string
+              type: array
+            zone:
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            cpuPlatform:
+              type: string
+            instanceId:
+              type: string
+            labelFingerprint:
+              type: string
+            metadataFingerprint:
+              type: string
+            selfLink:
+              type: string
+            tagsFingerprint:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeinstancetemplates.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeinstancetemplates.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,404 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeinstancetemplates.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeInstanceTemplate
+    plural: computeinstancetemplates
+    shortNames:
+    - gcpcomputeinstancetemplate
+    - gcpcomputeinstancetemplates
+    singular: computeinstancetemplate
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            canIpForward:
+              type: boolean
+            description:
+              type: string
+            disk:
+              items:
+                properties:
+                  autoDelete:
+                    type: boolean
+                  boot:
+                    type: boolean
+                  deviceName:
+                    type: string
+                  diskEncryptionKey:
+                    properties:
+                      kmsKeyRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                    required:
+                    - kmsKeyRef
+                    type: object
+                  diskName:
+                    type: string
+                  diskSizeGb:
+                    type: integer
+                  diskType:
+                    type: string
+                  interface:
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  mode:
+                    type: string
+                  sourceDiskRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  sourceImageRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  type:
+                    type: string
+                type: object
+              type: array
+            enableDisplay:
+              type: boolean
+            guestAccelerator:
+              items:
+                properties:
+                  count:
+                    type: integer
+                  type:
+                    type: string
+                required:
+                - count
+                - type
+                type: object
+              type: array
+            instanceDescription:
+              type: string
+            machineType:
+              type: string
+            metadata:
+              items:
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
+                required:
+                - key
+                - value
+                type: object
+              type: array
+            metadataStartupScript:
+              type: string
+            minCpuPlatform:
+              type: string
+            namePrefix:
+              type: string
+            networkInterface:
+              items:
+                properties:
+                  accessConfig:
+                    items:
+                      properties:
+                        natIpRef:
+                          oneOf:
+                          - not:
+                              required:
+                              - external
+                            required:
+                            - name
+                          - not:
+                              anyOf:
+                              - required:
+                                - name
+                              - required:
+                                - namespace
+                            required:
+                            - external
+                          properties:
+                            external:
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                          type: object
+                        networkTier:
+                          type: string
+                      type: object
+                    type: array
+                  aliasIpRange:
+                    items:
+                      properties:
+                        ipCidrRange:
+                          type: string
+                        subnetworkRangeName:
+                          type: string
+                      required:
+                      - ipCidrRange
+                      type: object
+                    type: array
+                  networkIp:
+                    type: string
+                  networkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  subnetworkProject:
+                    type: string
+                  subnetworkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                type: object
+              type: array
+            region:
+              type: string
+            scheduling:
+              properties:
+                automaticRestart:
+                  type: boolean
+                nodeAffinities:
+                  items:
+                    properties:
+                      value:
+                        type: object
+                    type: object
+                  type: array
+                onHostMaintenance:
+                  type: string
+                preemptible:
+                  type: boolean
+              type: object
+            serviceAccount:
+              properties:
+                scopes:
+                  items:
+                    type: string
+                  type: array
+                serviceAccountRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              required:
+              - scopes
+              type: object
+            shieldedInstanceConfig:
+              properties:
+                enableIntegrityMonitoring:
+                  type: boolean
+                enableSecureBoot:
+                  type: boolean
+                enableVtpm:
+                  type: boolean
+              type: object
+            tags:
+              items:
+                type: string
+              type: array
+          required:
+          - disk
+          - machineType
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            metadataFingerprint:
+              type: string
+            selfLink:
+              type: string
+            tagsFingerprint:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeinterconnectattachments.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeinterconnectattachments.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,210 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeinterconnectattachments.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeInterconnectAttachment
+    plural: computeinterconnectattachments
+    shortNames:
+    - gcpcomputeinterconnectattachment
+    - gcpcomputeinterconnectattachments
+    singular: computeinterconnectattachment
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            adminEnabled:
+              description: |-
+                Whether the VLAN attachment is enabled or disabled.  When using
+                PARTNER type this will Pre-Activate the interconnect attachment
+              type: boolean
+            bandwidth:
+              description: |-
+                Provisioned bandwidth capacity for the interconnect attachment.
+                For attachments of type DEDICATED, the user can set the bandwidth.
+                For attachments of type PARTNER, the Google Partner that is operating the interconnect must set the bandwidth.
+                Output only for PARTNER type, mutable for PARTNER_PROVIDER and DEDICATED,
+                Defaults to BPS_10G
+              type: string
+            candidateSubnets:
+              description: |-
+                Up to 16 candidate prefixes that can be used to restrict the allocation
+                of cloudRouterIpAddress and customerRouterIpAddress for this attachment.
+                All prefixes must be within link-local address space (169.254.0.0/16)
+                and must be /29 or shorter (/28, /27, etc). Google will attempt to select
+                an unused /29 from the supplied candidate prefix(es). The request will
+                fail if all possible /29s are in use on Google's edge. If not supplied,
+                Google will randomly select an unused /29 from all of link-local space.
+              items:
+                type: string
+              type: array
+            description:
+              description: An optional description of this resource.
+              type: string
+            edgeAvailabilityDomain:
+              description: |-
+                Desired availability domain for the attachment. Only available for type
+                PARTNER, at creation time. For improved reliability, customers should
+                configure a pair of attachments with one per availability domain. The
+                selected availability domain will be provided to the Partner via the
+                pairing key so that the provisioned circuit will lie in the specified
+                domain. If not specified, the value will default to AVAILABILITY_DOMAIN_ANY.
+              type: string
+            interconnect:
+              description: |-
+                URL of the underlying Interconnect object that this attachment's
+                traffic will traverse through. Required if type is DEDICATED, must not
+                be set if type is PARTNER.
+              type: string
+            region:
+              description: Region where the regional interconnect attachment resides.
+              type: string
+            routerRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            type:
+              description: |-
+                The type of InterconnectAttachment you wish to create. Defaults to
+                DEDICATED.
+              type: string
+            vlanTag8021q:
+              description: |-
+                The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. When
+                using PARTNER type this will be managed upstream.
+              type: integer
+          required:
+          - routerRef
+          type: object
+        status:
+          properties:
+            cloudRouterIpAddress:
+              description: |-
+                IPv4 address + prefix length to be configured on Cloud Router
+                Interface for this interconnect attachment.
+              type: string
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            customerRouterIpAddress:
+              description: |-
+                IPv4 address + prefix length to be configured on the customer
+                router subinterface for this interconnect attachment.
+              type: string
+            googleReferenceId:
+              description: |-
+                Google reference ID, to be used when raising support tickets with
+                Google or otherwise to debug backend connectivity issues.
+              type: string
+            pairingKey:
+              description: |-
+                [Output only for type PARTNER. Not present for DEDICATED]. The opaque
+                identifier of an PARTNER attachment used to initiate provisioning with
+                a selected partner. Of the form "XXXXX/region/domain"
+              type: string
+            partnerAsn:
+              description: |-
+                [Output only for type PARTNER. Not present for DEDICATED]. Optional
+                BGP ASN for the router that should be supplied by a layer 3 Partner if
+                they configured BGP on behalf of the customer.
+              type: string
+            privateInterconnectInfo:
+              description: |-
+                Information specific to an InterconnectAttachment. This property
+                is populated if the interconnect that this is attached to is of type DEDICATED.
+              properties:
+                tag8021q:
+                  description: |-
+                    802.1q encapsulation tag to be used for traffic between
+                    Google and the customer, going to and from this network and region.
+                  type: integer
+              type: object
+            selfLink:
+              type: string
+            state:
+              description: '[Output Only] The current state of this attachment''s
+                functionality.'
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computenetworkendpointgroups.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computenetworkendpointgroups.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,157 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computenetworkendpointgroups.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeNetworkEndpointGroup
+    plural: computenetworkendpointgroups
+    shortNames:
+    - gcpcomputenetworkendpointgroup
+    - gcpcomputenetworkendpointgroups
+    singular: computenetworkendpointgroup
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            defaultPort:
+              description: |-
+                The default port used if the port number is not specified in the
+                network endpoint.
+              type: integer
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            location:
+              description: 'Location represents the geographical location of the ComputeNetworkEndpointGroup.
+                Specify a zone name. Reference: GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            networkEndpointType:
+              description: |-
+                Type of network endpoints in this network endpoint group. Currently
+                the only supported value is GCE_VM_IP_PORT.
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            subnetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - location
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+            size:
+              description: Number of network endpoints in the network endpoint group.
+              type: integer
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computenetworkpeerings.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computenetworkpeerings.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,141 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computenetworkpeerings.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeNetworkPeering
+    plural: computenetworkpeerings
+    shortNames:
+    - gcpcomputenetworkpeering
+    - gcpcomputenetworkpeerings
+    singular: computenetworkpeering
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            exportCustomRoutes:
+              type: boolean
+            importCustomRoutes:
+              type: boolean
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            peerNetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - networkRef
+          - peerNetworkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            state:
+              type: string
+            stateDetails:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computenetworks.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computenetworks.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,109 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computenetworks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeNetwork
+    plural: computenetworks
+    shortNames:
+    - gcpcomputenetwork
+    - gcpcomputenetworks
+    singular: computenetwork
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            autoCreateSubnetworks:
+              description: |-
+                When set to 'true', the network is created in "auto subnet mode" and
+                it will create a subnet for each region automatically across the
+                '10.128.0.0/9' address range.
+
+                When set to 'false', the network is created in "custom subnet mode" so
+                the user can explicitly connect subnetwork resources.
+              type: boolean
+            deleteDefaultRoutesOnCreate:
+              type: boolean
+            description:
+              description: |-
+                An optional description of this resource. The resource must be
+                recreated to modify this field.
+              type: string
+            routingMode:
+              description: |-
+                The network-wide routing mode to use. If set to 'REGIONAL', this
+                network's cloud routers will only advertise routes with subnetworks
+                of this network in the same region as the router. If set to 'GLOBAL',
+                this network's cloud routers will advertise routes with all
+                subnetworks of this network, across regions.
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            gatewayIpv4:
+              description: |-
+                The gateway address for default routing out of the network. This value
+                is selected by GCP.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computenodegroups.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computenodegroups.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,122 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computenodegroups.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeNodeGroup
+    plural: computenodegroups
+    shortNames:
+    - gcpcomputenodegroup
+    - gcpcomputenodegroups
+    singular: computenodegroup
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional textual description of the resource.
+              type: string
+            nodeTemplateRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            size:
+              description: The total number of nodes in the node group.
+              type: integer
+            zone:
+              description: Zone where this node group is located
+              type: string
+          required:
+          - nodeTemplateRef
+          - size
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computenodetemplates.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computenodetemplates.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,136 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computenodetemplates.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeNodeTemplate
+    plural: computenodetemplates
+    shortNames:
+    - gcpcomputenodetemplate
+    - gcpcomputenodetemplates
+    singular: computenodetemplate
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional textual description of the resource.
+              type: string
+            nodeType:
+              description: |-
+                Node type to use for nodes group that are created from this template.
+                Only one of nodeTypeFlexibility and nodeType can be specified.
+              type: string
+            nodeTypeFlexibility:
+              description: |-
+                Flexible properties for the desired node type. Node groups that
+                use this node template will create nodes of a type that matches
+                these properties. Only one of nodeTypeFlexibility and nodeType can
+                be specified.
+              properties:
+                cpus:
+                  description: Number of virtual CPUs to use.
+                  type: string
+                localSsd:
+                  description: Use local SSD
+                  type: string
+                memory:
+                  description: Physical memory available to the node, defined in MB.
+                  type: string
+              type: object
+            region:
+              description: |-
+                Region where nodes using the node template will be created.
+                If it is not provided, the provider region is used.
+              type: string
+            serverBinding:
+              description: |-
+                The server binding policy for nodes using this template. Determines
+                where the nodes should restart following a maintenance event.
+              properties:
+                type:
+                  description: |-
+                    Type of server binding policy. If 'RESTART_NODE_ON_ANY_SERVER',
+                    nodes using this template will restart on any physical server
+                    following a maintenance event.
+
+                    If 'RESTART_NODE_ON_MINIMAL_SERVER', nodes using this template
+                    will restart on the same physical server following a maintenance
+                    event, instead of being live migrated to or restarted on a new
+                    physical server. This option may be useful if you are using
+                    software licenses tied to the underlying server characteristics
+                    such as physical sockets or cores, to avoid the need for
+                    additional licenses when maintenance occurs. However, VMs on such
+                    nodes will experience outages while maintenance is applied.
+                  type: string
+              required:
+              - type
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computereservations.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computereservations.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,177 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computereservations.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeReservation
+    plural: computereservations
+    shortNames:
+    - gcpcomputereservation
+    - gcpcomputereservations
+    singular: computereservation
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            specificReservation:
+              description: Reservation for instances with specific machine shapes.
+              properties:
+                count:
+                  description: The number of resources that are allocated.
+                  type: integer
+                inUseCount:
+                  description: How many instances are in use.
+                  type: integer
+                instanceProperties:
+                  description: The instance properties for the reservation.
+                  properties:
+                    guestAccelerators:
+                      description: Guest accelerator type and count.
+                      items:
+                        properties:
+                          acceleratorCount:
+                            description: |-
+                              The number of the guest accelerator cards exposed to
+                              this instance.
+                            type: integer
+                          acceleratorType:
+                            description: |-
+                              The full or partial URL of the accelerator type to
+                              attach to this instance. For example:
+                              'projects/my-project/zones/us-central1-c/acceleratorTypes/nvidia-tesla-p100'
+
+                              If you are creating an instance template, specify only the accelerator name.
+                            type: string
+                        required:
+                        - acceleratorCount
+                        - acceleratorType
+                        type: object
+                      type: array
+                    localSsds:
+                      description: |-
+                        The amount of local ssd to reserve with each instance. This
+                        reserves disks of type 'local-ssd'.
+                      items:
+                        properties:
+                          diskSizeGb:
+                            description: The size of the disk in base-2 GB.
+                            type: integer
+                          interface:
+                            description: |-
+                              The disk interface to use for attaching this disk, one
+                              of 'SCSI' or 'NVME'. The default is 'SCSI'.
+                            type: string
+                        required:
+                        - diskSizeGb
+                        type: object
+                      type: array
+                    machineType:
+                      description: The name of the machine type to reserve.
+                      type: string
+                    minCpuPlatform:
+                      description: |-
+                        The minimum CPU platform for the reservation. For example,
+                        '"Intel Skylake"'. See
+                        the CPU platform availability reference](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones)
+                        for information on available CPU platforms.
+                      type: string
+                  required:
+                  - machineType
+                  type: object
+              required:
+              - count
+              - instanceProperties
+              type: object
+            specificReservationRequired:
+              description: |-
+                When set to true, only VMs that target this reservation by name can
+                consume this reservation. Otherwise, it can be consumed by VMs with
+                affinity for any reservation. Defaults to false.
+              type: boolean
+            zone:
+              description: The zone where the reservation is made.
+              type: string
+          required:
+          - specificReservation
+          - zone
+          type: object
+        status:
+          properties:
+            commitment:
+              description: |-
+                Full or partial URL to a parent commitment. This field displays for
+                reservations that are tied to a commitment.
+              type: string
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+            status:
+              description: The status of the reservation.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeresourcepolicies.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeresourcepolicies.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,190 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeresourcepolicies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeResourcePolicy
+    plural: computeresourcepolicies
+    shortNames:
+    - gcpcomputeresourcepolicy
+    - gcpcomputeresourcepolicies
+    singular: computeresourcepolicy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            region:
+              description: Region where resource policy resides.
+              type: string
+            snapshotSchedulePolicy:
+              description: Policy for creating snapshots of persistent disks.
+              properties:
+                retentionPolicy:
+                  description: Retention policy applied to snapshots created by this
+                    resource policy.
+                  properties:
+                    maxRetentionDays:
+                      description: Maximum age of the snapshot that is allowed to
+                        be kept.
+                      type: integer
+                    onSourceDiskDelete:
+                      description: |-
+                        Specifies the behavior to apply to scheduled snapshots when
+                        the source disk is deleted.
+                        Valid options are KEEP_AUTO_SNAPSHOTS and APPLY_RETENTION_POLICY
+                      type: string
+                  required:
+                  - maxRetentionDays
+                  type: object
+                schedule:
+                  description: Contains one of an 'hourlySchedule', 'dailySchedule',
+                    or 'weeklySchedule'.
+                  properties:
+                    dailySchedule:
+                      description: The policy will execute every nth day at the specified
+                        time.
+                      properties:
+                        daysInCycle:
+                          description: The number of days between snapshots.
+                          type: integer
+                        startTime:
+                          description: |-
+                            This must be in UTC format that resolves to one of
+                            00:00, 04:00, 08:00, 12:00, 16:00, or 20:00. For example,
+                            both 13:00-5 and 08:00 are valid.
+                          type: string
+                      required:
+                      - daysInCycle
+                      - startTime
+                      type: object
+                    hourlySchedule:
+                      description: The policy will execute every nth hour starting
+                        at the specified time.
+                      properties:
+                        hoursInCycle:
+                          description: The number of hours between snapshots.
+                          type: integer
+                        startTime:
+                          description: |-
+                            Time within the window to start the operations.
+                            It must be in format "HH:MM",
+                            where HH : [00-23] and MM : [00-00] GMT.
+                          type: string
+                      required:
+                      - hoursInCycle
+                      - startTime
+                      type: object
+                    weeklySchedule:
+                      description: Allows specifying a snapshot time for each day
+                        of the week.
+                      properties:
+                        dayOfWeeks:
+                          description: May contain up to seven (one for each day of
+                            the week) snapshot times.
+                          items:
+                            properties:
+                              day:
+                                description: The day of the week to create the snapshot.
+                                  e.g. MONDAY
+                                type: string
+                              startTime:
+                                description: |-
+                                  Time within the window to start the operations.
+                                  It must be in format "HH:MM", where HH : [00-23] and MM : [00-00] GMT.
+                                type: string
+                            required:
+                            - day
+                            - startTime
+                            type: object
+                          type: array
+                      required:
+                      - dayOfWeeks
+                      type: object
+                  type: object
+                snapshotProperties:
+                  description: Properties with which the snapshots are created, such
+                    as labels.
+                  properties:
+                    guestFlush:
+                      description: Whether to perform a 'guest aware' snapshot.
+                      type: boolean
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: A set of key-value pairs.
+                      type: object
+                    storageLocations:
+                      description: Cloud Storage bucket location in which to store
+                        the snapshot (regional or multi-regional).
+                      items:
+                        type: string
+                      type: array
+                  type: object
+              required:
+              - schedule
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computerouterinterfaces.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computerouterinterfaces.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,161 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computerouterinterfaces.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeRouterInterface
+    plural: computerouterinterfaces
+    shortNames:
+    - gcpcomputerouterinterface
+    - gcpcomputerouterinterfaces
+    singular: computerouterinterface
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            interconnectAttachmentRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            ipRange:
+              type: string
+            region:
+              type: string
+            routerRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            vpnTunnelRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - routerRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computerouternats.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computerouternats.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,275 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computerouternats.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeRouterNAT
+    plural: computerouternats
+    shortNames:
+    - gcpcomputerouternat
+    - gcpcomputerouternats
+    singular: computerouternat
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            drainNatIps:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            icmpIdleTimeoutSec:
+              description: Timeout (in seconds) for ICMP connections. Defaults to
+                30s if not set.
+              type: integer
+            logConfig:
+              description: Configuration for logging on NAT
+              properties:
+                enable:
+                  description: Indicates whether or not to export logs.
+                  type: boolean
+                filter:
+                  description: |-
+                    Specifies the desired filtering of logs on this NAT. Valid
+                    values are: '"ERRORS_ONLY"', '"TRANSLATIONS_ONLY"', '"ALL"'
+                  type: string
+              required:
+              - enable
+              - filter
+              type: object
+            minPortsPerVm:
+              description: Minimum number of ports allocated to a VM from this NAT.
+              type: integer
+            natIpAllocateOption:
+              description: |-
+                How external IPs should be allocated for this NAT. Valid values are
+                'AUTO_ONLY' for only allowing NAT IPs allocated by Google Cloud
+                Platform, or 'MANUAL_ONLY' for only user-allocated NAT IP addresses.
+              type: string
+            natIps:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            region:
+              description: Region where the router and NAT reside.
+              type: string
+            routerRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            sourceSubnetworkIpRangesToNat:
+              description: |-
+                How NAT should be configured per Subnetwork.
+                If 'ALL_SUBNETWORKS_ALL_IP_RANGES', all of the
+                IP ranges in every Subnetwork are allowed to Nat.
+                If 'ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES', all of the primary IP
+                ranges in every Subnetwork are allowed to Nat.
+                'LIST_OF_SUBNETWORKS': A list of Subnetworks are allowed to Nat
+                (specified in the field subnetwork below). Note that if this field
+                contains ALL_SUBNETWORKS_ALL_IP_RANGES or
+                ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES, then there should not be any
+                other RouterNat section in any Router for this network in this region.
+              type: string
+            subnetwork:
+              description: |-
+                One or more subnetwork NAT configurations. Only used if
+                'source_subnetwork_ip_ranges_to_nat' is set to 'LIST_OF_SUBNETWORKS'
+              items:
+                properties:
+                  secondaryIpRangeNames:
+                    description: |-
+                      List of the secondary ranges of the subnetwork that are allowed
+                      to use NAT. This can be populated only if
+                      'LIST_OF_SECONDARY_IP_RANGES' is one of the values in
+                      sourceIpRangesToNat
+                    items:
+                      type: string
+                    type: array
+                  sourceIpRangesToNat:
+                    description: |-
+                      List of options for which source IPs in the subnetwork
+                      should have NAT enabled. Supported values include:
+                      'ALL_IP_RANGES', 'LIST_OF_SECONDARY_IP_RANGES',
+                      'PRIMARY_IP_RANGE'.
+                    items:
+                      type: string
+                    type: array
+                  subnetworkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                required:
+                - sourceIpRangesToNat
+                - subnetworkRef
+                type: object
+              type: array
+            tcpEstablishedIdleTimeoutSec:
+              description: |-
+                Timeout (in seconds) for TCP established connections.
+                Defaults to 1200s if not set.
+              type: integer
+            tcpTransitoryIdleTimeoutSec:
+              description: |-
+                Timeout (in seconds) for TCP transitory connections.
+                Defaults to 30s if not set.
+              type: integer
+            udpIdleTimeoutSec:
+              description: Timeout (in seconds) for UDP connections. Defaults to 30s
+                if not set.
+              type: integer
+          required:
+          - natIpAllocateOption
+          - routerRef
+          - sourceSubnetworkIpRangesToNat
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computerouterpeers.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computerouterpeers.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,217 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computerouterpeers.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeRouterPeer
+    plural: computerouterpeers
+    shortNames:
+    - gcpcomputerouterpeer
+    - gcpcomputerouterpeers
+    singular: computerouterpeer
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            advertiseMode:
+              description: |-
+                User-specified flag to indicate which mode to use for advertisement.
+                Valid values of this enum field are: 'DEFAULT', 'CUSTOM'
+              type: string
+            advertisedGroups:
+              description: |-
+                User-specified list of prefix groups to advertise in custom
+                mode, which can take one of the following options:
+
+                * 'ALL_SUBNETS': Advertises all available subnets, including peer VPC subnets.
+                * 'ALL_VPC_SUBNETS': Advertises the router's own VPC subnets.
+                * 'ALL_PEER_VPC_SUBNETS': Advertises peer subnets of the router's VPC network.
+
+
+                Note that this field can only be populated if advertiseMode is 'CUSTOM'
+                and overrides the list defined for the router (in the "bgp" message).
+                These groups are advertised in addition to any specified prefixes.
+                Leave this field blank to advertise no custom groups.
+              items:
+                type: string
+              type: array
+            advertisedIpRanges:
+              description: |-
+                User-specified list of individual IP ranges to advertise in
+                custom mode. This field can only be populated if advertiseMode
+                is 'CUSTOM' and is advertised to all peers of the router. These IP
+                ranges will be advertised in addition to any specified groups.
+                Leave this field blank to advertise no custom IP ranges.
+              items:
+                properties:
+                  description:
+                    description: User-specified description for the IP range.
+                    type: string
+                  range:
+                    description: |-
+                      The IP range to advertise. The value must be a
+                      CIDR-formatted string.
+                    type: string
+                required:
+                - range
+                type: object
+              type: array
+            advertisedRoutePriority:
+              description: |-
+                The priority of routes advertised to this BGP peer.
+                Where there is more than one matching route of maximum
+                length, the routes with the lowest priority value win.
+              type: integer
+            peerAsn:
+              description: |-
+                Peer BGP Autonomous System Number (ASN).
+                Each BGP interface may use a different value.
+              type: integer
+            peerIpAddress:
+              description: |-
+                IP address of the BGP interface outside Google Cloud Platform.
+                Only IPv4 is supported.
+              type: string
+            region:
+              description: |-
+                Region where the router and BgpPeer reside.
+                If it is not provided, the provider region is used.
+              type: string
+            routerInterfaceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            routerRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - peerAsn
+          - peerIpAddress
+          - routerInterfaceRef
+          - routerRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            ipAddress:
+              description: |-
+                IP address of the interface inside Google Cloud Platform.
+                Only IPv4 is supported.
+              type: string
+            managementType:
+              description: |-
+                The resource that configures and manages this BGP peer.
+
+                * 'MANAGED_BY_USER' is the default value and can be managed by
+                you or other users
+                * 'MANAGED_BY_ATTACHMENT' is a BGP peer that is configured and
+                managed by Cloud Interconnect, specifically by an
+                InterconnectAttachment of type PARTNER. Google automatically
+                creates, updates, and deletes this type of BGP peer when the
+                PARTNER InterconnectAttachment is created, updated,
+                or deleted.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computerouters.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computerouters.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,170 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computerouters.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeRouter
+    plural: computerouters
+    shortNames:
+    - gcpcomputerouter
+    - gcpcomputerouters
+    singular: computerouter
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bgp:
+              description: BGP information specific to this router.
+              properties:
+                advertiseMode:
+                  description: |-
+                    User-specified flag to indicate which mode to use for advertisement.
+
+                    Valid values of this enum field are: DEFAULT, CUSTOM
+                  type: string
+                advertisedGroups:
+                  description: |-
+                    User-specified list of prefix groups to advertise in custom mode.
+                    This field can only be populated if advertiseMode is CUSTOM and
+                    is advertised to all peers of the router. These groups will be
+                    advertised in addition to any specified prefixes. Leave this field
+                    blank to advertise no custom groups.
+
+                    This enum field has the one valid value: ALL_SUBNETS
+                  items:
+                    type: string
+                  type: array
+                advertisedIpRanges:
+                  description: |-
+                    User-specified list of individual IP ranges to advertise in
+                    custom mode. This field can only be populated if advertiseMode
+                    is CUSTOM and is advertised to all peers of the router. These IP
+                    ranges will be advertised in addition to any specified groups.
+                    Leave this field blank to advertise no custom IP ranges.
+                  items:
+                    properties:
+                      description:
+                        description: User-specified description for the IP range.
+                        type: string
+                      range:
+                        description: |-
+                          The IP range to advertise. The value must be a
+                          CIDR-formatted string.
+                        type: string
+                    required:
+                    - range
+                    type: object
+                  type: array
+                asn:
+                  description: |-
+                    Local BGP Autonomous System Number (ASN). Must be an RFC6996
+                    private ASN, either 16-bit or 32-bit. The value will be fixed for
+                    this router resource. All VPN tunnels that link to this router
+                    will have the same local ASN.
+                  type: integer
+              required:
+              - asn
+              type: object
+            description:
+              description: An optional description of this resource.
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            region:
+              description: Region where the router resides.
+              type: string
+          required:
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeroutes.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeroutes.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,227 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeroutes.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeRoute
+    plural: computeroutes
+    shortNames:
+    - gcpcomputeroute
+    - gcpcomputeroutes
+    singular: computeroute
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: |-
+                An optional description of this resource. Provide this property
+                when you create the resource.
+              type: string
+            destRange:
+              description: |-
+                The destination range of outgoing packets that this route applies to.
+                Only IPv4 is supported.
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            nextHopGateway:
+              description: |-
+                URL to a gateway that should handle matching packets.
+                Currently, you can only specify the internet gateway, using a full or
+                partial valid URL:
+                * 'https://www.googleapis.com/compute/v1/projects/project/global/gateways/default-internet-gateway'
+                * 'projects/project/global/gateways/default-internet-gateway'
+                * 'global/gateways/default-internet-gateway'
+                * The string 'default-internet-gateway'.
+              type: string
+            nextHopILBRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            nextHopInstanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            nextHopIp:
+              description: Network IP address of an instance that should handle matching
+                packets.
+              type: string
+            nextHopVPNTunnelRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            priority:
+              description: |-
+                The priority of this route. Priority is used to break ties in cases
+                where there is more than one matching route of equal prefix length.
+
+                In the case of two routes with equal prefix length, the one with the
+                lowest-numbered priority value wins.
+
+                Default value is 1000. Valid range is 0 through 65535.
+              type: integer
+            tags:
+              description: A list of instance tags to which this route applies.
+              items:
+                type: string
+              type: array
+          required:
+          - destRange
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            nextHopNetwork:
+              description: URL to a Network that should handle matching packets.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesecuritypolicies.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesecuritypolicies.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,122 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesecuritypolicies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSecurityPolicy
+    plural: computesecuritypolicies
+    shortNames:
+    - gcpcomputesecuritypolicy
+    - gcpcomputesecuritypolicies
+    singular: computesecuritypolicy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            rule:
+              items:
+                properties:
+                  action:
+                    type: string
+                  description:
+                    type: string
+                  match:
+                    properties:
+                      config:
+                        properties:
+                          srcIpRanges:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - srcIpRanges
+                        type: object
+                      expr:
+                        properties:
+                          expression:
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      versionedExpr:
+                        type: string
+                    type: object
+                  preview:
+                    type: boolean
+                  priority:
+                    type: integer
+                required:
+                - action
+                - match
+                - priority
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            fingerprint:
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesharedvpchostprojects.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesharedvpchostprojects.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,75 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesharedvpchostprojects.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSharedVPCHostProject
+    plural: computesharedvpchostprojects
+    shortNames:
+    - gcpcomputesharedvpchostproject
+    - gcpcomputesharedvpchostprojects
+    singular: computesharedvpchostproject
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesharedvpcserviceprojects.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesharedvpcserviceprojects.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,107 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesharedvpcserviceprojects.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSharedVPCServiceProject
+    plural: computesharedvpcserviceprojects
+    shortNames:
+    - gcpcomputesharedvpcserviceproject
+    - gcpcomputesharedvpcserviceprojects
+    singular: computesharedvpcserviceproject
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            projectRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - projectRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesnapshots.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesnapshots.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,246 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesnapshots.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSnapshot
+    plural: computesnapshots
+    shortNames:
+    - gcpcomputesnapshot
+    - gcpcomputesnapshots
+    singular: computesnapshot
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            snapshotEncryptionKey:
+              description: |-
+                The customer-supplied encryption key of the snapshot. Required if the
+                source snapshot is protected by a customer-supplied encryption key.
+              properties:
+                rawKey:
+                  description: |-
+                    Specifies a 256-bit customer-supplied encryption key, encoded in
+                    RFC 4648 base64 to either encrypt or decrypt this resource.
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                sha256:
+                  description: |-
+                    The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
+                    encryption key that protects this resource.
+                  type: string
+              required:
+              - rawKey
+              type: object
+            sourceDiskEncryptionKey:
+              description: |-
+                The customer-supplied encryption key of the source snapshot. Required
+                if the source snapshot is protected by a customer-supplied encryption
+                key.
+              properties:
+                rawKey:
+                  description: |-
+                    Specifies a 256-bit customer-supplied encryption key, encoded in
+                    RFC 4648 base64 to either encrypt or decrypt this resource.
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+              type: object
+            sourceDiskRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            zone:
+              description: A reference to the zone where the disk is hosted.
+              type: string
+          required:
+          - sourceDiskRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            diskSizeGb:
+              description: Size of the snapshot, specified in GB.
+              type: integer
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource. Used
+                internally during updates.
+              type: string
+            licenses:
+              description: |-
+                A list of public visible licenses that apply to this snapshot. This
+                can be because the original image had licenses attached (such as a
+                Windows image).  snapshotEncryptionKey nested object Encrypts the
+                snapshot using a customer-supplied encryption key.
+              items:
+                type: string
+              type: array
+            selfLink:
+              type: string
+            snapshotId:
+              description: The unique identifier for the resource.
+              type: integer
+            sourceDiskLink:
+              type: string
+            storageBytes:
+              description: |-
+                A size of the storage used by the snapshot. As snapshots share
+                storage, this number is expected to change with snapshot
+                creation/deletion.
+              type: integer
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesslcertificates.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesslcertificates.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,178 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesslcertificates.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSSLCertificate
+    plural: computesslcertificates
+    shortNames:
+    - gcpcomputesslcertificate
+    - gcpcomputesslcertificates
+    singular: computesslcertificate
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            certificate:
+              description: |-
+                The certificate in PEM format.
+                The certificate chain must be no greater than 5 certs long.
+                The chain must include at least one intermediate cert.
+              oneOf:
+              - not:
+                  required:
+                  - valueFrom
+                required:
+                - value
+              - not:
+                  required:
+                  - value
+                required:
+                - valueFrom
+              properties:
+                value:
+                  description: Value of the field. Cannot be used if 'valueFrom' is
+                    specified.
+                  type: string
+                valueFrom:
+                  description: Source for the field's value. Cannot be used if 'value'
+                    is specified.
+                  properties:
+                    secretKeyRef:
+                      description: Reference to a value with the given key in the
+                        given Secret in the resource's namespace.
+                      properties:
+                        key:
+                          description: Key that identifies the value to be extracted.
+                          type: string
+                        name:
+                          description: Name of the Secret to extract a value from.
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+              type: object
+            description:
+              description: An optional description of this resource.
+              type: string
+            location:
+              description: Location represents the geographical location of the ComputeSSLCertificate.
+                Specify "global" for global resources.
+              type: string
+            privateKey:
+              description: The write-only private key in PEM format.
+              oneOf:
+              - not:
+                  required:
+                  - valueFrom
+                required:
+                - value
+              - not:
+                  required:
+                  - value
+                required:
+                - valueFrom
+              properties:
+                value:
+                  description: Value of the field. Cannot be used if 'valueFrom' is
+                    specified.
+                  type: string
+                valueFrom:
+                  description: Source for the field's value. Cannot be used if 'value'
+                    is specified.
+                  properties:
+                    secretKeyRef:
+                      description: Reference to a value with the given key in the
+                        given Secret in the resource's namespace.
+                      properties:
+                        key:
+                          description: Key that identifies the value to be extracted.
+                          type: string
+                        name:
+                          description: Name of the Secret to extract a value from.
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+              type: object
+          required:
+          - certificate
+          - location
+          - privateKey
+          type: object
+        status:
+          properties:
+            certificateId:
+              description: The unique identifier for the resource.
+              type: integer
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesslpolicies.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesslpolicies.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,131 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesslpolicies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSSLPolicy
+    plural: computesslpolicies
+    shortNames:
+    - gcpcomputesslpolicy
+    - gcpcomputesslpolicies
+    singular: computesslpolicy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            customFeatures:
+              description: |-
+                Profile specifies the set of SSL features that can be used by the
+                load balancer when negotiating SSL with clients. This can be one of
+                'COMPATIBLE', 'MODERN', 'RESTRICTED', or 'CUSTOM'. If using 'CUSTOM',
+                the set of SSL features to enable must be specified in the
+                'customFeatures' field.
+
+                See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
+                for which ciphers are available to use. **Note**: this argument
+                *must* be present when using the 'CUSTOM' profile. This argument
+                *must not* be present when using any other profile.
+              items:
+                type: string
+              type: array
+            description:
+              description: An optional description of this resource.
+              type: string
+            minTlsVersion:
+              description: |-
+                The minimum version of SSL protocol that can be used by the clients
+                to establish a connection with the load balancer. This can be one of
+                'TLS_1_0', 'TLS_1_1', 'TLS_1_2'.
+                 Default is 'TLS_1_0'.
+              type: string
+            profile:
+              description: |-
+                Profile specifies the set of SSL features that can be used by the
+                load balancer when negotiating SSL with clients. This can be one of
+                'COMPATIBLE', 'MODERN', 'RESTRICTED', or 'CUSTOM'. If using 'CUSTOM',
+                the set of SSL features to enable must be specified in the
+                'customFeatures' field.
+
+                See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
+                for information on what cipher suites each profile provides. If
+                'CUSTOM' is used, the 'custom_features' attribute **must be set**.
+                Default is 'COMPATIBLE'.
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            enabledFeatures:
+              description: The list of features enabled in the SSL policy.
+              items:
+                type: string
+              type: array
+            fingerprint:
+              description: |-
+                Fingerprint of this resource. A hash of the contents stored in this
+                object. This field is used in optimistic locking.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesubnetworks.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computesubnetworks.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,214 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesubnetworks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSubnetwork
+    plural: computesubnetworks
+    shortNames:
+    - gcpcomputesubnetwork
+    - gcpcomputesubnetworks
+    singular: computesubnetwork
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource. This field can be set only at resource
+                creation time.
+              type: string
+            ipCidrRange:
+              description: |-
+                The range of internal addresses that are owned by this subnetwork.
+                Provide this property when you create the subnetwork. For example,
+                10.0.0.0/8 or 192.168.0.0/16. Ranges must be unique and
+                non-overlapping within a network. Only IPv4 is supported.
+              type: string
+            logConfig:
+              description: |-
+                Denotes the logging options for the subnetwork flow logs. If logging is enabled
+                logs will be exported to Stackdriver. This field cannot be set if the 'purpose' of this
+                subnetwork is 'INTERNAL_HTTPS_LOAD_BALANCER'
+              properties:
+                aggregationInterval:
+                  description: |-
+                    Can only be specified if VPC flow logging for this subnetwork is enabled.
+                    Toggles the aggregation interval for collecting flow logs. Increasing the
+                    interval time will reduce the amount of generated flow logs for long
+                    lasting connections. Default is an interval of 5 seconds per connection.
+                    Possible values are INTERVAL_5_SEC, INTERVAL_30_SEC, INTERVAL_1_MIN,
+                    INTERVAL_5_MIN, INTERVAL_10_MIN, INTERVAL_15_MIN
+                  type: string
+                flowSampling:
+                  description: |-
+                    Can only be specified if VPC flow logging for this subnetwork is enabled.
+                    The value of the field must be in [0, 1]. Set the sampling rate of VPC
+                    flow logs within the subnetwork where 1.0 means all collected logs are
+                    reported and 0.0 means no logs are reported. Default is 0.5 which means
+                    half of all collected logs are reported.
+                  type: number
+                metadata:
+                  description: |-
+                    Can only be specified if VPC flow logging for this subnetwork is enabled.
+                    Configures whether metadata fields should be added to the reported VPC
+                    flow logs. Default is 'INCLUDE_ALL_METADATA'.
+                  type: string
+              type: object
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            privateIpGoogleAccess:
+              description: |-
+                When enabled, VMs in this subnetwork without external IP addresses can
+                access Google APIs and services by using Private Google Access.
+              type: boolean
+            purpose:
+              description: |-
+                The purpose of the resource. This field can be either PRIVATE
+                or INTERNAL_HTTPS_LOAD_BALANCER. A subnetwork with purpose set to
+                INTERNAL_HTTPS_LOAD_BALANCER is a user-created subnetwork that is
+                reserved for Internal HTTP(S) Load Balancing. If unspecified, the
+                purpose defaults to PRIVATE.
+
+                If set to INTERNAL_HTTPS_LOAD_BALANCER you must also set the role.
+              type: string
+            region:
+              description: URL of the GCP region for this subnetwork.
+              type: string
+            role:
+              description: |-
+                The role of subnetwork. Currently, this field is only used when
+                purpose = INTERNAL_HTTPS_LOAD_BALANCER. The value can be set to ACTIVE
+                or BACKUP. An ACTIVE subnetwork is one that is currently being used
+                for Internal HTTP(S) Load Balancing. A BACKUP subnetwork is one that
+                is ready to be promoted to ACTIVE or is currently draining.
+              type: string
+            secondaryIpRange:
+              items:
+                properties:
+                  ipCidrRange:
+                    description: |-
+                      The range of IP addresses belonging to this subnetwork secondary
+                      range. Provide this property when you create the subnetwork.
+                      Ranges must be unique and non-overlapping with all primary and
+                      secondary IP ranges within a network. Only IPv4 is supported.
+                    type: string
+                  rangeName:
+                    description: |-
+                      The name associated with this subnetwork secondary range, used
+                      when adding an alias IP range to a VM instance. The name must
+                      be 1-63 characters long, and comply with RFC1035. The name
+                      must be unique within the subnetwork.
+                    type: string
+                required:
+                - ipCidrRange
+                - rangeName
+                type: object
+              type: array
+          required:
+          - ipCidrRange
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            fingerprint:
+              description: DEPRECATED — This field is not useful for users, and has
+                been removed as an output. Fingerprint of this resource. This field
+                is used internally during updates of this resource.
+              type: string
+            gatewayAddress:
+              description: |-
+                The gateway address for default routes to reach destination addresses
+                outside this subnetwork.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargethttpproxies.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargethttpproxies.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargethttpproxies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetHTTPProxy
+    plural: computetargethttpproxies
+    shortNames:
+    - gcpcomputetargethttpproxy
+    - gcpcomputetargethttpproxies
+    singular: computetargethttpproxy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            location:
+              description: Location represents the geographical location of the ComputeTargetHTTPProxy.
+                Specify "global" for global resources.
+              type: string
+            urlMapRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - location
+          - urlMapRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            proxyId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargethttpsproxies.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargethttpsproxies.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,185 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargethttpsproxies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetHTTPSProxy
+    plural: computetargethttpsproxies
+    shortNames:
+    - gcpcomputetargethttpsproxy
+    - gcpcomputetargethttpsproxies
+    singular: computetargethttpsproxy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            location:
+              description: Location represents the geographical location of the ComputeTargetHTTPSProxy.
+                Specify "global" for global resources.
+              type: string
+            quicOverride:
+              description: |-
+                Specifies the QUIC override policy for this resource. This determines
+                whether the load balancer will attempt to negotiate QUIC with clients
+                or not. Can specify one of NONE, ENABLE, or DISABLE. If NONE is
+                specified, uses the QUIC policy with no user overrides, which is
+                equivalent to DISABLE. Not specifying this field is equivalent to
+                specifying NONE.
+              type: string
+            sslCertificates:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            sslPolicyRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            urlMapRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - location
+          - sslCertificates
+          - urlMapRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            proxyId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargetinstances.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargetinstances.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargetinstances.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetInstance
+    plural: computetargetinstances
+    shortNames:
+    - gcpcomputetargetinstance
+    - gcpcomputetargetinstances
+    singular: computetargetinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            instanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            natPolicy:
+              description: |-
+                NAT option controlling how IPs are NAT'ed to the instance.
+                Currently only NO_NAT (default value) is supported.
+              type: string
+            zone:
+              description: URL of the zone where the target instance resides.
+              type: string
+          required:
+          - instanceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargetpools.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargetpools.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,170 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargetpools.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetPool
+    plural: computetargetpools
+    shortNames:
+    - gcpcomputetargetpool
+    - gcpcomputetargetpools
+    singular: computetargetpool
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            backupTargetPoolRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            description:
+              type: string
+            failoverRatio:
+              type: number
+            healthChecks:
+              items:
+                properties:
+                  httpHealthCheckRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                type: object
+              type: array
+            instances:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            region:
+              type: string
+            sessionAffinity:
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargetsslproxies.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargetsslproxies.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,176 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargetsslproxies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetSSLProxy
+    plural: computetargetsslproxies
+    shortNames:
+    - gcpcomputetargetsslproxy
+    - gcpcomputetargetsslproxies
+    singular: computetargetsslproxy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            backendServiceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            description:
+              description: An optional description of this resource.
+              type: string
+            proxyHeader:
+              description: |-
+                Specifies the type of proxy header to append before sending data to
+                the backend, either NONE or PROXY_V1. The default is NONE.
+              type: string
+            sslCertificates:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            sslPolicyRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - backendServiceRef
+          - sslCertificates
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            proxyId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargettcpproxies.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargettcpproxies.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargettcpproxies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetTCPProxy
+    plural: computetargettcpproxies
+    shortNames:
+    - gcpcomputetargettcpproxy
+    - gcpcomputetargettcpproxies
+    singular: computetargettcpproxy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            backendServiceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            description:
+              description: An optional description of this resource.
+              type: string
+            proxyHeader:
+              description: |-
+                Specifies the type of proxy header to append before sending data to
+                the backend, either NONE or PROXY_V1. The default is NONE.
+              type: string
+          required:
+          - backendServiceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            proxyId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargetvpngateways.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computetargetvpngateways.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,121 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargetvpngateways.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetVPNGateway
+    plural: computetargetvpngateways
+    shortNames:
+    - gcpcomputetargetvpngateway
+    - gcpcomputetargetvpngateways
+    singular: computetargetvpngateway
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            region:
+              description: The region this gateway should sit in.
+              type: string
+          required:
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            gatewayId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeurlmaps.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computeurlmaps.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,1654 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeurlmaps.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeURLMap
+    plural: computeurlmaps
+    shortNames:
+    - gcpcomputeurlmap
+    - gcpcomputeurlmaps
+    singular: computeurlmap
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            defaultService:
+              properties:
+                backendBucketRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                backendServiceRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              type: object
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when you create
+                the resource.
+              type: string
+            headerAction:
+              description: |-
+                Specifies changes to request and response headers that need to take effect for
+                the selected backendService. The headerAction specified here take effect after
+                headerAction specified under pathMatcher.
+              properties:
+                requestHeadersToAdd:
+                  description: |-
+                    Headers to add to a matching request prior to forwarding the request to the
+                    backendService.
+                  items:
+                    properties:
+                      headerName:
+                        description: The name of the header.
+                        type: string
+                      headerValue:
+                        description: The value of the header to add.
+                        type: string
+                      replace:
+                        description: |-
+                          If false, headerValue is appended to any values that already exist for the
+                          header. If true, headerValue is set for the header, discarding any values that
+                          were set for that header.
+                        type: boolean
+                    required:
+                    - headerName
+                    - headerValue
+                    - replace
+                    type: object
+                  type: array
+                requestHeadersToRemove:
+                  description: |-
+                    A list of header names for headers that need to be removed from the request
+                    prior to forwarding the request to the backendService.
+                  items:
+                    type: string
+                  type: array
+                responseHeadersToAdd:
+                  description: Headers to add the response prior to sending the response
+                    back to the client.
+                  items:
+                    properties:
+                      headerName:
+                        description: The name of the header.
+                        type: string
+                      headerValue:
+                        description: The value of the header to add.
+                        type: string
+                      replace:
+                        description: |-
+                          If false, headerValue is appended to any values that already exist for the
+                          header. If true, headerValue is set for the header, discarding any values that
+                          were set for that header.
+                        type: boolean
+                    required:
+                    - headerName
+                    - headerValue
+                    - replace
+                    type: object
+                  type: array
+                responseHeadersToRemove:
+                  description: |-
+                    A list of header names for headers that need to be removed from the response
+                    prior to sending the response back to the client.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            hostRule:
+              description: The list of HostRules to use against the URL.
+              items:
+                properties:
+                  description:
+                    description: |-
+                      An optional description of this resource. Provide this property when you create
+                      the resource.
+                    type: string
+                  hosts:
+                    description: |-
+                      The list of host patterns to match. They must be valid hostnames, except * will
+                      match any string of ([a-z0-9-.]*). In that case, * must be the first character
+                      and must be followed in the pattern by either - or ..
+                    items:
+                      type: string
+                    type: array
+                  pathMatcher:
+                    description: |-
+                      The name of the PathMatcher to use to match the path portion of the URL if the
+                      hostRule matches the URL's host portion.
+                    type: string
+                required:
+                - hosts
+                - pathMatcher
+                type: object
+              type: array
+            location:
+              description: Location represents the geographical location of the ComputeURLMap.
+                Specify "global" for global resources.
+              type: string
+            pathMatcher:
+              description: The list of named PathMatchers to use against the URL.
+              items:
+                properties:
+                  defaultService:
+                    properties:
+                      backendBucketRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                      backendServiceRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                    type: object
+                  description:
+                    description: |-
+                      An optional description of this resource. Provide this property when you create
+                      the resource.
+                    type: string
+                  headerAction:
+                    description: |-
+                      Specifies changes to request and response headers that need to take effect for
+                      the selected backendService. HeaderAction specified here are applied after the
+                      matching HttpRouteRule HeaderAction and before the HeaderAction in the UrlMap
+                    properties:
+                      requestHeadersToAdd:
+                        description: |-
+                          Headers to add to a matching request prior to forwarding the request to the
+                          backendService.
+                        items:
+                          properties:
+                            headerName:
+                              description: The name of the header.
+                              type: string
+                            headerValue:
+                              description: The value of the header to add.
+                              type: string
+                            replace:
+                              description: |-
+                                If false, headerValue is appended to any values that already exist for the
+                                header. If true, headerValue is set for the header, discarding any values that
+                                were set for that header.
+                              type: boolean
+                          required:
+                          - headerName
+                          - headerValue
+                          - replace
+                          type: object
+                        type: array
+                      requestHeadersToRemove:
+                        description: |-
+                          A list of header names for headers that need to be removed from the request
+                          prior to forwarding the request to the backendService.
+                        items:
+                          type: string
+                        type: array
+                      responseHeadersToAdd:
+                        description: Headers to add the response prior to sending
+                          the response back to the client.
+                        items:
+                          properties:
+                            headerName:
+                              description: The name of the header.
+                              type: string
+                            headerValue:
+                              description: The value of the header to add.
+                              type: string
+                            replace:
+                              description: |-
+                                If false, headerValue is appended to any values that already exist for the
+                                header. If true, headerValue is set for the header, discarding any values that
+                                were set for that header.
+                              type: boolean
+                          required:
+                          - headerName
+                          - headerValue
+                          - replace
+                          type: object
+                        type: array
+                      responseHeadersToRemove:
+                        description: |-
+                          A list of header names for headers that need to be removed from the response
+                          prior to sending the response back to the client.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  name:
+                    description: The name to which this PathMatcher is referred by
+                      the HostRule.
+                    type: string
+                  pathRule:
+                    description: |-
+                      The list of path rules. Use this list instead of routeRules when routing based
+                      on simple path matching is all that's required. The order by which path rules
+                      are specified does not matter. Matches are always done on the longest-path-first
+                      basis. For example: a pathRule with a path /a/b/c/* will match before /a/b/*
+                      irrespective of the order in which those paths appear in this list. Within a
+                      given pathMatcher, only one of pathRules or routeRules must be set.
+                    items:
+                      properties:
+                        paths:
+                          description: |-
+                            The list of path patterns to match. Each must start with / and the only place a
+                            * is allowed is at the end following a /. The string fed to the path matcher
+                            does not include any text after the first ? or #, and those chars are not
+                            allowed here.
+                          items:
+                            type: string
+                          type: array
+                        routeAction:
+                          description: |-
+                            In response to a matching path, the load balancer performs advanced routing
+                            actions like URL rewrites, header transformations, etc. prior to forwarding the
+                            request to the selected backend. If routeAction specifies any
+                            weightedBackendServices, service must not be set. Conversely if service is set,
+                            routeAction cannot contain any  weightedBackendServices. Only one of routeAction
+                            or urlRedirect must be set.
+                          properties:
+                            corsPolicy:
+                              description: |-
+                                The specification for allowing client side cross-origin requests. Please see W3C
+                                Recommendation for Cross Origin Resource Sharing
+                              properties:
+                                allowCredentials:
+                                  description: |-
+                                    In response to a preflight request, setting this to true indicates that the
+                                    actual request can include user credentials. This translates to the Access-
+                                    Control-Allow-Credentials header. Defaults to false.
+                                  type: boolean
+                                allowHeaders:
+                                  description: Specifies the content for the Access-Control-Allow-Headers
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowMethods:
+                                  description: Specifies the content for the Access-Control-Allow-Methods
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowOriginRegexes:
+                                  description: |-
+                                    Specifies the regualar expression patterns that match allowed origins. For
+                                    regular expression grammar please see en.cppreference.com/w/cpp/regex/ecmascript
+                                    An origin is allowed if it matches either allow_origins or allow_origin_regex.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowOrigins:
+                                  description: |-
+                                    Specifies the list of origins that will be allowed to do CORS requests. An
+                                    origin is allowed if it matches either allow_origins or allow_origin_regex.
+                                  items:
+                                    type: string
+                                  type: array
+                                disabled:
+                                  description: If true, specifies the CORS policy
+                                    is disabled.
+                                  type: boolean
+                                exposeHeaders:
+                                  description: Specifies the content for the Access-Control-Expose-Headers
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                maxAge:
+                                  description: |-
+                                    Specifies how long the results of a preflight request can be cached. This
+                                    translates to the content for the Access-Control-Max-Age header.
+                                  type: integer
+                              required:
+                              - disabled
+                              type: object
+                            faultInjectionPolicy:
+                              description: |-
+                                The specification for fault injection introduced into traffic to test the
+                                resiliency of clients to backend service failure. As part of fault injection,
+                                when clients send requests to a backend service, delays can be introduced by
+                                Loadbalancer on a percentage of requests before sending those request to the
+                                backend service. Similarly requests from clients can be aborted by the
+                                Loadbalancer for a percentage of requests. timeout and retry_policy will be
+                                ignored by clients that are configured with a fault_injection_policy.
+                              properties:
+                                abort:
+                                  description: |-
+                                    The specification for how client requests are aborted as part of fault
+                                    injection.
+                                  properties:
+                                    httpStatus:
+                                      description: |-
+                                        The HTTP status code used to abort the request. The value must be between 200
+                                        and 599 inclusive.
+                                      type: integer
+                                    percentage:
+                                      description: |-
+                                        The percentage of traffic (connections/operations/requests) which will be
+                                        aborted as part of fault injection. The value must be between 0.0 and 100.0
+                                        inclusive.
+                                      type: number
+                                  required:
+                                  - httpStatus
+                                  - percentage
+                                  type: object
+                                delay:
+                                  description: |-
+                                    The specification for how client requests are delayed as part of fault
+                                    injection, before being sent to a backend service.
+                                  properties:
+                                    fixedDelay:
+                                      description: Specifies the value of the fixed
+                                        delay interval.
+                                      properties:
+                                        nanos:
+                                          description: |-
+                                            Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                            less than one second are represented with a 0 'seconds' field and a positive
+                                            'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                          type: integer
+                                        seconds:
+                                          description: |-
+                                            Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                            inclusive.
+                                          type: string
+                                      required:
+                                      - seconds
+                                      type: object
+                                    percentage:
+                                      description: |-
+                                        The percentage of traffic (connections/operations/requests) on which delay will
+                                        be introduced as part of fault injection. The value must be between 0.0 and
+                                        100.0 inclusive.
+                                      type: number
+                                  required:
+                                  - fixedDelay
+                                  - percentage
+                                  type: object
+                              type: object
+                            requestMirrorPolicy:
+                              description: |-
+                                Specifies the policy on how requests intended for the route's backends are
+                                shadowed to a separate mirrored backend service. Loadbalancer does not wait for
+                                responses from the shadow service. Prior to sending traffic to the shadow
+                                service, the host / authority header is suffixed with -shadow.
+                              properties:
+                                backendService:
+                                  description: The BackendService resource being mirrored
+                                    to.
+                                  type: string
+                              required:
+                              - backendService
+                              type: object
+                            retryPolicy:
+                              description: Specifies the retry policy associated with
+                                this route.
+                              properties:
+                                numRetries:
+                                  description: Specifies the allowed number retries.
+                                    This number must be > 0.
+                                  type: integer
+                                perTryTimeout:
+                                  description: Specifies a non-zero timeout per retry
+                                    attempt.
+                                  properties:
+                                    nanos:
+                                      description: |-
+                                        Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                        less than one second are represented with a 0 'seconds' field and a positive
+                                        'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                      type: integer
+                                    seconds:
+                                      description: |-
+                                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                        inclusive.
+                                      type: string
+                                  required:
+                                  - seconds
+                                  type: object
+                                retryConditions:
+                                  description: |-
+                                    Specifies one or more conditions when this retry rule applies. Valid values are:
+                                    - 5xx: Loadbalancer will attempt a retry if the backend service responds with
+                                    any 5xx response code, or if the backend service does not respond at all,
+                                    example: disconnects, reset, read timeout, connection failure, and refused
+                                    streams.
+                                    - gateway-error: Similar to 5xx, but only applies to response codes
+                                    502, 503 or 504.
+                                    - connect-failure: Loadbalancer will retry on failures
+                                    connecting to backend services, for example due to connection timeouts.
+                                    - retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                                    Currently the only retriable error supported is 409.
+                                    - refused-stream: Loadbalancer will retry if the backend service resets the stream with a
+                                    REFUSED_STREAM error code. This reset type indicates that it is safe to retry.
+                                    - cancelled: Loadbalancer will retry if the gRPC status code in the response
+                                    header is set to cancelled
+                                    - deadline-exceeded: Loadbalancer will retry if the
+                                    gRPC status code in the response header is set to deadline-exceeded
+                                    - resource-exhausted: Loadbalancer will retry if the gRPC status code in the response
+                                    header is set to resource-exhausted
+                                    - unavailable: Loadbalancer will retry if
+                                    the gRPC status code in the response header is set to unavailable
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            timeout:
+                              description: |-
+                                Specifies the timeout for the selected route. Timeout is computed from the time
+                                the request is has been fully processed (i.e. end-of-stream) up until the
+                                response has been completely processed. Timeout includes all retries. If not
+                                specified, the default value is 15 seconds.
+                              properties:
+                                nanos:
+                                  description: |-
+                                    Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                    less than one second are represented with a 0 'seconds' field and a positive
+                                    'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                  type: integer
+                                seconds:
+                                  description: |-
+                                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                    inclusive.
+                                  type: string
+                              required:
+                              - seconds
+                              type: object
+                            urlRewrite:
+                              description: |-
+                                The spec to modify the URL of the request, prior to forwarding the request to
+                                the matched service
+                              properties:
+                                hostRewrite:
+                                  description: |-
+                                    Prior to forwarding the request to the selected service, the request's host
+                                    header is replaced with contents of hostRewrite. The value must be between 1 and
+                                    255 characters.
+                                  type: string
+                                pathPrefixRewrite:
+                                  description: |-
+                                    Prior to forwarding the request to the selected backend service, the matching
+                                    portion of the request's path is replaced by pathPrefixRewrite. The value must
+                                    be between 1 and 1024 characters.
+                                  type: string
+                              type: object
+                            weightedBackendServices:
+                              description: |-
+                                A list of weighted backend services to send traffic to when a route match
+                                occurs. The weights determine the fraction of traffic that flows to their
+                                corresponding backend service. If all traffic needs to go to a single backend
+                                service, there must be one  weightedBackendService with weight set to a non 0
+                                number. Once a backendService is identified and before forwarding the request to
+                                the backend service, advanced routing actions like Url rewrites and header
+                                transformations are applied depending on additional settings specified in this
+                                HttpRouteAction.
+                              items:
+                                properties:
+                                  backendServiceRef:
+                                    oneOf:
+                                    - not:
+                                        required:
+                                        - external
+                                      required:
+                                      - name
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - name
+                                        - required:
+                                          - namespace
+                                      required:
+                                      - external
+                                    properties:
+                                      external:
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      namespace:
+                                        description: 'Namespace of the referent. More
+                                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                        type: string
+                                    type: object
+                                  headerAction:
+                                    description: |-
+                                      Specifies changes to request and response headers that need to take effect for
+                                      the selected backendService. headerAction specified here take effect before
+                                      headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+                                    properties:
+                                      requestHeadersToAdd:
+                                        description: |-
+                                          Headers to add to a matching request prior to forwarding the request to the
+                                          backendService.
+                                        items:
+                                          properties:
+                                            headerName:
+                                              description: The name of the header.
+                                              type: string
+                                            headerValue:
+                                              description: The value of the header
+                                                to add.
+                                              type: string
+                                            replace:
+                                              description: |-
+                                                If false, headerValue is appended to any values that already exist for the
+                                                header. If true, headerValue is set for the header, discarding any values that
+                                                were set for that header.
+                                              type: boolean
+                                          required:
+                                          - headerName
+                                          - headerValue
+                                          - replace
+                                          type: object
+                                        type: array
+                                      requestHeadersToRemove:
+                                        description: |-
+                                          A list of header names for headers that need to be removed from the request
+                                          prior to forwarding the request to the backendService.
+                                        items:
+                                          type: string
+                                        type: array
+                                      responseHeadersToAdd:
+                                        description: Headers to add the response prior
+                                          to sending the response back to the client.
+                                        items:
+                                          properties:
+                                            headerName:
+                                              description: The name of the header.
+                                              type: string
+                                            headerValue:
+                                              description: The value of the header
+                                                to add.
+                                              type: string
+                                            replace:
+                                              description: |-
+                                                If false, headerValue is appended to any values that already exist for the
+                                                header. If true, headerValue is set for the header, discarding any values that
+                                                were set for that header.
+                                              type: boolean
+                                          required:
+                                          - headerName
+                                          - headerValue
+                                          - replace
+                                          type: object
+                                        type: array
+                                      responseHeadersToRemove:
+                                        description: |-
+                                          A list of header names for headers that need to be removed from the response
+                                          prior to sending the response back to the client.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      Specifies the fraction of traffic sent to backendService, computed as weight /
+                                      (sum of all weightedBackendService weights in routeAction) . The selection of a
+                                      backend service is determined only for new traffic. Once a user's request has
+                                      been directed to a backendService, subsequent requests will be sent to the same
+                                      backendService as determined by the BackendService's session affinity policy.
+                                      The value must be between 0 and 1000
+                                    type: integer
+                                required:
+                                - backendServiceRef
+                                - weight
+                                type: object
+                              type: array
+                          type: object
+                        service:
+                          properties:
+                            backendBucketRef:
+                              oneOf:
+                              - not:
+                                  required:
+                                  - external
+                                required:
+                                - name
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - name
+                                  - required:
+                                    - namespace
+                                required:
+                                - external
+                              properties:
+                                external:
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                              type: object
+                            backendServiceRef:
+                              oneOf:
+                              - not:
+                                  required:
+                                  - external
+                                required:
+                                - name
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - name
+                                  - required:
+                                    - namespace
+                                required:
+                                - external
+                              properties:
+                                external:
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                              type: object
+                          type: object
+                        urlRedirect:
+                          description: |-
+                            When a path pattern is matched, the request is redirected to a URL specified by
+                            urlRedirect. If urlRedirect is specified, service or routeAction must not be
+                            set.
+                          properties:
+                            hostRedirect:
+                              description: |-
+                                The host that will be used in the redirect response instead of the one that was
+                                supplied in the request. The value must be between 1 and 255 characters.
+                              type: string
+                            httpsRedirect:
+                              description: |-
+                                If set to true, the URL scheme in the redirected request is set to https. If set
+                                to false, the URL scheme of the redirected request will remain the same as that
+                                of the request. This must only be set for UrlMaps used in TargetHttpProxys.
+                                Setting this true for TargetHttpsProxy is not permitted. Defaults to false.
+                              type: boolean
+                            pathRedirect:
+                              description: |-
+                                The path that will be used in the redirect response instead of the one that was
+                                supplied in the request. Only one of pathRedirect or prefixRedirect must be
+                                specified. The value must be between 1 and 1024 characters.
+                              type: string
+                            prefixRedirect:
+                              description: |-
+                                The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
+                                retaining the remaining portion of the URL before redirecting the request.
+                              type: string
+                            redirectResponseCode:
+                              description: |-
+                                The HTTP Status code to use for this RedirectAction. Supported values are:
+                                - MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+                                - FOUND, which corresponds to 302.
+                                - SEE_OTHER which corresponds to 303.
+                                - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                                will be retained.
+                                - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                                the request method will be retained.
+                              type: string
+                            stripQuery:
+                              description: |-
+                                If set to true, any accompanying query portion of the original URL is removed
+                                prior to redirecting the request. If set to false, the query portion of the
+                                original URL is retained.
+                              type: boolean
+                          required:
+                          - stripQuery
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  routeRules:
+                    description: |-
+                      The list of ordered HTTP route rules. Use this list instead of pathRules when
+                      advanced route matching and routing actions are desired. The order of specifying
+                      routeRules matters: the first rule that matches will cause its specified routing
+                      action to take effect. Within a given pathMatcher, only one of pathRules or
+                      routeRules must be set. routeRules are not supported in UrlMaps intended for
+                      External load balancers.
+                    items:
+                      properties:
+                        headerAction:
+                          description: |-
+                            Specifies changes to request and response headers that need to take effect for
+                            the selected backendService. The headerAction specified here are applied before
+                            the matching pathMatchers[].headerAction and after pathMatchers[].routeRules[].r
+                            outeAction.weightedBackendService.backendServiceWeightAction[].headerAction
+                          properties:
+                            requestHeadersToAdd:
+                              description: |-
+                                Headers to add to a matching request prior to forwarding the request to the
+                                backendService.
+                              items:
+                                properties:
+                                  headerName:
+                                    description: The name of the header.
+                                    type: string
+                                  headerValue:
+                                    description: The value of the header to add.
+                                    type: string
+                                  replace:
+                                    description: |-
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    type: boolean
+                                required:
+                                - headerName
+                                - headerValue
+                                - replace
+                                type: object
+                              type: array
+                            requestHeadersToRemove:
+                              description: |-
+                                A list of header names for headers that need to be removed from the request
+                                prior to forwarding the request to the backendService.
+                              items:
+                                type: string
+                              type: array
+                            responseHeadersToAdd:
+                              description: Headers to add the response prior to sending
+                                the response back to the client.
+                              items:
+                                properties:
+                                  headerName:
+                                    description: The name of the header.
+                                    type: string
+                                  headerValue:
+                                    description: The value of the header to add.
+                                    type: string
+                                  replace:
+                                    description: |-
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    type: boolean
+                                required:
+                                - headerName
+                                - headerValue
+                                - replace
+                                type: object
+                              type: array
+                            responseHeadersToRemove:
+                              description: |-
+                                A list of header names for headers that need to be removed from the response
+                                prior to sending the response back to the client.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        matchRules:
+                          description: The rules for determining a match.
+                          items:
+                            properties:
+                              fullPathMatch:
+                                description: |-
+                                  For satifying the matchRule condition, the path of the request must exactly
+                                  match the value specified in fullPathMatch after removing any query parameters
+                                  and anchor that may be part of the original URL. FullPathMatch must be between 1
+                                  and 1024 characters. Only one of prefixMatch, fullPathMatch or regexMatch must
+                                  be specified.
+                                type: string
+                              headerMatches:
+                                description: |-
+                                  Specifies a list of header match criteria, all of which must match corresponding
+                                  headers in the request.
+                                items:
+                                  properties:
+                                    exactMatch:
+                                      description: |-
+                                        The value should exactly match contents of exactMatch. Only one of exactMatch,
+                                        prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
+                                      type: string
+                                    headerName:
+                                      description: |-
+                                        The name of the HTTP header to match. For matching against the HTTP request's
+                                        authority, use a headerMatch with the header name ":authority". For matching a
+                                        request's method, use the headerName ":method".
+                                      type: string
+                                    invertMatch:
+                                      description: |-
+                                        If set to false, the headerMatch is considered a match if the match criteria
+                                        above are met. If set to true, the headerMatch is considered a match if the
+                                        match criteria above are NOT met. Defaults to false.
+                                      type: boolean
+                                    prefixMatch:
+                                      description: |-
+                                        The value of the header must start with the contents of prefixMatch. Only one of
+                                        exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                                        must be set.
+                                      type: string
+                                    presentMatch:
+                                      description: |-
+                                        A header with the contents of headerName must exist. The match takes place
+                                        whether or not the request's header has a value or not. Only one of exactMatch,
+                                        prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
+                                      type: boolean
+                                    rangeMatch:
+                                      description: |-
+                                        The header value must be an integer and its value must be in the range specified
+                                        in rangeMatch. If the header does not contain an integer, number or is empty,
+                                        the match fails. For example for a range [-5, 0]   - -3 will match.  - 0 will
+                                        not match.  - 0.25 will not match.  - -3someString will not match.   Only one of
+                                        exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                                        must be set.
+                                      properties:
+                                        rangeEnd:
+                                          description: The end of the range (exclusive).
+                                          type: integer
+                                        rangeStart:
+                                          description: The start of the range (inclusive).
+                                          type: integer
+                                      required:
+                                      - rangeEnd
+                                      - rangeStart
+                                      type: object
+                                    regexMatch:
+                                      description: |-
+                                        The value of the header must match the regualar expression specified in
+                                        regexMatch. For regular expression grammar, please see:
+                                        en.cppreference.com/w/cpp/regex/ecmascript  For matching against a port
+                                        specified in the HTTP request, use a headerMatch with headerName set to PORT and
+                                        a regular expression that satisfies the RFC2616 Host header's port specifier.
+                                        Only one of exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or
+                                        rangeMatch must be set.
+                                      type: string
+                                    suffixMatch:
+                                      description: |-
+                                        The value of the header must end with the contents of suffixMatch. Only one of
+                                        exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                                        must be set.
+                                      type: string
+                                  required:
+                                  - headerName
+                                  type: object
+                                type: array
+                              ignoreCase:
+                                description: |-
+                                  Specifies that prefixMatch and fullPathMatch matches are case sensitive.
+                                  Defaults to false.
+                                type: boolean
+                              metadataFilters:
+                                description: |-
+                                  Opaque filter criteria used by Loadbalancer to restrict routing configuration to
+                                  a limited set xDS compliant clients. In their xDS requests to Loadbalancer, xDS
+                                  clients present node metadata. If a match takes place, the relevant routing
+                                  configuration is made available to those proxies. For each metadataFilter in
+                                  this list, if its filterMatchCriteria is set to MATCH_ANY, at least one of the
+                                  filterLabels must match the corresponding label provided in the metadata. If its
+                                  filterMatchCriteria is set to MATCH_ALL, then all of its filterLabels must match
+                                  with corresponding labels in the provided metadata. metadataFilters specified
+                                  here can be overrides those specified in ForwardingRule that refers to this
+                                  UrlMap. metadataFilters only applies to Loadbalancers that have their
+                                  loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+                                items:
+                                  properties:
+                                    filterLabels:
+                                      description: |-
+                                        The list of label value pairs that must match labels in the provided metadata
+                                        based on filterMatchCriteria  This list must not be empty and can have at the
+                                        most 64 entries.
+                                      items:
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of metadata label. The name can have a maximum length of 1024 characters
+                                              and must be at least 1 character long.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              The value of the label must match the specified value. value can have a maximum
+                                              length of 1024 characters.
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    filterMatchCriteria:
+                                      description: |-
+                                        Specifies how individual filterLabel matches within the list of filterLabels
+                                        contribute towards the overall metadataFilter match. Supported values are:
+                                          - MATCH_ANY: At least one of the filterLabels must have a matching label in the
+                                        provided metadata.
+                                          - MATCH_ALL: All filterLabels must have matching labels in
+                                        the provided metadata.
+                                      type: string
+                                  required:
+                                  - filterLabels
+                                  - filterMatchCriteria
+                                  type: object
+                                type: array
+                              prefixMatch:
+                                description: |-
+                                  For satifying the matchRule condition, the request's path must begin with the
+                                  specified prefixMatch. prefixMatch must begin with a /. The value must be
+                                  between 1 and 1024 characters. Only one of prefixMatch, fullPathMatch or
+                                  regexMatch must be specified.
+                                type: string
+                              queryParameterMatches:
+                                description: |-
+                                  Specifies a list of query parameter match criteria, all of which must match
+                                  corresponding query parameters in the request.
+                                items:
+                                  properties:
+                                    exactMatch:
+                                      description: |-
+                                        The queryParameterMatch matches if the value of the parameter exactly matches
+                                        the contents of exactMatch. Only one of presentMatch, exactMatch and regexMatch
+                                        must be set.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        The name of the query parameter to match. The query parameter must exist in the
+                                        request, in the absence of which the request match fails.
+                                      type: string
+                                    presentMatch:
+                                      description: |-
+                                        Specifies that the queryParameterMatch matches if the request contains the query
+                                        parameter, irrespective of whether the parameter has a value or not. Only one of
+                                        presentMatch, exactMatch and regexMatch must be set.
+                                      type: boolean
+                                    regexMatch:
+                                      description: |-
+                                        The queryParameterMatch matches if the value of the parameter matches the
+                                        regular expression specified by regexMatch. For the regular expression grammar,
+                                        please see en.cppreference.com/w/cpp/regex/ecmascript  Only one of presentMatch,
+                                        exactMatch and regexMatch must be set.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              regexMatch:
+                                description: |-
+                                  For satifying the matchRule condition, the path of the request must satisfy the
+                                  regular expression specified in regexMatch after removing any query parameters
+                                  and anchor supplied with the original URL. For regular expression grammar please
+                                  see en.cppreference.com/w/cpp/regex/ecmascript  Only one of prefixMatch,
+                                  fullPathMatch or regexMatch must be specified.
+                                type: string
+                            type: object
+                          type: array
+                        priority:
+                          description: |-
+                            For routeRules within a given pathMatcher, priority determines the order
+                            in which load balancer will interpret routeRules. RouteRules are evaluated
+                            in order of priority, from the lowest to highest number. The priority of
+                            a rule decreases as its number increases (1, 2, 3, N+1). The first rule
+                            that matches the request is applied.
+
+                            You cannot configure two or more routeRules with the same priority.
+                            Priority for each rule must be set to a number between 0 and
+                            2147483647 inclusive.
+
+                            Priority numbers can have gaps, which enable you to add or remove rules
+                            in the future without affecting the rest of the rules. For example,
+                            1, 2, 3, 4, 5, 9, 12, 16 is a valid series of priority numbers to which
+                            you could add rules numbered from 6 to 8, 10 to 11, and 13 to 15 in the
+                            future without any impact on existing rules.
+                          type: integer
+                        routeAction:
+                          description: |-
+                            In response to a matching matchRule, the load balancer performs advanced routing
+                            actions like URL rewrites, header transformations, etc. prior to forwarding the
+                            request to the selected backend. If  routeAction specifies any
+                            weightedBackendServices, service must not be set. Conversely if service is set,
+                            routeAction cannot contain any  weightedBackendServices. Only one of routeAction
+                            or urlRedirect must be set.
+                          properties:
+                            corsPolicy:
+                              description: |-
+                                The specification for allowing client side cross-origin requests. Please see W3C
+                                Recommendation for Cross Origin Resource Sharing
+                              properties:
+                                allowCredentials:
+                                  description: |-
+                                    In response to a preflight request, setting this to true indicates that the
+                                    actual request can include user credentials. This translates to the Access-
+                                    Control-Allow-Credentials header. Defaults to false.
+                                  type: boolean
+                                allowHeaders:
+                                  description: Specifies the content for the Access-Control-Allow-Headers
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowMethods:
+                                  description: Specifies the content for the Access-Control-Allow-Methods
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowOriginRegexes:
+                                  description: |-
+                                    Specifies the regualar expression patterns that match allowed origins. For
+                                    regular expression grammar please see en.cppreference.com/w/cpp/regex/ecmascript
+                                    An origin is allowed if it matches either allow_origins or allow_origin_regex.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowOrigins:
+                                  description: |-
+                                    Specifies the list of origins that will be allowed to do CORS requests. An
+                                    origin is allowed if it matches either allow_origins or allow_origin_regex.
+                                  items:
+                                    type: string
+                                  type: array
+                                disabled:
+                                  description: |-
+                                    If true, specifies the CORS policy is disabled.
+                                    which indicates that the CORS policy is in effect. Defaults to false.
+                                  type: boolean
+                                exposeHeaders:
+                                  description: Specifies the content for the Access-Control-Expose-Headers
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                maxAge:
+                                  description: |-
+                                    Specifies how long the results of a preflight request can be cached. This
+                                    translates to the content for the Access-Control-Max-Age header.
+                                  type: integer
+                              type: object
+                            faultInjectionPolicy:
+                              description: |-
+                                The specification for fault injection introduced into traffic to test the
+                                resiliency of clients to backend service failure. As part of fault injection,
+                                when clients send requests to a backend service, delays can be introduced by
+                                Loadbalancer on a percentage of requests before sending those request to the
+                                backend service. Similarly requests from clients can be aborted by the
+                                Loadbalancer for a percentage of requests. timeout and retry_policy will be
+                                ignored by clients that are configured with a fault_injection_policy.
+                              properties:
+                                abort:
+                                  description: |-
+                                    The specification for how client requests are aborted as part of fault
+                                    injection.
+                                  properties:
+                                    httpStatus:
+                                      description: |-
+                                        The HTTP status code used to abort the request. The value must be between 200
+                                        and 599 inclusive.
+                                      type: integer
+                                    percentage:
+                                      description: |-
+                                        The percentage of traffic (connections/operations/requests) which will be
+                                        aborted as part of fault injection. The value must be between 0.0 and 100.0
+                                        inclusive.
+                                      type: number
+                                  type: object
+                                delay:
+                                  description: |-
+                                    The specification for how client requests are delayed as part of fault
+                                    injection, before being sent to a backend service.
+                                  properties:
+                                    fixedDelay:
+                                      description: Specifies the value of the fixed
+                                        delay interval.
+                                      properties:
+                                        nanos:
+                                          description: |-
+                                            Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                            less than one second are represented with a 0 'seconds' field and a positive
+                                            'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                          type: integer
+                                        seconds:
+                                          description: |-
+                                            Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                            inclusive.
+                                          type: string
+                                      required:
+                                      - seconds
+                                      type: object
+                                    percentage:
+                                      description: |-
+                                        The percentage of traffic (connections/operations/requests) on which delay will
+                                        be introduced as part of fault injection. The value must be between 0.0 and
+                                        100.0 inclusive.
+                                      type: number
+                                  type: object
+                              type: object
+                            requestMirrorPolicy:
+                              description: |-
+                                Specifies the policy on how requests intended for the route's backends are
+                                shadowed to a separate mirrored backend service. Loadbalancer does not wait for
+                                responses from the shadow service. Prior to sending traffic to the shadow
+                                service, the host / authority header is suffixed with -shadow.
+                              properties:
+                                backendService:
+                                  description: The BackendService resource being mirrored
+                                    to.
+                                  type: string
+                              required:
+                              - backendService
+                              type: object
+                            retryPolicy:
+                              description: Specifies the retry policy associated with
+                                this route.
+                              properties:
+                                numRetries:
+                                  description: Specifies the allowed number retries.
+                                    This number must be > 0.
+                                  type: integer
+                                perTryTimeout:
+                                  description: |-
+                                    Specifies a non-zero timeout per retry attempt.
+                                    If not specified, will use the timeout set in HttpRouteAction. If timeout in HttpRouteAction
+                                    is not set, will use the largest timeout among all backend services associated with the route.
+                                  properties:
+                                    nanos:
+                                      description: |-
+                                        Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                        less than one second are represented with a 0 'seconds' field and a positive
+                                        'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                      type: integer
+                                    seconds:
+                                      description: |-
+                                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                        inclusive.
+                                      type: string
+                                  required:
+                                  - seconds
+                                  type: object
+                                retryConditions:
+                                  description: |-
+                                    Specfies one or more conditions when this retry rule applies. Valid values are:
+                                    - 5xx: Loadbalancer will attempt a retry if the backend service responds with
+                                      any 5xx response code, or if the backend service does not respond at all,
+                                      example: disconnects, reset, read timeout, connection failure, and refused
+                                      streams.
+                                    - gateway-error: Similar to 5xx, but only applies to response codes
+                                      502, 503 or 504.
+                                    - connect-failure: Loadbalancer will retry on failures
+                                      connecting to backend services, for example due to connection timeouts.
+                                    - retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                                      Currently the only retriable error supported is 409.
+                                    - refused-stream: Loadbalancer will retry if the backend service resets the stream with a
+                                      REFUSED_STREAM error code. This reset type indicates that it is safe to retry.
+                                    - cancelled: Loadbalancer will retry if the gRPC status code in the response
+                                      header is set to cancelled
+                                    - deadline-exceeded: Loadbalancer will retry if the
+                                      gRPC status code in the response header is set to deadline-exceeded
+                                    - resource-exhausted: Loadbalancer will retry if the gRPC status code in the response
+                                      header is set to resource-exhausted
+                                    - unavailable: Loadbalancer will retry if the gRPC status code in
+                                      the response header is set to unavailable
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - numRetries
+                              type: object
+                            timeout:
+                              description: |-
+                                Specifies the timeout for the selected route. Timeout is computed from the time
+                                the request is has been fully processed (i.e. end-of-stream) up until the
+                                response has been completely processed. Timeout includes all retries. If not
+                                specified, the default value is 15 seconds.
+                              properties:
+                                nanos:
+                                  description: |-
+                                    Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                    less than one second are represented with a 0 'seconds' field and a positive
+                                    'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                  type: integer
+                                seconds:
+                                  description: |-
+                                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                    inclusive.
+                                  type: string
+                              required:
+                              - seconds
+                              type: object
+                            urlRewrite:
+                              description: |-
+                                The spec to modify the URL of the request, prior to forwarding the request to
+                                the matched service
+                              properties:
+                                hostRewrite:
+                                  description: |-
+                                    Prior to forwarding the request to the selected service, the request's host
+                                    header is replaced with contents of hostRewrite. The value must be between 1 and
+                                    255 characters.
+                                  type: string
+                                pathPrefixRewrite:
+                                  description: |-
+                                    Prior to forwarding the request to the selected backend service, the matching
+                                    portion of the request's path is replaced by pathPrefixRewrite. The value must
+                                    be between 1 and 1024 characters.
+                                  type: string
+                              type: object
+                            weightedBackendServices:
+                              description: |-
+                                A list of weighted backend services to send traffic to when a route match
+                                occurs. The weights determine the fraction of traffic that flows to their
+                                corresponding backend service. If all traffic needs to go to a single backend
+                                service, there must be one  weightedBackendService with weight set to a non 0
+                                number. Once a backendService is identified and before forwarding the request to
+                                the backend service, advanced routing actions like Url rewrites and header
+                                transformations are applied depending on additional settings specified in this
+                                HttpRouteAction.
+                              items:
+                                properties:
+                                  backendServiceRef:
+                                    oneOf:
+                                    - not:
+                                        required:
+                                        - external
+                                      required:
+                                      - name
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - name
+                                        - required:
+                                          - namespace
+                                      required:
+                                      - external
+                                    properties:
+                                      external:
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      namespace:
+                                        description: 'Namespace of the referent. More
+                                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                        type: string
+                                    type: object
+                                  headerAction:
+                                    description: |-
+                                      Specifies changes to request and response headers that need to take effect for
+                                      the selected backendService. headerAction specified here take effect before
+                                      headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+                                    properties:
+                                      requestHeadersToAdd:
+                                        description: |-
+                                          Headers to add to a matching request prior to forwarding the request to the
+                                          backendService.
+                                        items:
+                                          properties:
+                                            headerName:
+                                              description: The name of the header.
+                                              type: string
+                                            headerValue:
+                                              description: The value of the header
+                                                to add.
+                                              type: string
+                                            replace:
+                                              description: |-
+                                                If false, headerValue is appended to any values that already exist for the
+                                                header. If true, headerValue is set for the header, discarding any values that
+                                                were set for that header.
+                                              type: boolean
+                                          required:
+                                          - headerName
+                                          - headerValue
+                                          - replace
+                                          type: object
+                                        type: array
+                                      requestHeadersToRemove:
+                                        description: |-
+                                          A list of header names for headers that need to be removed from the request
+                                          prior to forwarding the request to the backendService.
+                                        items:
+                                          type: string
+                                        type: array
+                                      responseHeadersToAdd:
+                                        description: Headers to add the response prior
+                                          to sending the response back to the client.
+                                        items:
+                                          properties:
+                                            headerName:
+                                              description: The name of the header.
+                                              type: string
+                                            headerValue:
+                                              description: The value of the header
+                                                to add.
+                                              type: string
+                                            replace:
+                                              description: |-
+                                                If false, headerValue is appended to any values that already exist for the
+                                                header. If true, headerValue is set for the header, discarding any values that
+                                                were set for that header.
+                                              type: boolean
+                                          required:
+                                          - headerName
+                                          - headerValue
+                                          - replace
+                                          type: object
+                                        type: array
+                                      responseHeadersToRemove:
+                                        description: |-
+                                          A list of header names for headers that need to be removed from the response
+                                          prior to sending the response back to the client.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      Specifies the fraction of traffic sent to backendService, computed as weight /
+                                      (sum of all weightedBackendService weights in routeAction) . The selection of a
+                                      backend service is determined only for new traffic. Once a user's request has
+                                      been directed to a backendService, subsequent requests will be sent to the same
+                                      backendService as determined by the BackendService's session affinity policy.
+                                      The value must be between 0 and 1000
+                                    type: integer
+                                required:
+                                - backendServiceRef
+                                - weight
+                                type: object
+                              type: array
+                          type: object
+                        service:
+                          description: |-
+                            The backend service resource to which traffic is
+                            directed if this rule is matched. If routeAction is additionally specified,
+                            advanced routing actions like URL Rewrites, etc. take effect prior to sending
+                            the request to the backend. However, if service is specified, routeAction cannot
+                            contain any weightedBackendService s. Conversely, if routeAction specifies any
+                            weightedBackendServices, service must not be specified. Only one of urlRedirect,
+                            service or routeAction.weightedBackendService must be set.
+                          type: string
+                        urlRedirect:
+                          description: |-
+                            When this rule is matched, the request is redirected to a URL specified by
+                            urlRedirect. If urlRedirect is specified, service or routeAction must not be
+                            set.
+                          properties:
+                            hostRedirect:
+                              description: |-
+                                The host that will be used in the redirect response instead of the one that was
+                                supplied in the request. The value must be between 1 and 255 characters.
+                              type: string
+                            httpsRedirect:
+                              description: |-
+                                If set to true, the URL scheme in the redirected request is set to https. If set
+                                to false, the URL scheme of the redirected request will remain the same as that
+                                of the request. This must only be set for UrlMaps used in TargetHttpProxys.
+                                Setting this true for TargetHttpsProxy is not permitted. Defaults to false.
+                              type: boolean
+                            pathRedirect:
+                              description: |-
+                                The path that will be used in the redirect response instead of the one that was
+                                supplied in the request. Only one of pathRedirect or prefixRedirect must be
+                                specified. The value must be between 1 and 1024 characters.
+                              type: string
+                            prefixRedirect:
+                              description: |-
+                                The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
+                                retaining the remaining portion of the URL before redirecting the request.
+                              type: string
+                            redirectResponseCode:
+                              description: |-
+                                The HTTP Status code to use for this RedirectAction. Supported values are:   -
+                                MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.  -
+                                FOUND, which corresponds to 302.  - SEE_OTHER which corresponds to 303.  -
+                                TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                                will be retained.  - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                                the request method will be retained.
+                              type: string
+                            stripQuery:
+                              description: |-
+                                If set to true, any accompanying query portion of the original URL is removed
+                                prior to redirecting the request. If set to false, the query portion of the
+                                original URL is retained. Defaults to false.
+                              type: boolean
+                          type: object
+                      required:
+                      - priority
+                      type: object
+                    type: array
+                required:
+                - name
+                type: object
+              type: array
+            test:
+              description: |-
+                The list of expected URL mapping tests. Request to update this UrlMap will
+                succeed only if all of the test cases pass. You can specify a maximum of 100
+                tests per UrlMap.
+              items:
+                properties:
+                  description:
+                    description: Description of this test case.
+                    type: string
+                  host:
+                    description: Host portion of the URL.
+                    type: string
+                  path:
+                    description: Path portion of the URL.
+                    type: string
+                  service:
+                    properties:
+                      backendBucketRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                      backendServiceRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - host
+                - path
+                - service
+                type: object
+              type: array
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            fingerprint:
+              description: |-
+                Fingerprint of this resource. A hash of the contents stored in this object. This
+                field is used in optimistic locking.
+              type: string
+            mapId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computevpngateways.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computevpngateways.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,127 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computevpngateways.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeVPNGateway
+    plural: computevpngateways
+    shortNames:
+    - gcpcomputevpngateway
+    - gcpcomputevpngateways
+    singular: computevpngateway
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            region:
+              description: The region this gateway should sit in.
+              type: string
+          required:
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+            vpnInterfaces:
+              description: A list of interfaces on this VPN gateway.
+              items:
+                properties:
+                  id:
+                    description: The numeric ID of this VPN gateway interface.
+                    type: integer
+                  ipAddress:
+                    description: The external IP address for this VPN gateway interface.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computevpntunnels.compute.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_computevpntunnels.compute.cnrm.cloud.google.com.yaml
@@ -1,0 +1,309 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computevpntunnels.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeVPNTunnel
+    plural: computevpntunnels
+    shortNames:
+    - gcpcomputevpntunnel
+    - gcpcomputevpntunnels
+    singular: computevpntunnel
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            ikeVersion:
+              description: |-
+                IKE protocol version to use when establishing the VPN tunnel with
+                peer VPN gateway.
+                Acceptable IKE versions are 1 or 2. Default version is 2.
+              type: integer
+            localTrafficSelector:
+              description: |-
+                Local traffic selector to use when establishing the VPN tunnel with
+                peer VPN gateway. The value should be a CIDR formatted string,
+                for example '192.168.0.0/16'. The ranges should be disjoint.
+                Only IPv4 is supported.
+              items:
+                type: string
+              type: array
+            peerExternalGatewayInterface:
+              description: The interface ID of the external VPN gateway to which this
+                VPN tunnel is connected.
+              type: integer
+            peerExternalGatewayRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            peerGCPGatewayRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            peerIp:
+              description: IP address of the peer VPN gateway. Only IPv4 is supported.
+              type: string
+            region:
+              description: The region where the tunnel is located. If unset, is set
+                to the region of 'target_vpn_gateway'.
+              type: string
+            remoteTrafficSelector:
+              description: |-
+                Remote traffic selector to use when establishing the VPN tunnel with
+                peer VPN gateway. The value should be a CIDR formatted string,
+                for example '192.168.0.0/16'. The ranges should be disjoint.
+                Only IPv4 is supported.
+              items:
+                type: string
+              type: array
+            routerRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            sharedSecret:
+              description: |-
+                Shared secret used to set the secure session between the Cloud VPN
+                gateway and the peer VPN gateway.
+              oneOf:
+              - not:
+                  required:
+                  - valueFrom
+                required:
+                - value
+              - not:
+                  required:
+                  - value
+                required:
+                - valueFrom
+              properties:
+                value:
+                  description: Value of the field. Cannot be used if 'valueFrom' is
+                    specified.
+                  type: string
+                valueFrom:
+                  description: Source for the field's value. Cannot be used if 'value'
+                    is specified.
+                  properties:
+                    secretKeyRef:
+                      description: Reference to a value with the given key in the
+                        given Secret in the resource's namespace.
+                      properties:
+                        key:
+                          description: Key that identifies the value to be extracted.
+                          type: string
+                        name:
+                          description: Name of the Secret to extract a value from.
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+              type: object
+            targetVPNGatewayRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            vpnGatewayInterface:
+              description: The interface ID of the VPN gateway with which this VPN
+                tunnel is associated.
+              type: integer
+            vpnGatewayRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - sharedSecret
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            detailedStatus:
+              description: Detailed status message for the VPN tunnel.
+              type: string
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource.  Used
+                internally during updates.
+              type: string
+            selfLink:
+              type: string
+            sharedSecretHash:
+              description: Hash of the shared secret.
+              type: string
+            tunnelId:
+              description: The unique identifier for the resource. This identifier
+                is defined by the server.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_containerclusters.container.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_containerclusters.container.cnrm.cloud.google.com.yaml
@@ -1,0 +1,565 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: containerclusters.container.cnrm.cloud.google.com
+spec:
+  group: container.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ContainerCluster
+    plural: containerclusters
+    shortNames:
+    - gcpcontainercluster
+    - gcpcontainerclusters
+    singular: containercluster
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            addonsConfig:
+              properties:
+                cloudrunConfig:
+                  properties:
+                    disabled:
+                      type: boolean
+                  required:
+                  - disabled
+                  type: object
+                horizontalPodAutoscaling:
+                  properties:
+                    disabled:
+                      type: boolean
+                  required:
+                  - disabled
+                  type: object
+                httpLoadBalancing:
+                  properties:
+                    disabled:
+                      type: boolean
+                  required:
+                  - disabled
+                  type: object
+                istioConfig:
+                  properties:
+                    auth:
+                      type: string
+                    disabled:
+                      type: boolean
+                  required:
+                  - disabled
+                  type: object
+                networkPolicyConfig:
+                  properties:
+                    disabled:
+                      type: boolean
+                  required:
+                  - disabled
+                  type: object
+              type: object
+            authenticatorGroupsConfig:
+              properties:
+                securityGroup:
+                  type: string
+              required:
+              - securityGroup
+              type: object
+            clusterAutoscaling:
+              properties:
+                autoProvisioningDefaults:
+                  properties:
+                    oauthScopes:
+                      items:
+                        type: string
+                      type: array
+                    serviceAccountRef:
+                      oneOf:
+                      - not:
+                          required:
+                          - external
+                        required:
+                        - name
+                      - not:
+                          anyOf:
+                          - required:
+                            - name
+                          - required:
+                            - namespace
+                        required:
+                        - external
+                      properties:
+                        external:
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                      type: object
+                  type: object
+                enabled:
+                  type: boolean
+                resourceLimits:
+                  items:
+                    properties:
+                      maximum:
+                        type: integer
+                      minimum:
+                        type: integer
+                      resourceType:
+                        type: string
+                    required:
+                    - resourceType
+                    type: object
+                  type: array
+              required:
+              - enabled
+              type: object
+            clusterIpv4Cidr:
+              type: string
+            databaseEncryption:
+              properties:
+                keyName:
+                  type: string
+                state:
+                  type: string
+              required:
+              - state
+              type: object
+            defaultMaxPodsPerNode:
+              type: integer
+            description:
+              type: string
+            enableBinaryAuthorization:
+              type: boolean
+            enableIntranodeVisibility:
+              type: boolean
+            enableKubernetesAlpha:
+              type: boolean
+            enableLegacyAbac:
+              type: boolean
+            enableShieldedNodes:
+              type: boolean
+            enableTpu:
+              type: boolean
+            initialNodeCount:
+              type: integer
+            ipAllocationPolicy:
+              properties:
+                clusterIpv4CidrBlock:
+                  type: string
+                clusterSecondaryRangeName:
+                  type: string
+                servicesIpv4CidrBlock:
+                  type: string
+                servicesSecondaryRangeName:
+                  type: string
+              type: object
+            location:
+              type: string
+            loggingService:
+              type: string
+            maintenancePolicy:
+              properties:
+                dailyMaintenanceWindow:
+                  properties:
+                    duration:
+                      type: string
+                    startTime:
+                      type: string
+                  required:
+                  - startTime
+                  type: object
+                recurringWindow:
+                  properties:
+                    endTime:
+                      type: string
+                    recurrence:
+                      type: string
+                    startTime:
+                      type: string
+                  required:
+                  - endTime
+                  - recurrence
+                  - startTime
+                  type: object
+              type: object
+            masterAuth:
+              properties:
+                clientCertificate:
+                  type: string
+                clientCertificateConfig:
+                  properties:
+                    issueClientCertificate:
+                      type: boolean
+                  required:
+                  - issueClientCertificate
+                  type: object
+                clientKey:
+                  type: string
+                clusterCaCertificate:
+                  type: string
+                password:
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                username:
+                  type: string
+              type: object
+            masterAuthorizedNetworksConfig:
+              properties:
+                cidrBlocks:
+                  items:
+                    properties:
+                      cidrBlock:
+                        type: string
+                      displayName:
+                        type: string
+                    required:
+                    - cidrBlock
+                    type: object
+                  type: array
+              type: object
+            minMasterVersion:
+              type: string
+            monitoringService:
+              type: string
+            networkPolicy:
+              properties:
+                enabled:
+                  type: boolean
+                provider:
+                  type: string
+              required:
+              - enabled
+              type: object
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            nodeConfig:
+              properties:
+                diskSizeGb:
+                  type: integer
+                diskType:
+                  type: string
+                guestAccelerator:
+                  items:
+                    properties:
+                      count:
+                        type: integer
+                      type:
+                        type: string
+                    required:
+                    - count
+                    - type
+                    type: object
+                  type: array
+                imageType:
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                localSsdCount:
+                  type: integer
+                machineType:
+                  type: string
+                metadata:
+                  additionalProperties:
+                    type: string
+                  type: object
+                minCpuPlatform:
+                  type: string
+                oauthScopes:
+                  items:
+                    type: string
+                  type: array
+                preemptible:
+                  type: boolean
+                sandboxConfig:
+                  properties:
+                    sandboxType:
+                      type: string
+                  required:
+                  - sandboxType
+                  type: object
+                serviceAccountRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                shieldedInstanceConfig:
+                  properties:
+                    enableIntegrityMonitoring:
+                      type: boolean
+                    enableSecureBoot:
+                      type: boolean
+                  type: object
+                tags:
+                  items:
+                    type: string
+                  type: array
+                taint:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - effect
+                    - key
+                    - value
+                    type: object
+                  type: array
+                workloadMetadataConfig:
+                  properties:
+                    nodeMetadata:
+                      type: string
+                  required:
+                  - nodeMetadata
+                  type: object
+              type: object
+            nodeLocations:
+              items:
+                type: string
+              type: array
+            nodeVersion:
+              type: string
+            podSecurityPolicyConfig:
+              properties:
+                enabled:
+                  type: boolean
+              required:
+              - enabled
+              type: object
+            privateClusterConfig:
+              properties:
+                enablePrivateEndpoint:
+                  type: boolean
+                enablePrivateNodes:
+                  type: boolean
+                masterIpv4CidrBlock:
+                  type: string
+                peeringName:
+                  type: string
+                privateEndpoint:
+                  type: string
+                publicEndpoint:
+                  type: string
+              required:
+              - enablePrivateEndpoint
+              type: object
+            releaseChannel:
+              properties:
+                channel:
+                  type: string
+              required:
+              - channel
+              type: object
+            resourceUsageExportConfig:
+              properties:
+                bigqueryDestination:
+                  properties:
+                    datasetId:
+                      type: string
+                  required:
+                  - datasetId
+                  type: object
+                enableNetworkEgressMetering:
+                  type: boolean
+              required:
+              - bigqueryDestination
+              type: object
+            subnetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            verticalPodAutoscaling:
+              properties:
+                enabled:
+                  type: boolean
+              required:
+              - enabled
+              type: object
+            workloadIdentityConfig:
+              properties:
+                identityNamespace:
+                  type: string
+              required:
+              - identityNamespace
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            endpoint:
+              type: string
+            instanceGroupUrls:
+              items:
+                type: string
+              type: array
+            labelFingerprint:
+              type: string
+            masterVersion:
+              type: string
+            operation:
+              type: string
+            servicesIpv4Cidr:
+              type: string
+            tpuIpv4CidrBlock:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_containernodepools.container.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_containernodepools.container.cnrm.cloud.google.com.yaml
@@ -1,0 +1,260 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: containernodepools.container.cnrm.cloud.google.com
+spec:
+  group: container.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ContainerNodePool
+    plural: containernodepools
+    shortNames:
+    - gcpcontainernodepool
+    - gcpcontainernodepools
+    singular: containernodepool
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            autoscaling:
+              properties:
+                maxNodeCount:
+                  type: integer
+                minNodeCount:
+                  type: integer
+              required:
+              - maxNodeCount
+              - minNodeCount
+              type: object
+            clusterRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            initialNodeCount:
+              type: integer
+            location:
+              type: string
+            management:
+              properties:
+                autoRepair:
+                  type: boolean
+                autoUpgrade:
+                  type: boolean
+              type: object
+            maxPodsPerNode:
+              type: integer
+            namePrefix:
+              type: string
+            nodeConfig:
+              properties:
+                diskSizeGb:
+                  type: integer
+                diskType:
+                  type: string
+                guestAccelerator:
+                  items:
+                    properties:
+                      count:
+                        type: integer
+                      type:
+                        type: string
+                    required:
+                    - count
+                    - type
+                    type: object
+                  type: array
+                imageType:
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                localSsdCount:
+                  type: integer
+                machineType:
+                  type: string
+                metadata:
+                  additionalProperties:
+                    type: string
+                  type: object
+                minCpuPlatform:
+                  type: string
+                oauthScopes:
+                  items:
+                    type: string
+                  type: array
+                preemptible:
+                  type: boolean
+                sandboxConfig:
+                  properties:
+                    sandboxType:
+                      type: string
+                  required:
+                  - sandboxType
+                  type: object
+                serviceAccountRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                shieldedInstanceConfig:
+                  properties:
+                    enableIntegrityMonitoring:
+                      type: boolean
+                    enableSecureBoot:
+                      type: boolean
+                  type: object
+                tags:
+                  items:
+                    type: string
+                  type: array
+                taint:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - effect
+                    - key
+                    - value
+                    type: object
+                  type: array
+                workloadMetadataConfig:
+                  properties:
+                    nodeMetadata:
+                      type: string
+                  required:
+                  - nodeMetadata
+                  type: object
+              type: object
+            nodeCount:
+              type: integer
+            nodeLocations:
+              items:
+                type: string
+              type: array
+            upgradeSettings:
+              properties:
+                maxSurge:
+                  type: integer
+                maxUnavailable:
+                  type: integer
+              required:
+              - maxSurge
+              - maxUnavailable
+              type: object
+            version:
+              type: string
+          required:
+          - clusterRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            instanceGroupUrls:
+              items:
+                type: string
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_dataflowjobs.dataflow.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_dataflowjobs.dataflow.cnrm.cloud.google.com.yaml
@@ -1,0 +1,181 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: dataflowjobs.dataflow.cnrm.cloud.google.com
+spec:
+  group: dataflow.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: DataflowJob
+    plural: dataflowjobs
+    shortNames:
+    - gcpdataflowjob
+    - gcpdataflowjobs
+    singular: dataflowjob
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            ipConfiguration:
+              type: string
+            machineType:
+              type: string
+            maxWorkers:
+              type: integer
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            parameters:
+              type: object
+            region:
+              type: string
+            serviceAccountRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            subnetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            tempGcsLocation:
+              type: string
+            templateGcsPath:
+              type: string
+            zone:
+              type: string
+          required:
+          - tempGcsLocation
+          - templateGcsPath
+          - zone
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            jobId:
+              type: string
+            state:
+              type: string
+            type:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_dnsmanagedzones.dns.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_dnsmanagedzones.dns.cnrm.cloud.google.com.yaml
@@ -1,0 +1,245 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: dnsmanagedzones.dns.cnrm.cloud.google.com
+spec:
+  group: dns.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: DNSManagedZone
+    plural: dnsmanagedzones
+    shortNames:
+    - gcpdnsmanagedzone
+    - gcpdnsmanagedzones
+    singular: dnsmanagedzone
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            dnsName:
+              description: The DNS name of this managed zone, for instance "example.com.".
+              type: string
+            dnssecConfig:
+              description: DNSSEC configuration
+              properties:
+                defaultKeySpecs:
+                  description: |-
+                    Specifies parameters that will be used for generating initial DnsKeys
+                    for this ManagedZone. If you provide a spec for keySigning or zoneSigning,
+                    you must also provide one for the other.
+                  items:
+                    properties:
+                      algorithm:
+                        description: String mnemonic specifying the DNSSEC algorithm
+                          of this key
+                        type: string
+                      keyLength:
+                        description: Length of the keys in bits
+                        type: integer
+                      keyType:
+                        description: |-
+                          Specifies whether this is a key signing key (KSK) or a zone
+                          signing key (ZSK). Key signing keys have the Secure Entry
+                          Point flag set and, when active, will only be used to sign
+                          resource record sets of type DNSKEY. Zone signing keys do
+                          not have the Secure Entry Point flag set and will be used
+                          to sign all other types of resource record sets.
+                        type: string
+                      kind:
+                        description: Identifies what kind of resource this is
+                        type: string
+                    type: object
+                  type: array
+                kind:
+                  description: Identifies what kind of resource this is
+                  type: string
+                nonExistence:
+                  description: Specifies the mechanism used to provide authenticated
+                    denial-of-existence responses.
+                  type: string
+                state:
+                  description: Specifies whether DNSSEC is enabled, and what mode
+                    it is in
+                  type: string
+              type: object
+            forwardingConfig:
+              description: |-
+                The presence for this field indicates that outbound forwarding is enabled
+                for this zone. The value of this field contains the set of destinations
+                to forward to.
+              properties:
+                targetNameServers:
+                  description: |-
+                    List of target name servers to forward to. Cloud DNS will
+                    select the best available name server if more than
+                    one target is given.
+                  items:
+                    properties:
+                      ipv4Address:
+                        description: IPv4 address of a target name server.
+                        type: string
+                    required:
+                    - ipv4Address
+                    type: object
+                  type: array
+              required:
+              - targetNameServers
+              type: object
+            peeringConfig:
+              description: |-
+                The presence of this field indicates that DNS Peering is enabled for this
+                zone. The value of this field contains the network to peer with.
+              properties:
+                targetNetwork:
+                  description: The network with which to peer.
+                  properties:
+                    networkRef:
+                      oneOf:
+                      - not:
+                          required:
+                          - external
+                        required:
+                        - name
+                      - not:
+                          anyOf:
+                          - required:
+                            - name
+                          - required:
+                            - namespace
+                        required:
+                        - external
+                      properties:
+                        external:
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                      type: object
+                  required:
+                  - networkRef
+                  type: object
+              required:
+              - targetNetwork
+              type: object
+            privateVisibilityConfig:
+              description: |-
+                For privately visible zones, the set of Virtual Private Cloud
+                resources that the zone is visible from.
+              properties:
+                networks:
+                  items:
+                    properties:
+                      networkRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                    required:
+                    - networkRef
+                    type: object
+                  type: array
+              required:
+              - networks
+              type: object
+            visibility:
+              description: |-
+                The zone's visibility: public zones are exposed to the Internet,
+                while private zones are visible only to Virtual Private Cloud resources.
+                Must be one of: 'public', 'private'.
+              type: string
+          required:
+          - dnsName
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            nameServers:
+              description: |-
+                Delegate your managed_zone to these virtual name servers;
+                defined by the server
+              items:
+                type: string
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_dnspolicies.dns.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_dnspolicies.dns.cnrm.cloud.google.com.yaml
@@ -1,0 +1,149 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: dnspolicies.dns.cnrm.cloud.google.com
+spec:
+  group: dns.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: DNSPolicy
+    plural: dnspolicies
+    shortNames:
+    - gcpdnspolicy
+    - gcpdnspolicies
+    singular: dnspolicy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            alternativeNameServerConfig:
+              description: |-
+                Sets an alternative name server for the associated networks.
+                When specified, all DNS queries are forwarded to a name server that you choose.
+                Names such as .internal are not available when an alternative name server is specified.
+              properties:
+                targetNameServers:
+                  description: |-
+                    Sets an alternative name server for the associated networks. When specified,
+                    all DNS queries are forwarded to a name server that you choose. Names such as .internal
+                    are not available when an alternative name server is specified.
+                  items:
+                    properties:
+                      ipv4Address:
+                        description: IPv4 address to forward to.
+                        type: string
+                    required:
+                    - ipv4Address
+                    type: object
+                  type: array
+              required:
+              - targetNameServers
+              type: object
+            description:
+              type: string
+            enableInboundForwarding:
+              description: |-
+                Allows networks bound to this policy to receive DNS queries sent
+                by VMs or applications over VPN connections. When enabled, a
+                virtual IP address will be allocated from each of the sub-networks
+                that are bound to this policy.
+              type: boolean
+            enableLogging:
+              description: |-
+                Controls whether logging is enabled for the networks bound to this policy.
+                Defaults to no logging if not set.
+              type: boolean
+            networks:
+              description: List of network names specifying networks to which this
+                policy is applied.
+              items:
+                properties:
+                  networkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                required:
+                - networkRef
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_dnsrecordsets.dns.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_dnsrecordsets.dns.cnrm.cloud.google.com.yaml
@@ -1,0 +1,121 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: dnsrecordsets.dns.cnrm.cloud.google.com
+spec:
+  group: dns.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: DNSRecordSet
+    plural: dnsrecordsets
+    shortNames:
+    - gcpdnsrecordset
+    - gcpdnsrecordsets
+    singular: dnsrecordset
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            managedZoneRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            name:
+              type: string
+            rrdatas:
+              items:
+                type: string
+              type: array
+            ttl:
+              type: integer
+            type:
+              type: string
+          required:
+          - managedZoneRef
+          - name
+          - rrdatas
+          - ttl
+          - type
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_firestoreindexes.firestore.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_firestoreindexes.firestore.cnrm.cloud.google.com.yaml
@@ -1,0 +1,124 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: firestoreindexes.firestore.cnrm.cloud.google.com
+spec:
+  group: firestore.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: FirestoreIndex
+    plural: firestoreindexes
+    shortNames:
+    - gcpfirestoreindex
+    - gcpfirestoreindexes
+    singular: firestoreindex
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            collection:
+              description: The collection being indexed.
+              type: string
+            database:
+              description: The Firestore database id. Defaults to '"(default)"'.
+              type: string
+            fields:
+              description: |-
+                The fields supported by this index. The last field entry is always for
+                the field path '__name__'. If, on creation, '__name__' was not
+                specified as the last field, it will be added automatically with the
+                same direction as that of the last field defined. If the final field
+                in a composite index is not directional, the '__name__' will be
+                ordered '"ASCENDING"' (unless explicitly specified otherwise).
+              items:
+                properties:
+                  arrayConfig:
+                    description: |-
+                      Indicates that this field supports operations on arrayValues. Only one of 'order' and 'arrayConfig' can
+                      be specified.
+                    type: string
+                  fieldPath:
+                    description: Name of the field.
+                    type: string
+                  order:
+                    description: |-
+                      Indicates that this field supports ordering by the specified order or comparing using =, <, <=, >, >=.
+                      Only one of 'order' and 'arrayConfig' can be specified.
+                    type: string
+                type: object
+              type: array
+            queryScope:
+              description: |-
+                The scope at which a query is run. One of '"COLLECTION"' or
+                '"COLLECTION_GROUP"'. Defaults to '"COLLECTION"'.
+              type: string
+          required:
+          - collection
+          - fields
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            name:
+              description: |-
+                A server defined name for this index. Format:
+                'projects/{{project}}/databases/{{database}}/collectionGroups/{{collection}}/indexes/{{server_generated_id}}'
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_folders.resourcemanager.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_folders.resourcemanager.cnrm.cloud.google.com.yaml
@@ -1,0 +1,90 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: folders.resourcemanager.cnrm.cloud.google.com
+spec:
+  group: resourcemanager.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: Folder
+    plural: folders
+    shortNames:
+    - gcpfolder
+    - gcpfolders
+    singular: folder
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            displayName:
+              type: string
+          required:
+          - displayName
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            createTime:
+              type: string
+            lifecycleState:
+              type: string
+            name:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_iamcustomroles.iam.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_iamcustomroles.iam.cnrm.cloud.google.com.yaml
@@ -1,0 +1,95 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: iamcustomroles.iam.cnrm.cloud.google.com
+spec:
+  group: iam.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: IAMCustomRole
+    plural: iamcustomroles
+    shortNames:
+    - gcpiamcustomrole
+    - gcpiamcustomroles
+    singular: iamcustomrole
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            permissions:
+              items:
+                type: string
+              type: array
+            stage:
+              type: string
+            title:
+              type: string
+          required:
+          - permissions
+          - title
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            deleted:
+              type: boolean
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_iampolicies.iam.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_iampolicies.iam.cnrm.cloud.google.com.yaml
@@ -1,0 +1,147 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    controller-tools.k8s.io: "1.0"
+  name: iampolicies.iam.cnrm.cloud.google.com
+spec:
+  group: iam.cnrm.cloud.google.com
+  names:
+    kind: IAMPolicy
+    plural: iampolicies
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bindings:
+              description: Optional. The list of IAM bindings.
+              items:
+                properties:
+                  condition:
+                    description: Optional. The condition under which the binding applies.
+                    properties:
+                      description:
+                        type: string
+                      expression:
+                        type: string
+                      title:
+                        type: string
+                    required:
+                    - title
+                    - expression
+                    type: object
+                  members:
+                    description: Optional. The list of IAM users to be bound to the
+                      role.
+                    items:
+                      pattern: ^(user|serviceAccount|group|domain):.+|allUsers|allAuthenticatedUsers$
+                      type: string
+                    pattern: ^(user|serviceAccount|group|domain):.+|allUsers|allAuthenticatedUsers$
+                    type: array
+                  role:
+                    description: Required. The role to bind the users to.
+                    pattern: ^roles/[\w\.]+$
+                    type: string
+                required:
+                - role
+                type: object
+              type: array
+            resourceRef:
+              description: Required. The GCP resource to set the IAM policy on.
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                  - required:
+                    - apiVersion
+                  - required:
+                    - external
+              properties:
+                apiVersion:
+                  type: string
+                external:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - kind
+              type: object
+          required:
+          - resourceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observations
+                of the IAM policy's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_iampolicymembers.iam.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_iampolicymembers.iam.cnrm.cloud.google.com.yaml
@@ -1,0 +1,138 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    controller-tools.k8s.io: "1.0"
+  name: iampolicymembers.iam.cnrm.cloud.google.com
+spec:
+  group: iam.cnrm.cloud.google.com
+  names:
+    kind: IAMPolicyMember
+    plural: iampolicymembers
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            condition:
+              description: Optional. The condition under which the binding applies.
+              properties:
+                description:
+                  type: string
+                expression:
+                  type: string
+                title:
+                  type: string
+              required:
+              - title
+              - expression
+              type: object
+            member:
+              description: Required. The list of IAM identities to be bound to the
+                role
+              pattern: ^(user|serviceAccount|group|domain):.+|allUsers|allAuthenticatedUsers$
+              type: string
+            resourceRef:
+              description: Required. The GCP resource to set the IAM policy on.
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                  - required:
+                    - apiVersion
+                  - required:
+                    - external
+              properties:
+                apiVersion:
+                  type: string
+                external:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - kind
+              type: object
+            role:
+              description: Required. The role for which the Member will be bound.
+              pattern: ^roles/[\w\.]+$
+              type: string
+          required:
+          - resourceRef
+          - member
+          - role
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observations
+                of the IAM policy's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_iamserviceaccountkeys.iam.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_iamserviceaccountkeys.iam.cnrm.cloud.google.com.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: iamserviceaccountkeys.iam.cnrm.cloud.google.com
+spec:
+  group: iam.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: IAMServiceAccountKey
+    plural: iamserviceaccountkeys
+    shortNames:
+    - gcpiamserviceaccountkey
+    - gcpiamserviceaccountkeys
+    singular: iamserviceaccountkey
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            keyAlgorithm:
+              type: string
+            privateKeyType:
+              type: string
+            publicKeyType:
+              type: string
+            serviceAccountRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - serviceAccountRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            name:
+              type: string
+            privateKey:
+              type: string
+            publicKey:
+              type: string
+            validAfter:
+              type: string
+            validBefore:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_iamserviceaccounts.iam.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_iamserviceaccounts.iam.cnrm.cloud.google.com.yaml
@@ -1,0 +1,88 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: iamserviceaccounts.iam.cnrm.cloud.google.com
+spec:
+  group: iam.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: IAMServiceAccount
+    plural: iamserviceaccounts
+    shortNames:
+    - gcpiamserviceaccount
+    - gcpiamserviceaccounts
+    singular: iamserviceaccount
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            displayName:
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            email:
+              type: string
+            name:
+              type: string
+            uniqueId:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_kmscryptokeys.kms.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_kmscryptokeys.kms.cnrm.cloud.google.com.yaml
@@ -1,0 +1,137 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: kmscryptokeys.kms.cnrm.cloud.google.com
+spec:
+  group: kms.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: KMSCryptoKey
+    plural: kmscryptokeys
+    shortNames:
+    - gcpkmscryptokey
+    - gcpkmscryptokeys
+    singular: kmscryptokey
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            keyRingRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            purpose:
+              description: |-
+                The immutable purpose of this CryptoKey. See the
+                [purpose reference](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys#CryptoKeyPurpose)
+                for possible inputs.
+              type: string
+            rotationPeriod:
+              description: |-
+                Every time this period passes, generate a new CryptoKeyVersion and set it as the primary.
+                The first rotation will take place after the specified period. The rotation period has
+                the format of a decimal number with up to 9 fractional digits, followed by the
+                letter 's' (seconds). It must be greater than a day (ie, 86400).
+              type: string
+            versionTemplate:
+              description: A template describing settings for new crypto key versions.
+              properties:
+                algorithm:
+                  description: |-
+                    The algorithm to use when creating a version based on this template.
+                    See the [algorithm reference](https://cloud.google.com/kms/docs/reference/rest/v1/CryptoKeyVersionAlgorithm) for possible inputs.
+                  type: string
+                protectionLevel:
+                  description: The protection level to use when creating a version
+                    based on this template.
+                  type: string
+              required:
+              - algorithm
+              type: object
+          required:
+          - keyRingRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_kmskeyrings.kms.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_kmskeyrings.kms.cnrm.cloud.google.com.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: kmskeyrings.kms.cnrm.cloud.google.com
+spec:
+  group: kms.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: KMSKeyRing
+    plural: kmskeyrings
+    shortNames:
+    - gcpkmskeyring
+    - gcpkmskeyrings
+    singular: kmskeyring
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            location:
+              description: |-
+                The location for the KeyRing.
+                A full list of valid locations can be found by running 'gcloud kms locations list'.
+              type: string
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_projects.resourcemanager.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_projects.resourcemanager.cnrm.cloud.google.com.yaml
@@ -1,0 +1,111 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: projects.resourcemanager.cnrm.cloud.google.com
+spec:
+  group: resourcemanager.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: Project
+    plural: projects
+    shortNames:
+    - gcpproject
+    - gcpprojects
+    singular: project
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            billingAccountRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            name:
+              type: string
+          required:
+          - name
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            number:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_pubsubsubscriptions.pubsub.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_pubsubsubscriptions.pubsub.cnrm.cloud.google.com.yaml
@@ -1,0 +1,237 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: pubsubsubscriptions.pubsub.cnrm.cloud.google.com
+spec:
+  group: pubsub.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: PubSubSubscription
+    plural: pubsubsubscriptions
+    shortNames:
+    - gcppubsubsubscription
+    - gcppubsubsubscriptions
+    singular: pubsubsubscription
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            ackDeadlineSeconds:
+              description: |-
+                This value is the maximum time after a subscriber receives a message
+                before the subscriber should acknowledge the message. After message
+                delivery but before the ack deadline expires and before the message is
+                acknowledged, it is an outstanding message and will not be delivered
+                again during that time (on a best-effort basis).
+
+                For pull subscriptions, this value is used as the initial value for
+                the ack deadline. To override this value for a given message, call
+                subscriptions.modifyAckDeadline with the corresponding ackId if using
+                pull. The minimum custom deadline you can specify is 10 seconds. The
+                maximum custom deadline you can specify is 600 seconds (10 minutes).
+                If this parameter is 0, a default value of 10 seconds is used.
+
+                For push delivery, this value is also used to set the request timeout
+                for the call to the push endpoint.
+
+                If the subscriber never acknowledges the message, the Pub/Sub system
+                will eventually redeliver the message.
+              type: integer
+            expirationPolicy:
+              description: |-
+                A policy that specifies the conditions for this subscription's expiration.
+                A subscription is considered active as long as any connected subscriber
+                is successfully consuming messages from the subscription or is issuing
+                operations on the subscription. If expirationPolicy is not set, a default
+                policy with ttl of 31 days will be used.  If it is set but ttl is "", the
+                resource never expires.  The minimum allowed value for expirationPolicy.ttl
+                is 1 day.
+              properties:
+                ttl:
+                  description: |-
+                    Specifies the "time-to-live" duration for an associated resource. The
+                    resource expires if it is not active for a period of ttl.
+                    If ttl is not set, the associated resource never expires.
+                    A duration in seconds with up to nine fractional digits, terminated by 's'.
+                    Example - "3.5s".
+                  type: string
+              required:
+              - ttl
+              type: object
+            messageRetentionDuration:
+              description: |-
+                How long to retain unacknowledged messages in the subscription's
+                backlog, from the moment a message is published. If
+                retainAckedMessages is true, then this also configures the retention
+                of acknowledged messages, and thus configures how far back in time a
+                subscriptions.seek can be done. Defaults to 7 days. Cannot be more
+                than 7 days ('"604800s"') or less than 10 minutes ('"600s"').
+
+                A duration in seconds with up to nine fractional digits, terminated
+                by 's'. Example: '"600.5s"'.
+              type: string
+            pushConfig:
+              description: |-
+                If push delivery is used with this subscription, this field is used to
+                configure it. An empty pushConfig signifies that the subscriber will
+                pull and ack messages using API methods.
+              properties:
+                attributes:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Endpoint configuration attributes.
+
+                    Every endpoint has a set of API supported attributes that can
+                    be used to control different aspects of the message delivery.
+
+                    The currently supported attribute is x-goog-version, which you
+                    can use to change the format of the pushed message. This
+                    attribute indicates the version of the data expected by
+                    the endpoint. This controls the shape of the pushed message
+                    (i.e., its fields and metadata). The endpoint version is
+                    based on the version of the Pub/Sub API.
+
+                    If not present during the subscriptions.create call,
+                    it will default to the version of the API used to make
+                    such call. If not present during a subscriptions.modifyPushConfig
+                    call, its value will not be changed. subscriptions.get
+                    calls will always return a valid version, even if the
+                    subscription was created without this attribute.
+
+                    The possible values for this attribute are:
+
+                    - v1beta1: uses the push format defined in the v1beta1 Pub/Sub API.
+                    - v1 or v1beta2: uses the push format defined in the v1 Pub/Sub API.
+                  type: object
+                oidcToken:
+                  description: |-
+                    If specified, Pub/Sub will generate and attach an OIDC JWT token as
+                    an Authorization header in the HTTP request for every pushed message.
+                  properties:
+                    audience:
+                      description: |-
+                        Audience to be used when generating OIDC token. The audience claim
+                        identifies the recipients that the JWT is intended for. The audience
+                        value is a single case-sensitive string. Having multiple values (array)
+                        for the audience field is not supported. More info about the OIDC JWT
+                        token audience here: https://tools.ietf.org/html/rfc7519#section-4.1.3
+                        Note: if not specified, the Push endpoint URL will be used.
+                      type: string
+                    serviceAccountEmail:
+                      description: |-
+                        Service account email to be used for generating the OIDC token.
+                        The caller (for subscriptions.create, subscriptions.patch, and
+                        subscriptions.modifyPushConfig RPCs) must have the
+                        iam.serviceAccounts.actAs permission for the service account.
+                      type: string
+                  required:
+                  - serviceAccountEmail
+                  type: object
+                pushEndpoint:
+                  description: |-
+                    A URL locating the endpoint to which messages should be pushed.
+                    For example, a Webhook endpoint might use
+                    "https://example.com/push".
+                  type: string
+              required:
+              - pushEndpoint
+              type: object
+            retainAckedMessages:
+              description: |-
+                Indicates whether to retain acknowledged messages. If 'true', then
+                messages are not expunged from the subscription's backlog, even if
+                they are acknowledged, until they fall out of the
+                messageRetentionDuration window.
+              type: boolean
+            topicRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - topicRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            path:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_pubsubtopics.pubsub.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_pubsubtopics.pubsub.cnrm.cloud.google.com.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: pubsubtopics.pubsub.cnrm.cloud.google.com
+spec:
+  group: pubsub.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: PubSubTopic
+    plural: pubsubtopics
+    shortNames:
+    - gcppubsubtopic
+    - gcppubsubtopics
+    singular: pubsubtopic
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            kmsKeyRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            messageStoragePolicy:
+              description: |-
+                Policy constraining the set of Google Cloud Platform regions where
+                messages published to the topic may be stored. If not present, then no
+                constraints are in effect.
+              properties:
+                allowedPersistenceRegions:
+                  description: |-
+                    A list of IDs of GCP regions where messages that are published to
+                    the topic may be persisted in storage. Messages published by
+                    publishers running in non-allowed GCP regions (or running outside
+                    of GCP altogether) will be routed for storage in one of the
+                    allowed regions. An empty list means that no regions are allowed,
+                    and is not a valid configuration.
+                  items:
+                    type: string
+                  type: array
+              required:
+              - allowedPersistenceRegions
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_redisinstances.redis.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_redisinstances.redis.cnrm.cloud.google.com.yaml
@@ -1,0 +1,183 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: redisinstances.redis.cnrm.cloud.google.com
+spec:
+  group: redis.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: RedisInstance
+    plural: redisinstances
+    shortNames:
+    - gcpredisinstance
+    - gcpredisinstances
+    singular: redisinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            alternativeLocationId:
+              description: |-
+                Only applicable to STANDARD_HA tier which protects the instance
+                against zonal failures by provisioning it across two zones.
+                If provided, it must be a different zone from the one provided in
+                [locationId].
+              type: string
+            authorizedNetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            displayName:
+              description: An arbitrary and optional user-provided name for the instance.
+              type: string
+            locationId:
+              description: |-
+                The zone where the instance will be provisioned. If not provided,
+                the service will choose a zone for the instance. For STANDARD_HA tier,
+                instances will be created across two zones for protection against
+                zonal failures. If [alternativeLocationId] is also provided, it must
+                be different from [locationId].
+              type: string
+            memorySizeGb:
+              description: Redis memory size in GiB.
+              type: integer
+            redisConfigs:
+              additionalProperties:
+                type: string
+              description: |-
+                Redis configuration parameters, according to http://redis.io/topics/config.
+                Please check Memorystore documentation for the list of supported parameters:
+                https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs
+              type: object
+            redisVersion:
+              description: |-
+                The version of Redis software. If not provided, latest supported
+                version will be used. Currently, the supported values are:
+
+                - REDIS_4_0 for Redis 4.0 compatibility
+                - REDIS_3_2 for Redis 3.2 compatibility
+              type: string
+            region:
+              description: The name of the Redis region of the instance.
+              type: string
+            reservedIpRange:
+              description: |-
+                The CIDR range of internal addresses that are reserved for this
+                instance. If not provided, the service will choose an unused /29
+                block, for example, 10.0.0.0/29 or 192.168.0.0/29. Ranges must be
+                unique and non-overlapping with existing subnets in an authorized
+                network.
+              type: string
+            tier:
+              description: |-
+                The service tier of the instance. Must be one of these values:
+
+                - BASIC: standalone instance
+                - STANDARD_HA: highly available primary/replica instances
+              type: string
+          required:
+          - memorySizeGb
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            createTime:
+              description: |-
+                The time the instance was created in RFC3339 UTC "Zulu" format,
+                accurate to nanoseconds.
+              type: string
+            currentLocationId:
+              description: |-
+                The current zone where the Redis endpoint is placed.
+                For Basic Tier instances, this will always be the same as the
+                [locationId] provided by the user at creation time. For Standard Tier
+                instances, this can be either [locationId] or [alternativeLocationId]
+                and can change after a failover event.
+              type: string
+            host:
+              description: |-
+                Hostname or IP address of the exposed Redis endpoint used by clients
+                to connect to the service.
+              type: string
+            port:
+              description: The port number of the exposed Redis endpoint.
+              type: integer
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_servicemappings.core.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_servicemappings.core.cnrm.cloud.google.com.yaml
@@ -1,0 +1,362 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    controller-tools.k8s.io: "1.0"
+  name: servicemappings.core.cnrm.cloud.google.com
+spec:
+  group: core.cnrm.cloud.google.com
+  names:
+    kind: ServiceMapping
+    plural: servicemappings
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ServiceMappingSpec defines the aspects common to all resources
+            of a particular service being mapped from the Terraform provider to Kubernetes
+            Resource Model (KRM).
+          properties:
+            name:
+              description: Name is the name of the service being mapped (e.g. Spanner,
+                PubSub). This is used for the construction of the generated CRDs'
+                API group and kind.
+              type: string
+            resources:
+              description: Resources is a list of configurations specifying how to
+                map a specific resource from the Terraform provider to KRM.
+              items:
+                properties:
+                  containers:
+                    description: Containers describes all the container mappings this
+                      resource understands. Config Connector maps Kubernetes namespaces
+                      to the abstract GCP container objects they are scoped by via
+                      namespaces. For most resource types, this is a project, but
+                      certain resources live outside the scope of a project, like
+                      folders or projects themselves. Containers are expressed as
+                      annotations on a given Namespace, though users may provide resource-level
+                      overrides.
+                    items:
+                      properties:
+                        tfField:
+                          description: TFField is the path to the field in the underlying
+                            Terraform provider that represents the implicit reference
+                            to the container object. Use periods to delimit the fields
+                            in the path. For example, if the field is "bar" nested
+                            inside "foo" ("foo" being either an object or a list of
+                            objects), the associated TFField should be "foo.bar")
+                          type: string
+                        type:
+                          description: Type is the type of container this represents.
+                          type: string
+                        valueTemplate:
+                          description: ValueTemplate is a template by which the value
+                            of the container annotation should be interpreted before
+                            being passed to the Terraform provider. {{value}} is used
+                            in place of this sourced value.  e.g. If the value sourced
+                            from the container annotation is "123456789", a valueTemplate
+                            of "folders/{{value}}" would mean the final value passed
+                            to the provider is "folders/123456789"
+                          type: string
+                      required:
+                      - type
+                      - tfField
+                      type: object
+                    type: array
+                  directives:
+                    description: Directives is a list of Terraform fields that perform
+                      unique behaviors on top of the resource which are not part of
+                      a GET response. If the KCC annotation's key contains a directive
+                      from this list (e.g. `cnrm.cloud.google.com/force-destroy`),
+                      the value from the annotation is stored/overwritten in the TF
+                      config (e.g. force_destroy -> true)
+                    items:
+                      type: string
+                    type: array
+                  iamConfig:
+                    description: IAMConfig contains the mappings from a given resource
+                      onto its associated terraform IAM resources (policies, bindings,
+                      and members)
+                    properties:
+                      policyMemberName:
+                        description: PolicyMemberName is the terraform name of the
+                          associated IAM Policy Member resource (e.g. google_spanner_instance_iam_member)
+                        type: string
+                      policyName:
+                        description: PolicyName is the terraform name of the associated
+                          IAM Policy resource (e.g. google_spanner_instance_iam_policy)
+                        type: string
+                      referenceField:
+                        description: A description of the manner in which the IAM
+                          Policy references its resource.
+                        properties:
+                          name:
+                            description: The name of the field in the policy or binding
+                              which references the resource. For 'google_spanner_instance_iam_policy'
+                              this value is 'instance'.
+                            type: string
+                          type:
+                            description: The type of value that should be used in
+                              this field. It can be one of { name, id }. For 'google_spanner_instance_iam_policy'
+                              it would be 'name' for 'google_kms_key_ring_iam_policy'
+                              it would be 'id'.
+                            type: string
+                        required:
+                        - name
+                        - type
+                        type: object
+                      supportsConditions:
+                        description: SupportsConditions indicates whether or not the
+                          resource supports IAM Conditions.
+                        type: boolean
+                    required:
+                    - policyName
+                    - policyMemberName
+                    - supportsConditions
+                    type: object
+                  idTemplate:
+                    description: IDTemplate defines the format in which the ID fed
+                      into the TF resource's importer should look. Fields may be sourced
+                      from the TF resource by using the `{{foo}}` syntax. (e.g. {{project}}/{{location}}/{{name}}.
+                      If SkipImport is true, this must be specified, and its expanded
+                      form will be directly used as the TF resource's `id` field.
+                    type: string
+                  ignoredFields:
+                    description: IgnoredFields is a list of fields that should be
+                      dropped from the underlying Terraform resource.
+                    items:
+                      type: string
+                    type: array
+                  kind:
+                    description: Kind is the Kubernetes kind you wish the resource
+                      to have.
+                    type: string
+                  locationality:
+                    description: 'Locationality categorizes the GCP resources as global,
+                      regional, or zonal. It''s only applicable to the effort of unifying
+                      multiple locational TF resources into one, e.g. KCC could have
+                      a single ComputeAddress CRD to represent two TF/GCE resources
+                      - compute address and global compute address. The location field
+                      in ComputeAddress CRD is used to specify whether it is a global
+                      address or regional address. If unset, it''s assumed that there
+                      is no multiple TF locational resources mapping to the same compute
+                      resource schema. Currently, this supports the following values:
+                      global, regional, zonal.'
+                    type: string
+                  metadataMapping:
+                    description: MetadataMapping determines how to map Kubernetes
+                      metadata fields to the Terraform resource's configuration.
+                    properties:
+                      labels:
+                        description: Labels is a JSONPath to the field in the TF resource
+                          where the KRM "metadata.labels" field will be mapped to.
+                          By default, this is mapped to the "labels" field, if that
+                          field is found in the TF resource schema.
+                        type: string
+                      name:
+                        description: Name is a JSONPath to the field in the TF resource
+                          where the KRM "metadata.name" field will be mapped to. By
+                          default, this is mapped to the "name" field, if that field
+                          is found in the TF resource schema.
+                        type: string
+                      nameValueTemplate:
+                        description: NameValueTemplate is a template by which the
+                          value of the metadata.name value should be interpreted before
+                          being passed to the Terraform provider. {{value}} is used
+                          in place of this sourced value.  e.g. If the value sourced
+                          from metadata.name is "foo_bar", a nameValueTemplate of
+                          "resource/{{value}}" would mean the final value passed to
+                          the provider is "resource/foo_bar"
+                        type: string
+                    type: object
+                  name:
+                    description: Name is the Terraform name of the resource (e.g.
+                      google_spanner_instance)
+                    type: string
+                  resourceReferences:
+                    description: ResourceReferences configures the mapping of fields
+                      in the Terraform resource that implicitly define references
+                      to other GCP resources into explicit Kubernetes-style references.
+                    items:
+                      properties:
+                        group:
+                          description: Group is the Kubernetes group of the resource
+                            being referenced. If not is set, it is implied that the
+                            kind specified is unique across all groups.
+                          type: string
+                        jsonSchemaType:
+                          description: JSONSchemaType specifies the type as understood
+                            by JSON schema validation of this reference field. Should
+                            never be specified for a TypeConfig inlined in the ReferenceConfig.  This
+                            field is mutually exclusive with Kind and TargetField.
+                          type: string
+                        key:
+                          description: 'Key is the field name that will be exposed
+                            through the KRM resource''s spec. It should follow the
+                            Kubernetes reference naming semantics:   `fooRef`, where
+                            foo is some describer of what is being referenced (e.g.   instanceRef,
+                            healthCheckRef) Complex references (those with a "Types"
+                            list defined) or lists of references should not specify
+                            a key.'
+                          type: string
+                        kind:
+                          description: Kind is the Kubernetes kind of the resource
+                            being referenced. The API group and version are assumed
+                            to match the referencing resource's.  This field is mutually
+                            exclusive with JSONSchemaType.
+                          type: string
+                        parent:
+                          description: Parent specifies whether the referenced resource
+                            is a parent. If the parent is successfully deleted, this
+                            resource may be deleted without any call to the underlying
+                            API. Only one parent may be present. A parent reference's
+                            TFField must not be a nested path.
+                          type: boolean
+                        targetField:
+                          description: TargetField is the referenced resource's Terraform
+                            field that will be extracted and set as the value of the
+                            TFField. For example, a ComputeSubnetwork can reference
+                            a ComputeNetwork's self link by setting TargetField to
+                            "self_link", a field defined on the google_compute_network
+                            resource.
+                          type: string
+                        tfField:
+                          description: TFField is the path to the field in the underlying
+                            Terraform provider that is the implicit reference. Use
+                            periods to delimit the fields in the path. For example,
+                            if the reference field is "bar" nested inside "foo" ("foo"
+                            being either an object or a list of objects), the associated
+                            TFField should be "foo.bar")
+                          type: string
+                        types:
+                          description: Types is the supported types this resource
+                            reference supports. Must not be specified if the inlined
+                            TypeConfig is filled out.  If the value for the reference
+                            is not specified in the KRM spec, it is possible that
+                            a default value may be set by GCP. This default reference
+                            value will be populated in the KRM resource's spec. In
+                            cases where a resource reference has multiple types, the
+                            first type in this list will become the default TypeConfig
+                            for that value.
+                          items:
+                            properties:
+                              group:
+                                description: Group is the Kubernetes group of the
+                                  resource being referenced. If not is set, it is
+                                  implied that the kind specified is unique across
+                                  all groups.
+                                type: string
+                              jsonSchemaType:
+                                description: JSONSchemaType specifies the type as
+                                  understood by JSON schema validation of this reference
+                                  field. Should never be specified for a TypeConfig
+                                  inlined in the ReferenceConfig.  This field is mutually
+                                  exclusive with Kind and TargetField.
+                                type: string
+                              key:
+                                description: 'Key is the field name that will be exposed
+                                  through the KRM resource''s spec. It should follow
+                                  the Kubernetes reference naming semantics:   `fooRef`,
+                                  where foo is some describer of what is being referenced
+                                  (e.g.   instanceRef, healthCheckRef) Complex references
+                                  (those with a "Types" list defined) or lists of
+                                  references should not specify a key.'
+                                type: string
+                              kind:
+                                description: Kind is the Kubernetes kind of the resource
+                                  being referenced. The API group and version are
+                                  assumed to match the referencing resource's.  This
+                                  field is mutually exclusive with JSONSchemaType.
+                                type: string
+                              parent:
+                                description: Parent specifies whether the referenced
+                                  resource is a parent. If the parent is successfully
+                                  deleted, this resource may be deleted without any
+                                  call to the underlying API. Only one parent may
+                                  be present. A parent reference's TFField must not
+                                  be a nested path.
+                                type: boolean
+                              targetField:
+                                description: TargetField is the referenced resource's
+                                  Terraform field that will be extracted and set as
+                                  the value of the TFField. For example, a ComputeSubnetwork
+                                  can reference a ComputeNetwork's self link by setting
+                                  TargetField to "self_link", a field defined on the
+                                  google_compute_network resource.
+                                type: string
+                              valueTemplate:
+                                description: ValueTemplate is a template by which
+                                  the value sourced from the reference should be interpreted
+                                  before being passed to the Terraform provider. {{value}}
+                                  is used in place of this sourced value.  e.g. If
+                                  the value sourced from the reference is "foo@domain.com",
+                                  a valueTemplate of "serviceAccount:{{value}}" would
+                                  mean the final value passed to the provider is "serviceAccount:foo@domain.com"
+                                type: string
+                            type: object
+                          type: array
+                        valueTemplate:
+                          description: ValueTemplate is a template by which the value
+                            sourced from the reference should be interpreted before
+                            being passed to the Terraform provider. {{value}} is used
+                            in place of this sourced value.  e.g. If the value sourced
+                            from the reference is "foo@domain.com", a valueTemplate
+                            of "serviceAccount:{{value}}" would mean the final value
+                            passed to the provider is "serviceAccount:foo@domain.com"
+                          type: string
+                      required:
+                      - tfField
+                      type: object
+                    type: array
+                  serverGeneratedIDField:
+                    description: ServerGeneratedIDField is the field in the resource's
+                      status that corresponds to the server-generated resource ID.
+                      If unset, it's assumed the resource ID is specified by the user.
+                      Resources with this set do not support acquisition.
+                    type: string
+                  skipImport:
+                    description: SkipImport skips the import step when fetching the
+                      live state of the underlying resource. If specified, IDTemplate
+                      must also be specified, and its expanded form will be used as
+                      the TF resource's `id` field.
+                    type: boolean
+                required:
+                - name
+                - kind
+                type: object
+              type: array
+            version:
+              description: Version is the API version for all the resource CRDs being
+                generated.
+              type: string
+          required:
+          - name
+          - version
+          - resources
+          type: object
+      type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_servicenetworkingconnections.servicenetworking.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_servicenetworkingconnections.servicenetworking.cnrm.cloud.google.com.yaml
@@ -1,0 +1,140 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: servicenetworkingconnections.servicenetworking.cnrm.cloud.google.com
+spec:
+  group: servicenetworking.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ServiceNetworkingConnection
+    plural: servicenetworkingconnections
+    shortNames:
+    - gcpservicenetworkingconnection
+    - gcpservicenetworkingconnections
+    singular: servicenetworkingconnection
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            reservedPeeringRanges:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            service:
+              type: string
+          required:
+          - networkRef
+          - reservedPeeringRanges
+          - service
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            peering:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_services.serviceusage.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_services.serviceusage.cnrm.cloud.google.com.yaml
@@ -1,0 +1,75 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: services.serviceusage.cnrm.cloud.google.com
+spec:
+  group: serviceusage.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: Service
+    plural: services
+    shortNames:
+    - gcpservice
+    - gcpservices
+    singular: service
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_sourcereporepositories.sourcerepo.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_sourcereporepositories.sourcerepo.cnrm.cloud.google.com.yaml
@@ -1,0 +1,151 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: sourcereporepositories.sourcerepo.cnrm.cloud.google.com
+spec:
+  group: sourcerepo.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SourceRepoRepository
+    plural: sourcereporepositories
+    shortNames:
+    - gcpsourcereporepository
+    - gcpsourcereporepositories
+    singular: sourcereporepository
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            pubsubConfigs:
+              description: |-
+                How this repository publishes a change in the repository through Cloud Pub/Sub.
+                Keyed by the topic names.
+              items:
+                properties:
+                  messageFormat:
+                    description: |-
+                      The format of the Cloud Pub/Sub messages.
+                      - PROTOBUF: The message payload is a serialized protocol buffer of SourceRepoEvent.
+                      - JSON: The message payload is a JSON string of SourceRepoEvent.
+                    type: string
+                  serviceAccountRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  topicRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                required:
+                - messageFormat
+                - topicRef
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            size:
+              description: The disk usage of the repo, in bytes.
+              type: integer
+            url:
+              description: URL to clone the repository from Google Cloud Source Repositories.
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_spannerdatabases.spanner.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_spannerdatabases.spanner.cnrm.cloud.google.com.yaml
@@ -1,0 +1,119 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: spannerdatabases.spanner.cnrm.cloud.google.com
+spec:
+  group: spanner.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SpannerDatabase
+    plural: spannerdatabases
+    shortNames:
+    - gcpspannerdatabase
+    - gcpspannerdatabases
+    singular: spannerdatabase
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            ddl:
+              description: |-
+                An optional list of DDL statements to run inside the newly created
+                database. Statements can create tables, indexes, etc. These statements
+                execute atomically with the creation of the database: if there is an
+                error in any statement, the database is not created.
+              items:
+                type: string
+              type: array
+            instanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - instanceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            state:
+              description: An explanation of the status of the database.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_spannerinstances.spanner.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_spannerinstances.spanner.cnrm.cloud.google.com.yaml
@@ -1,0 +1,103 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: spannerinstances.spanner.cnrm.cloud.google.com
+spec:
+  group: spanner.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SpannerInstance
+    plural: spannerinstances
+    shortNames:
+    - gcpspannerinstance
+    - gcpspannerinstances
+    singular: spannerinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            config:
+              description: |-
+                The name of the instance's configuration (similar but not
+                quite the same as a region) which defines defines the geographic placement and
+                replication of your databases in this instance. It determines where your data
+                is stored. Values are typically of the form 'regional-europe-west1' , 'us-central' etc.
+                In order to obtain a valid list please consult the
+                [Configuration section of the docs](https://cloud.google.com/spanner/docs/instances).
+              type: string
+            displayName:
+              description: |-
+                The descriptive name for this instance as it appears in UIs. Must be
+                unique per project and between 4 and 30 characters in length.
+              type: string
+            numNodes:
+              description: The number of nodes allocated to this instance.
+              type: integer
+          required:
+          - config
+          - displayName
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            state:
+              description: 'Instance status: ''CREATING'' or ''READY''.'
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_sqldatabases.sql.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_sqldatabases.sql.cnrm.cloud.google.com.yaml
@@ -1,0 +1,125 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: sqldatabases.sql.cnrm.cloud.google.com
+spec:
+  group: sql.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SQLDatabase
+    plural: sqldatabases
+    shortNames:
+    - gcpsqldatabase
+    - gcpsqldatabases
+    singular: sqldatabase
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            charset:
+              description: |-
+                The charset value. See MySQL's
+                [Supported Character Sets and Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html)
+                and Postgres' [Character Set Support](https://www.postgresql.org/docs/9.6/static/multibyte.html)
+                for more details and supported values. Postgres databases only support
+                a value of 'UTF8' at creation time.
+              type: string
+            collation:
+              description: |-
+                The collation value. See MySQL's
+                [Supported Character Sets and Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html)
+                and Postgres' [Collation Support](https://www.postgresql.org/docs/9.6/static/collation.html)
+                for more details and supported values. Postgres databases only support
+                a value of 'en_US.UTF8' at creation time.
+              type: string
+            instanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - instanceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_sqlinstances.sql.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_sqlinstances.sql.cnrm.cloud.google.com.yaml
@@ -1,0 +1,355 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: sqlinstances.sql.cnrm.cloud.google.com
+spec:
+  group: sql.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SQLInstance
+    plural: sqlinstances
+    shortNames:
+    - gcpsqlinstance
+    - gcpsqlinstances
+    singular: sqlinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            databaseVersion:
+              type: string
+            masterInstanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            region:
+              type: string
+            replicaConfiguration:
+              properties:
+                caCertificate:
+                  type: string
+                clientCertificate:
+                  type: string
+                clientKey:
+                  type: string
+                connectRetryInterval:
+                  type: integer
+                dumpFilePath:
+                  type: string
+                failoverTarget:
+                  type: boolean
+                masterHeartbeatPeriod:
+                  type: integer
+                password:
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                sslCipher:
+                  type: string
+                username:
+                  type: string
+                verifyServerCertificate:
+                  type: boolean
+              type: object
+            rootPassword:
+              oneOf:
+              - not:
+                  required:
+                  - valueFrom
+                required:
+                - value
+              - not:
+                  required:
+                  - value
+                required:
+                - valueFrom
+              properties:
+                value:
+                  description: Value of the field. Cannot be used if 'valueFrom' is
+                    specified.
+                  type: string
+                valueFrom:
+                  description: Source for the field's value. Cannot be used if 'value'
+                    is specified.
+                  properties:
+                    secretKeyRef:
+                      description: Reference to a value with the given key in the
+                        given Secret in the resource's namespace.
+                      properties:
+                        key:
+                          description: Key that identifies the value to be extracted.
+                          type: string
+                        name:
+                          description: Name of the Secret to extract a value from.
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+              type: object
+            settings:
+              properties:
+                activationPolicy:
+                  type: string
+                authorizedGaeApplications:
+                  items:
+                    type: string
+                  type: array
+                availabilityType:
+                  type: string
+                backupConfiguration:
+                  properties:
+                    binaryLogEnabled:
+                      type: boolean
+                    enabled:
+                      type: boolean
+                    location:
+                      type: string
+                    startTime:
+                      type: string
+                  type: object
+                crashSafeReplication:
+                  type: boolean
+                databaseFlags:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                diskAutoresize:
+                  type: boolean
+                diskSize:
+                  type: integer
+                diskType:
+                  type: string
+                ipConfiguration:
+                  properties:
+                    authorizedNetworks:
+                      items:
+                        properties:
+                          expirationTime:
+                            type: string
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - value
+                        type: object
+                      type: array
+                    ipv4Enabled:
+                      type: boolean
+                    privateNetworkRef:
+                      oneOf:
+                      - not:
+                          required:
+                          - external
+                        required:
+                        - name
+                      - not:
+                          anyOf:
+                          - required:
+                            - name
+                          - required:
+                            - namespace
+                        required:
+                        - external
+                      properties:
+                        external:
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                      type: object
+                    requireSsl:
+                      type: boolean
+                  type: object
+                locationPreference:
+                  properties:
+                    followGaeApplication:
+                      type: string
+                    zone:
+                      type: string
+                  type: object
+                maintenanceWindow:
+                  properties:
+                    day:
+                      type: integer
+                    hour:
+                      type: integer
+                    updateTrack:
+                      type: string
+                  type: object
+                pricingPlan:
+                  type: string
+                replicationType:
+                  type: string
+                tier:
+                  type: string
+              required:
+              - tier
+              type: object
+          required:
+          - settings
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            connectionName:
+              type: string
+            firstIpAddress:
+              type: string
+            ipAddress:
+              items:
+                properties:
+                  ipAddress:
+                    type: string
+                  timeToRetire:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+            privateIpAddress:
+              type: string
+            publicIpAddress:
+              type: string
+            selfLink:
+              type: string
+            serverCaCert:
+              properties:
+                cert:
+                  type: string
+                commonName:
+                  type: string
+                createTime:
+                  type: string
+                expirationTime:
+                  type: string
+                sha1Fingerprint:
+                  type: string
+              type: object
+            serviceAccountEmailAddress:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_sqlusers.sql.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_sqlusers.sql.cnrm.cloud.google.com.yaml
@@ -1,0 +1,146 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: sqlusers.sql.cnrm.cloud.google.com
+spec:
+  group: sql.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SQLUser
+    plural: sqlusers
+    shortNames:
+    - gcpsqluser
+    - gcpsqlusers
+    singular: sqluser
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            host:
+              type: string
+            instanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            password:
+              oneOf:
+              - not:
+                  required:
+                  - valueFrom
+                required:
+                - value
+              - not:
+                  required:
+                  - value
+                required:
+                - valueFrom
+              properties:
+                value:
+                  description: Value of the field. Cannot be used if 'valueFrom' is
+                    specified.
+                  type: string
+                valueFrom:
+                  description: Source for the field's value. Cannot be used if 'value'
+                    is specified.
+                  properties:
+                    secretKeyRef:
+                      description: Reference to a value with the given key in the
+                        given Secret in the resource's namespace.
+                      properties:
+                        key:
+                          description: Key that identifies the value to be extracted.
+                          type: string
+                        name:
+                          description: Name of the Secret to extract a value from.
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+              type: object
+          required:
+          - instanceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_storagebucketaccesscontrols.storage.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_storagebucketaccesscontrols.storage.cnrm.cloud.google.com.yaml
@@ -1,0 +1,135 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: storagebucketaccesscontrols.storage.cnrm.cloud.google.com
+spec:
+  group: storage.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: StorageBucketAccessControl
+    plural: storagebucketaccesscontrols
+    shortNames:
+    - gcpstoragebucketaccesscontrol
+    - gcpstoragebucketaccesscontrols
+    singular: storagebucketaccesscontrol
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bucketRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            entity:
+              description: |-
+                The entity holding the permission, in one of the following forms:
+                  user-userId
+                  user-email
+                  group-groupId
+                  group-email
+                  domain-domain
+                  project-team-projectId
+                  allUsers
+                  allAuthenticatedUsers
+                Examples:
+                  The user liz@example.com would be user-liz@example.com.
+                  The group example@googlegroups.com would be
+                  group-example@googlegroups.com.
+                  To refer to all members of the Google Apps for Business domain
+                  example.com, the entity would be domain-example.com.
+              type: string
+            role:
+              description: The access permission for the entity.
+              type: string
+          required:
+          - bucketRef
+          - entity
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            domain:
+              description: The domain associated with the entity.
+              type: string
+            email:
+              description: The email address associated with the entity.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_storagebuckets.storage.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_storagebuckets.storage.cnrm.cloud.google.com.yaml
@@ -1,0 +1,203 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: storagebuckets.storage.cnrm.cloud.google.com
+spec:
+  group: storage.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: StorageBucket
+    plural: storagebuckets
+    shortNames:
+    - gcpstoragebucket
+    - gcpstoragebuckets
+    singular: storagebucket
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bucketPolicyOnly:
+              type: boolean
+            cors:
+              items:
+                properties:
+                  maxAgeSeconds:
+                    type: integer
+                  method:
+                    items:
+                      type: string
+                    type: array
+                  origin:
+                    items:
+                      type: string
+                    type: array
+                  responseHeader:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            encryption:
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              required:
+              - kmsKeyRef
+              type: object
+            lifecycleRule:
+              items:
+                properties:
+                  action:
+                    properties:
+                      storageClass:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  condition:
+                    properties:
+                      age:
+                        type: integer
+                      createdBefore:
+                        type: string
+                      matchesStorageClass:
+                        items:
+                          type: string
+                        type: array
+                      numNewerVersions:
+                        type: integer
+                      withState:
+                        type: string
+                    type: object
+                required:
+                - action
+                - condition
+                type: object
+              type: array
+            location:
+              type: string
+            logging:
+              properties:
+                logBucket:
+                  type: string
+                logObjectPrefix:
+                  type: string
+              required:
+              - logBucket
+              type: object
+            requesterPays:
+              type: boolean
+            retentionPolicy:
+              properties:
+                isLocked:
+                  type: boolean
+                retentionPeriod:
+                  type: integer
+              required:
+              - retentionPeriod
+              type: object
+            storageClass:
+              type: string
+            versioning:
+              properties:
+                enabled:
+                  type: boolean
+              required:
+              - enabled
+              type: object
+            website:
+              properties:
+                mainPageSuffix:
+                  type: string
+                notFoundPage:
+                  type: string
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+            url:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_storagedefaultobjectaccesscontrols.storage.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_storagedefaultobjectaccesscontrols.storage.cnrm.cloud.google.com.yaml
@@ -1,0 +1,150 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: storagedefaultobjectaccesscontrols.storage.cnrm.cloud.google.com
+spec:
+  group: storage.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: StorageDefaultObjectAccessControl
+    plural: storagedefaultobjectaccesscontrols
+    shortNames:
+    - gcpstoragedefaultobjectaccesscontrol
+    - gcpstoragedefaultobjectaccesscontrols
+    singular: storagedefaultobjectaccesscontrol
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bucketRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            entity:
+              description: |-
+                The entity holding the permission, in one of the following forms:
+                  * user-{{userId}}
+                  * user-{{email}} (such as "user-liz@example.com")
+                  * group-{{groupId}}
+                  * group-{{email}} (such as "group-example@googlegroups.com")
+                  * domain-{{domain}} (such as "domain-example.com")
+                  * project-team-{{projectId}}
+                  * allUsers
+                  * allAuthenticatedUsers
+              type: string
+            object:
+              description: The name of the object, if applied to an object.
+              type: string
+            role:
+              description: The access permission for the entity.
+              type: string
+          required:
+          - bucketRef
+          - entity
+          - role
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            domain:
+              description: The domain associated with the entity.
+              type: string
+            email:
+              description: The email address associated with the entity.
+              type: string
+            entityId:
+              description: The ID for the entity
+              type: string
+            generation:
+              description: The content generation of the object, if applied to an
+                object.
+              type: integer
+            projectTeam:
+              description: The project team associated with the entity
+              properties:
+                projectNumber:
+                  description: The project team associated with the entity
+                  type: string
+                team:
+                  description: The team.
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_storagenotifications.storage.cnrm.cloud.google.com.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apiextensions.k8s.io_v1beta1_customresourcedefinition_storagenotifications.storage.cnrm.cloud.google.com.yaml
@@ -1,0 +1,150 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: storagenotifications.storage.cnrm.cloud.google.com
+spec:
+  group: storage.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: StorageNotification
+    plural: storagenotifications
+    shortNames:
+    - gcpstoragenotification
+    - gcpstoragenotifications
+    singular: storagenotification
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bucketRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            customAttributes:
+              additionalProperties:
+                type: string
+              type: object
+            eventTypes:
+              items:
+                type: string
+              type: array
+            objectNamePrefix:
+              type: string
+            payloadFormat:
+              type: string
+            topicRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - bucketRef
+          - payloadFormat
+          - topicRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            notificationId:
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/.build/cnrm-install-system/apps_v1_deployment_cnrm-resource-stats-recorder.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apps_v1_deployment_cnrm-resource-stats-recorder.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/component: cnrm-resource-stats-recorder
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-resource-stats-recorder
+  namespace: cnrm-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cnrm.cloud.google.com/component: cnrm-resource-stats-recorder
+      cnrm.cloud.google.com/system: "true"
+  template:
+    metadata:
+      annotations:
+        cnrm.cloud.google.com/version: 1.7.1
+      labels:
+        cnrm.cloud.google.com/component: cnrm-resource-stats-recorder
+        cnrm.cloud.google.com/system: "true"
+    spec:
+      containers:
+      - args:
+        - --prometheus-scrape-endpoint=:8888
+        - --metric-interval=60
+        command:
+        - /configconnector/recorder
+        env:
+        - name: CONFIG_CONNECTOR_VERSION
+          value: 1.7.1
+        image: gcr.io/cnrm-eap/recorder:f190973
+        imagePullPolicy: Always
+        name: recorder
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+      serviceAccountName: cnrm-resource-stats-recorder
+      terminationGracePeriodSeconds: 10

--- a/test-infra/management/.build/cnrm-install-system/apps_v1_deployment_cnrm-webhook-manager.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apps_v1_deployment_cnrm-webhook-manager.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/component: cnrm-webhook-manager
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-webhook-manager
+  namespace: cnrm-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cnrm.cloud.google.com/component: cnrm-webhook-manager
+      cnrm.cloud.google.com/system: "true"
+  template:
+    metadata:
+      annotations:
+        cnrm.cloud.google.com/version: 1.7.1
+      labels:
+        cnrm.cloud.google.com/component: cnrm-webhook-manager
+        cnrm.cloud.google.com/system: "true"
+    spec:
+      containers:
+      - args:
+        - --stderrthreshold=INFO
+        command:
+        - /configconnector/webhook
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/cnrm-eap/webhook:f190973
+        imagePullPolicy: Always
+        name: webhook
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+      serviceAccountName: cnrm-webhook-manager
+      terminationGracePeriodSeconds: 10

--- a/test-infra/management/.build/cnrm-install-system/apps_v1_statefulset_cnrm-deletiondefender.yaml
+++ b/test-infra/management/.build/cnrm-install-system/apps_v1_statefulset_cnrm-deletiondefender.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/component: cnrm-deletiondefender
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-deletiondefender
+  namespace: cnrm-system
+spec:
+  selector:
+    matchLabels:
+      cnrm.cloud.google.com/component: cnrm-deletiondefender
+      cnrm.cloud.google.com/system: "true"
+  serviceName: cnrm-deletiondefender
+  template:
+    metadata:
+      annotations:
+        cnrm.cloud.google.com/version: 1.7.1
+      labels:
+        cnrm.cloud.google.com/component: cnrm-deletiondefender
+        cnrm.cloud.google.com/system: "true"
+    spec:
+      containers:
+      - args:
+        - --stderrthreshold=INFO
+        command:
+        - /configconnector/deletiondefender
+        image: gcr.io/cnrm-eap/deletiondefender:f190973
+        imagePullPolicy: Always
+        name: deletiondefender
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+      serviceAccountName: cnrm-deletiondefender
+      terminationGracePeriodSeconds: 10

--- a/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-admin.yaml
+++ b/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-admin.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-admin
+rules:
+- apiGroups:
+  - accesscontextmanager.cnrm.cloud.google.com
+  - bigquery.cnrm.cloud.google.com
+  - bigtable.cnrm.cloud.google.com
+  - cloudbuild.cnrm.cloud.google.com
+  - compute.cnrm.cloud.google.com
+  - container.cnrm.cloud.google.com
+  - dataflow.cnrm.cloud.google.com
+  - dns.cnrm.cloud.google.com
+  - firestore.cnrm.cloud.google.com
+  - iam.cnrm.cloud.google.com
+  - kms.cnrm.cloud.google.com
+  - pubsub.cnrm.cloud.google.com
+  - redis.cnrm.cloud.google.com
+  - resourcemanager.cnrm.cloud.google.com
+  - servicenetworking.cnrm.cloud.google.com
+  - serviceusage.cnrm.cloud.google.com
+  - sourcerepo.cnrm.cloud.google.com
+  - spanner.cnrm.cloud.google.com
+  - sql.cnrm.cloud.google.com
+  - storage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-deletiondefender-role.yaml
+++ b/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-deletiondefender-role.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-deletiondefender-role
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-manager-cluster-role.yaml
+++ b/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-manager-cluster-role.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-cluster-role
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - servicemappings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-manager-ns-role.yaml
+++ b/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-manager-ns-role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-ns-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-recorder-role.yaml
+++ b/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-recorder-role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-recorder-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-webhook-role.yaml
+++ b/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrole_cnrm-webhook-role.yaml
@@ -1,0 +1,62 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-webhook-role
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - servicemappings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrolebinding_cnrm-admin-binding.yaml
+++ b/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrolebinding_cnrm-admin-binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-admin-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-admin
+subjects:
+- kind: ServiceAccount
+  name: cnrm-resource-stats-recorder
+  namespace: cnrm-system
+- kind: ServiceAccount
+  name: cnrm-deletiondefender
+  namespace: cnrm-system

--- a/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrolebinding_cnrm-deletiondefender-binding.yaml
+++ b/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrolebinding_cnrm-deletiondefender-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-deletiondefender-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-deletiondefender-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-deletiondefender
+  namespace: cnrm-system

--- a/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrolebinding_cnrm-recorder-binding.yaml
+++ b/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrolebinding_cnrm-recorder-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-recorder-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-recorder-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-resource-stats-recorder
+  namespace: cnrm-system

--- a/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrolebinding_cnrm-webhook-binding.yaml
+++ b/test-infra/management/.build/cnrm-install-system/rbac.authorization.k8s.io_v1_clusterrolebinding_cnrm-webhook-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-webhook-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-webhook-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-webhook-manager
+  namespace: cnrm-system

--- a/test-infra/management/.build/cnrm-install-system/~g_v1_namespace_cnrm-system.yaml
+++ b/test-infra/management/.build/cnrm-install-system/~g_v1_namespace_cnrm-system.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-system

--- a/test-infra/management/.build/cnrm-install-system/~g_v1_service_cnrm-deletiondefender.yaml
+++ b/test-infra/management/.build/cnrm-install-system/~g_v1_service_cnrm-deletiondefender.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-deletiondefender
+  namespace: cnrm-system
+spec:
+  ports:
+  - name: deletiondefender
+    port: 443
+  selector:
+    cnrm.cloud.google.com/component: cnrm-deletiondefender
+    cnrm.cloud.google.com/system: "true"

--- a/test-infra/management/.build/cnrm-install-system/~g_v1_service_cnrm-resource-stats-recorder-service.yaml
+++ b/test-infra/management/.build/cnrm-install-system/~g_v1_service_cnrm-resource-stats-recorder-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+    prometheus.io/port: "8888"
+    prometheus.io/scrape: "true"
+  labels:
+    cnrm.cloud.google.com/monitored: "true"
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-resource-stats-recorder-service
+  namespace: cnrm-system
+spec:
+  ports:
+  - name: metrics
+    port: 8888
+  selector:
+    cnrm.cloud.google.com/component: cnrm-resource-stats-recorder
+    cnrm.cloud.google.com/system: "true"

--- a/test-infra/management/.build/cnrm-install-system/~g_v1_serviceaccount_cnrm-deletiondefender.yaml
+++ b/test-infra/management/.build/cnrm-install-system/~g_v1_serviceaccount_cnrm-deletiondefender.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-deletiondefender
+  namespace: cnrm-system

--- a/test-infra/management/.build/cnrm-install-system/~g_v1_serviceaccount_cnrm-resource-stats-recorder.yaml
+++ b/test-infra/management/.build/cnrm-install-system/~g_v1_serviceaccount_cnrm-resource-stats-recorder.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-resource-stats-recorder
+  namespace: cnrm-system

--- a/test-infra/management/.build/cnrm-install-system/~g_v1_serviceaccount_cnrm-webhook-manager.yaml
+++ b/test-infra/management/.build/cnrm-install-system/~g_v1_serviceaccount_cnrm-webhook-manager.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-webhook-manager
+  namespace: cnrm-system

--- a/test-infra/management/Makefile
+++ b/test-infra/management/Makefile
@@ -1,0 +1,62 @@
+
+# The kname of the context for the management cluster
+# The name of the context for your Kubeflow cluster
+NAME=$(shell yq r ./instance/settings.yaml name)
+MGMTCTXT=$(NAME)
+
+# The URL you want to fetch manifests from
+# TODO(jlewi): Change to kubeflow/gcp-blueprints once its checked in
+MANIFESTS_URL=https://github.com/jlewi/manifests.git/gcp/v2/management@blueprints
+
+PROJECT=$(shell yq r ./instance/settings.yaml project)
+
+# Directory where manifests should be fetched to
+MANIFESTS_DIR=./upstream/management
+
+INSTANCE_DIR=./instance
+# Print out the context
+.PHONY: echo
+echo-ctxt:
+	@echo MGMTCTXT=$(MGMTCTXT)
+
+# Get packages
+.PHONY: get-pkg
+get-pkg:
+	# TODO(jlewi): We should switch to using upstream kubeflow/manifests and pin
+	# to a specific version
+	# TODO(jlewi): We should think about how we layout packages in kubeflow/manifests so
+	# users don't end up pulling tests or other things they don't need.	
+	mkdir -p  ./upstream
+	kpt pkg get $(MANIFESTS_URL) $(MANIFESTS_DIR)
+
+.PHONY: apply
+apply: hydrate
+	anthoscli apply --project=$(PROJECT) -f .build/cluster
+
+.PHONY: hydrate
+hydrate:
+	# Delete the directory so any resources that have been removed
+	# from the manifests will be pruned
+	rm -rf .build
+	mkdir -p .build/
+	mkdir -p .build/cluster
+	kustomize build $(INSTANCE_DIR)/cluster -o .build/cluster 
+
+
+# Create a kubeconfig context for the kubeflow cluster
+.PHONE: create-ctxt
+create-ctxt:
+	PROJECT=$(shell yq r ./instance/settings.yaml project) \
+	   REGION=$(shell yq r ./instance/settings.yaml location) \
+	   NAME=$(NAME) ./hack/create_context.sh
+
+.PHONY: hydrate-kcc
+hydrate-kcc:
+	rm -rf ./.build/cnrm-install-system	
+	mkdir -p ./.build/cnrm-install-system	
+	kustomize build -o ./.build/cnrm-install-system $(INSTANCE_DIR)/cnrm-install-system
+
+.PHONY: apply-kcc
+apply-kcc: hydrate-kcc
+	kubectl --context=$(MGMTCTXT) apply -f .build/cnrm-install-system/~g_v1_namespace_cnrm-system.yaml
+	kubectl --context=$(MGMTCTXT) apply -f .build/cnrm-install-system

--- a/test-infra/management/README.md
+++ b/test-infra/management/README.md
@@ -1,0 +1,158 @@
+# Management Blueprint
+
+This directory contains the configuration needed to setup a management GKE cluster.
+
+This management cluster must run [Cloud Config Connector](https://cloud.google.com/config-connector/docs/overview). The management cluster is configured in namespace mode.
+Each namespace is associated with a Google Service Account which has owner permissions on 
+one or more GCP projects. You can then create GCP resources by creating CNRM resources
+in that namespace.
+
+Optionally, the cluster can be configured with [Anthos Config Managmenet](https://cloud.google.com/anthos-config-management/docs) 
+to manage GCP infrastructure using GitOps.
+
+## Install the required tools
+
+1. Install gcloud components
+
+   ```
+   gcloud components install kpt anthoscli beta
+   gcloud components update
+   ```
+
+## Setting up the management cluster
+
+
+1. Fetch the management blueprint
+
+   ```
+   kpt pkg get https://github.com/kubeflow/gcp-blueprints.git/management@master ./
+   ```
+
+1. Fetch the upstream manifests
+
+   ```
+   cd ./management
+   make get-pkg
+   ```
+
+   * TODO(jlewi): This is giving an error like the one below but this can be ignored
+
+    ```
+    kpt pkg get https://github.com/jlewi/manifests.git@blueprints ./upstream
+    fetching package / from https://github.com/jlewi/manifests to upstream/manifests
+    Error: resources must be annotated with config.kubernetes.io/index to be written to files
+    ```
+
+1. Pick a name for the management cluster
+
+   ```
+   export MGMT_NAME=<some name>
+   ```
+
+1. Pick a location for the Kubeflow deployment
+
+   ```
+   export LOCATION=<zone or region>
+   export PROJECT=<project>   
+   ```
+
+1. Set the name for the management resources in the upstream kustomize package
+
+   ```
+   kpt cfg set ./upstream name $(MGMT_NAME)   
+   ```
+
+1. Set the same names in the instance kustomize package defining patches
+
+   ```   
+   
+   kpt cfg set ./instance name $(MGMT_NAME)   
+   kpt cfg set ./instance location $(LOCATION)
+   kpt cfg set ./instance gcloud.core.project $(PROJECT)   
+   ```
+
+   * This directory defines kustomize overlays applied to `upstream/management`
+
+   * The names of the CNRM resources need to be set in both the base 
+     package and the overlays
+
+1. Hydrate and apply the manifests to create the cluster
+
+   ```
+   make apply
+   ```
+
+1. Create a kubeconfig context for the cluster
+
+   ```
+   make create-ctxt
+   ```
+
+1. Install the CNRM system components
+
+   ```
+   make install-kcc
+   ```
+
+### Setup KCC Namespace For Each Project
+
+You will configure Config Connector in [Namespaced Mode](https://cloud.google.com/config-connector/docs/concepts/installation-types#namespaced_mode). This means
+
+* There will be a separate namespace for each GCP project under management
+* CNRM resources will be created in the namespace matching the GCP project
+  in which the resource lives.
+* There will be multiple instances of the CNRM controller each managing
+  resources in a different namespace
+* Each CNRM controller can use a different K8s account which can be bound
+  through workload identity to a different GCP Service Account with permissions to manage the project
+
+For each project you want to setup follow the instructions below.
+
+1. Create a copy of the per namespace/project resources
+
+   ```
+   cp -r ./instance/install-per-project ./instance/cnrm-install-${MANAGED_PROJECT}
+   ```
+1. Set the project to be mananged
+
+   ```
+   kpt cfg set cnrm-install-${MANAGED_PROJECT} managed_project ${MANAGED_PROJECT}
+   ```
+
+1. Set the host project where kcc is running
+
+   ```
+   kpt cfg set instance/cnrm-install-${MANAGED_PROJECT} managed_gsa_name ${MANAGED_GSA_NAME}
+   kpt cfg set instance/cnrm-install-${MANAGED_PROJECT} host_project ${HOST_PROJECT}
+   kpt cfg set instance/cnrm-install-${MANAGED_PROJECt} host_id_pool ${HOST_PROJECT}.svc.id.goog
+   ```
+
+   * **MANAGED_SA_NAME** Name for the Google Service Account (GSA) to create to be used
+     with Cloud Config Connector to create resources in the managed project
+   * host_id_pool should be the workload identity pool used for the host project
+
+1. Apply this manifest to the mgmt cluster
+
+
+   ```
+   kubectl --context=$(MGMTCTXT) apply -f ./instance/cnrm-install-${PROJECT}/per-namespace-components.yaml
+   ```
+
+1. Create the GSA and workload identity binding
+
+   ```
+   anthoscli apply --project=${MANAGED_PROJECT} -f ./instance/cnrm-install-${PROJECT}/service_account.yaml
+   ```
+
+1. anthoscli doesn't support IAMPolicyMember resources yet so we use this as a workaround
+   to make the newly created GSA an owner of the hosted project
+
+   ```
+   gcloud projects add-iam-policy-binding ${MANAGED_PROJECT} \
+    --member=serviceAccount:${MANAGED_GSA_NAME}@${MANAGED_PROJECT}.iam.gserviceaccount.com  \
+    --role roles/owner
+   ```
+
+## References
+
+[CNRM Reference Documentation](https://cloud.google.com/config-connector/docs/reference/resources) 

--- a/test-infra/management/hack/create_context.sh
+++ b/test-infra/management/hack/create_context.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# A simple helper script to create a kubeconfig context for a particular cluster.
+#
+# usage
+# PROJECT=<PROJECT> REGION=<region> NAME=<NAME>
+#
+# TODO(jlewi): Support zonal clusters as well
+set -x 
+
+echo Checking if context ${NAME} exists 
+
+kubectl config use-context ${NAME}
+
+RESULT=$?
+
+if [ ${RESULT} -eq 0 ]; then
+echo kubeconfig context ${NAME} already exists
+exit 0
+fi
+
+set -ex
+
+# TODO test if the context already exists and if it does do nothing
+gcloud --project=${PROJECT} container clusters get-credentials \
+	   --region=${REGION} ${NAME}
+
+# Rename the context
+kubectl config rename-context $(kubectl config current-context) ${NAME}
+
+# Set the namespace to the host project
+kubectl config set-context --current --namespace=cnrm-system

--- a/test-infra/management/instance/cluster/cluster.yaml
+++ b/test-infra/management/instance/cluster/cluster.yaml
@@ -1,0 +1,16 @@
+# This is a patch for the management cluster.
+# It is used to define user specific values.
+apiVersion: identity.cnrm.cloud.google.com/v1alpha2
+kind: IdentityNamespace
+metadata:
+  name: default
+---
+# TODO(jlewi): Use a regional cluster? There should no longer be any cost savings to using zonal
+apiVersion: container.cnrm.cloud.google.com/v1alpha2
+kind: ContainerCluster
+metadata:
+  clusterName: "kubeflow-ci/us-central1/kf-ci-management" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"kubeflow-ci"},{"name":"name","value":"kf-ci-management"},{"name":"location","value":"us-central1"}]}}
+  name: kf-ci-management # {"type":"string","x-kustomize":{"setter":{"name":"name","value":"kf-ci-management"}}}
+spec:
+  # Use a regional cluster. Regional offer higher availability and the cluster management fee is the same.
+  location: us-central1 # {"type":"string","x-kustomize":{"setter":{"name":"location","value":"us-central1"}}}

--- a/test-infra/management/instance/cluster/kustomization.yaml
+++ b/test-infra/management/instance/cluster/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow-ci # {"type":"string","x-kustomize":{"setter":{"name":"gcloud.core.project","value":"kubeflow-ci"}}}
+resources:
+- ../../upstream/management/cluster
+patchesStrategicMerge:
+- cluster.yaml
+- nodepool.yaml

--- a/test-infra/management/instance/cluster/nodepool.yaml
+++ b/test-infra/management/instance/cluster/nodepool.yaml
@@ -1,0 +1,5 @@
+apiVersion: container.cnrm.cloud.google.com/v1alpha2
+kind: ContainerNodePool
+metadata:
+  clusterName: "kubeflow-ci/us-central1/kf-ci-management" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"kubeflow-ci"},{"name":"name","value":"kf-ci-management"},{"name":"location","value":"us-central1"}]}}
+  name: kf-ci-management-pool # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"project-id"},{"name":"name","value":"kf-ci-management"},{"name":"location","value":"us-central1-f"}]}}

--- a/test-infra/management/instance/cnrm-install-kubeflow-ci-deployment/README.md
+++ b/test-infra/management/instance/cnrm-install-kubeflow-ci-deployment/README.md
@@ -1,0 +1,2 @@
+TODO(jlewi): What should we do about this directory?
+Should we make it an example template? Remove it all together from git?

--- a/test-infra/management/instance/cnrm-install-kubeflow-ci-deployment/namespace.yaml
+++ b/test-infra/management/instance/cnrm-install-kubeflow-ci-deployment/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "ns1" # {"$ref":"#/definitions/io.k8s.cli.setters.namespace"}
+  annotations:
+    cnrm.cloud.google.com/project-id: "gcp-project" # {"$ref":"#/definitions/io.k8s.cli.setters.managed-project"}
+    gke.io/cluster: gke://gcp-project/us-central1-f/management # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-cluster-annotation"}

--- a/test-infra/management/instance/cnrm-install-kubeflow-ci-deployment/per-namespace-components.yaml
+++ b/test-infra/management/instance/cnrm-install-kubeflow-ci-deployment/per-namespace-components.yaml
@@ -1,0 +1,173 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+    iam.gke.io/gcp-service-account: cnrm-kf-ci-deployment@kubeflow-ci-deployment.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"},{"name":"managed_gsa_name","value":"cnrm-kf-ci-deployment"}]}}
+  labels:
+    cnrm.cloud.google.com/scoped-namespace: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-controller-manager-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/scoped-namespace: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-admin-binding-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: cnrm-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-admin
+subjects:
+- kind: ServiceAccount
+  name: cnrm-controller-manager-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/scoped-namespace: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-ns-binding-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: cnrm-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-manager-ns-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-controller-manager-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/scoped-namespace: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-ns-binding-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: cnrm-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-manager-ns-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-controller-manager-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/scoped-namespace: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-cluster-binding-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-manager-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-controller-manager-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: cnrm-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+    prometheus.io/port: "8888"
+    prometheus.io/scrape: "true"
+  labels:
+    cnrm.cloud.google.com/monitored: "true"
+    cnrm.cloud.google.com/scoped-namespace: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: cnrm-system
+spec:
+  ports:
+  - name: controller-manager
+    port: 443
+  - name: metrics
+    port: 8888
+  selector:
+    cnrm.cloud.google.com/component: cnrm-controller-manager
+    cnrm.cloud.google.com/scoped-namespace: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+    cnrm.cloud.google.com/system: "true"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/component: cnrm-controller-manager
+    cnrm.cloud.google.com/scoped-namespace: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-controller-manager-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: cnrm-system
+spec:
+  selector:
+    matchLabels:
+      cnrm.cloud.google.com/component: cnrm-controller-manager
+      cnrm.cloud.google.com/scoped-namespace: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+      cnrm.cloud.google.com/system: "true"
+  serviceName: cnrm-manager-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  template:
+    metadata:
+      annotations:
+        cnrm.cloud.google.com/version: 1.7.1
+      labels:
+        cnrm.cloud.google.com/component: cnrm-controller-manager
+        cnrm.cloud.google.com/scoped-namespace: kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+        cnrm.cloud.google.com/system: "true"
+    spec:
+      containers:
+      - args:
+        - --scoped-namespace=kubeflow-ci # {"type":"string","x-kustomize":{"partialSetters":[{"name":"host_project","value":"kubeflow-ci"}]}}
+        - --stderrthreshold=INFO
+        - --prometheus-scrape-endpoint=:8888
+        command:
+        - /configconnector/manager
+        image: gcr.io/cnrm-eap/controller:f190973
+        imagePullPolicy: Always
+        name: manager
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+      serviceAccountName: cnrm-controller-manager-kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+      terminationGracePeriodSeconds: 10

--- a/test-infra/management/instance/cnrm-install-kubeflow-ci-deployment/service_account.yaml
+++ b/test-infra/management/instance/cnrm-install-kubeflow-ci-deployment/service_account.yaml
@@ -1,0 +1,49 @@
+# Define the Google Service Account to be used with CNRM
+# in the management cluster.
+# Also define the workload identity binding.
+#
+# These resources should be created with AnthosCLI since we
+# need to bootstrap the management cluster.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: cnrm-kf-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_gsa_name","value":"cnrm-kf-ci-deployment"}]}}
+  namespace: "kubeflow-ci-deployment" # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"managed_project","value":"kubeflow-ci-deployment"}}}
+spec:
+  displayName: Service account for CNRM
+---
+# TODO(jlewi): Switch to IAMPolicyMember once anthos CLI supports that.
+apiVersion: iam.cnrm.cloud.google.com/v1alpha1
+kind: IAMPolicy
+metadata:
+  name: cnrm-system-kubeflow-ci-deployment-wi # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: "kubeflow-ci-deployment" # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"managed_project","value":"kubeflow-ci-deployment"}}}
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1alpha1
+    kind: IAMServiceAccount
+    name: cnrm-kf-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_gsa_name","value":"cnrm-kf-ci-deployment"}]}}
+  bindings:
+  - role: roles/iam.workloadIdentityUser
+    members:
+    # We use a partial setter for the entire workload id pool; i.e. ${PROJECT}.svc.id.goog
+    # Because in the case where the managed project and host project are the same setters
+    # for host and managed project would be the same and kpt would no longer know which field goes  where.
+    - serviceAccount:kubeflow-ci.svc.id.goog[cnrm-system/cnrm-controller-manager-kubeflow-ci-deployment] # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"host_id_pool","value":"kubeflow-ci.svc.id.goog"},{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+---
+# Make the GCP SA a project owner
+# TODO(jlewi): AnthosCLI doesn't appear to support IAMPolicy Member yet so 
+# as a work around you will need to use gcloud
+
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cnrm-system-kubeflow-ci-deployment-owner # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}
+  namespace: "kubeflow-ci-deployment" # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"managed_project","value":"kubeflow-ci-deployment"}}}
+spec:
+  member: serviceAccount:cnrm-kf-ci-deployment@kubeflow-ci-deployment.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"},{"name":"managed_gsa_name","value":"cnrm-kf-ci-deployment"}]}}
+  role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: projects/kubeflow-ci-deployment # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"kubeflow-ci-deployment"}]}}

--- a/test-infra/management/instance/cnrm-install-system/kustomization.yaml
+++ b/test-infra/management/instance/cnrm-install-system/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../upstream/management/cnrm-install/install-system

--- a/test-infra/management/instance/settings.yaml
+++ b/test-infra/management/instance/settings.yaml
@@ -1,0 +1,6 @@
+# The purpose of this file is to store values in setters
+# so its easy to get them using yq for use in Make.
+# TODO(jlewi): File a feature request to have kpt list-setters return the value
+project: kubeflow-ci # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"kubeflow-ci"}]}}
+name: kf-ci-management # {"type":"string","x-kustomize":{"partialSetters":[{"name":"name","value":"kf-ci-management"}]}}
+location: us-central1 # {"type":"string","x-kustomize":{"partialSetters":[{"name":"location","value":"us-central1"}]}}

--- a/test-infra/management/upstream/management/Kptfile
+++ b/test-infra/management/upstream/management/Kptfile
@@ -1,0 +1,11 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+    name: manifests
+upstream:
+    type: git
+    git:
+        commit: 555bc964672c8fa7706989e77d1b94c07fdb5493
+        repo: https://github.com/jlewi/manifests
+        directory: /gcp/v2/management
+        ref: blueprints

--- a/test-infra/management/upstream/management/cluster/README.md
+++ b/test-infra/management/upstream/management/cluster/README.md
@@ -1,0 +1,2 @@
+Configuration for the cluster; a basic GKE cluster with workload
+identity.

--- a/test-infra/management/upstream/management/cluster/cluster.yaml
+++ b/test-infra/management/upstream/management/cluster/cluster.yaml
@@ -1,0 +1,27 @@
+# TODO(jlewi): Do we still need IdentityNamespace? Isn't it automatically set for each project
+apiVersion: identity.cnrm.cloud.google.com/v1alpha2
+kind: IdentityNamespace
+metadata:
+  name: default
+spec: {}
+---
+# TODO(jlewi): Use a regional cluster? There should no longer be any cost savings to using zonal
+#
+# User specific values should be defined in a patch inside the blueprint package.
+# Exception is the name since that needs to be changed in teh base package as well.
+apiVersion: container.cnrm.cloud.google.com/v1alpha2
+kind: ContainerCluster
+metadata:
+  name: kf-ci-management # {"type":"string","x-kustomize":{"setter":{"name":"name","value":"kf-ci-management"}}}
+spec:
+  # Use a regional cluster. Regional offer higher availability and the cluster management fee is the same.
+  location: us-central1-f
+  workloadIdentity:
+    identityNamespace: default
+  ipAllocationPolicy:
+    useIpAliases: true
+  releaseChannel:
+    # TODO(jlewi): Should we switch to a stable channel?
+    channel: RAPID
+  clusterTelemetry:
+    type: enabled

--- a/test-infra/management/upstream/management/cluster/enable-services.yaml
+++ b/test-infra/management/upstream/management/cluster/enable-services.yaml
@@ -1,0 +1,8 @@
+# GKE
+apiVersion: cnrm.cloud.google.com/v1alpha1
+kind: CloudService
+metadata:
+  name: gke
+  namespace: "jlewi-dev" # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"gcloud.core.project","value":"jlewi-dev"}}}
+spec:
+  service: container.googleapis.com

--- a/test-infra/management/upstream/management/cluster/kustomization.yaml
+++ b/test-infra/management/upstream/management/cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- enable-services.yaml
+- cluster.yaml
+- nodepool.yaml

--- a/test-infra/management/upstream/management/cluster/nodepool.yaml
+++ b/test-infra/management/upstream/management/cluster/nodepool.yaml
@@ -1,0 +1,28 @@
+apiVersion: container.cnrm.cloud.google.com/v1alpha2
+kind: ContainerNodePool
+metadata:
+  clusterName: "project-id/us-central1/kf-ci-management" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"project-id"},{"name":"name","value":"kf-ci-management"},{"name":"location","value":"us-central1"}]}}
+  name: kf-ci-management-pool # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"project-id"},{"name":"name","value":"kf-ci-management"},{"name":"location","value":"us-central1-f"}]}}
+spec:
+  autoscaling:
+    minNodeCount: 1
+    maxNodeCount: 3
+  nodeConfig:
+    diskSizeGb: 100
+    diskType: pd-standard
+    machineType: n1-standard-4
+    preemptible: false
+    oauthScopes:
+    - https://www.googleapis.com/auth/devstorage.read_only
+    - https://www.googleapis.com/auth/logging.write
+    - https://www.googleapis.com/auth/monitoring
+    - https://www.googleapis.com/auth/servicecontrol
+    - https://www.googleapis.com/auth/service.management.readonly
+    - https://www.googleapis.com/auth/trace.append
+    metadata:
+      disable-legacy-endpoints: "true"
+  management:
+    autoRepair: true
+    autoUpgrade: true
+  clusterRef:
+    name: kf-ci-management # {"type":"string","x-kustomize":{"setter":{"name":"name","value":"kf-ci-management"}}}

--- a/test-infra/management/upstream/management/cnrm-install/README.md
+++ b/test-infra/management/upstream/management/cnrm-install/README.md
@@ -1,0 +1,12 @@
+# Configuration for installing KCC in the management cluster.
+
+Configs are a copy of the CNRM install (see [docs](https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall#namespaced-mode))
+
+To update:
+
+1. Download the the latest GCS install bundle listed on (https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall#namespaced-mode)
+
+1. Copy the system components for the namespaced install bundle to `install-system`
+1. Copy the per namespace components to the template stored in the blueprint repo.
+
+   * You will need to add kpt setters to the per namespace components.

--- a/test-infra/management/upstream/management/cnrm-install/enable-services.yaml
+++ b/test-infra/management/upstream/management/cnrm-install/enable-services.yaml
@@ -1,0 +1,8 @@
+# cloudresourcemanager, used for creating projects
+apiVersion: cnrm.cloud.google.com/v1alpha1
+kind: CloudService
+metadata:
+  name: cloudresourcemanager.googleapis.com
+  namespace: "jlewi-dev" # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"gcloud.core.project","value":"jlewi-dev"}}}
+spec:
+  service: cloudresourcemanager.googleapis.com

--- a/test-infra/management/upstream/management/cnrm-install/iam.yaml
+++ b/test-infra/management/upstream/management/cnrm-install/iam.yaml
@@ -1,0 +1,36 @@
+apiVersion: iam.cnrm.cloud.google.com/v1alpha1
+kind: IAMServiceAccount
+metadata:
+  name: cnrm-controller-manager
+spec:
+  displayName: Service Account for CNRM
+  projectRoles:
+  - roles/source.reader
+---
+apiVersion: iam.cnrm.cloud.google.com/v1alpha1
+kind: IAMPolicy
+metadata:
+  name: cnrm-controller-manager
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1alpha1
+    kind: IAMServiceAccount
+    name: cnrm-controller-manager
+  bindings:
+  - role: roles/iam.workloadIdentityUser
+    members:
+    - serviceAccount:root-270714.svc.id.goog[cnrm-system/cnrm-controller-manager]
+---
+# TODO: Implement this in anthos-cli ?
+# For now:  gcloud organizations add-iam-policy-binding  190265346736 --member=serviceAccount:cnrm-controller-manager@root-270714.iam.gserviceaccount.com --role=roles/resourcemanager.projectCreator
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cnrm-controller-manager:project
+spec:
+  member: serviceAccount:cnrm-controller-manager@root-270714.iam.gserviceaccount.com
+  role: roles/resourcemanager.projectCreator
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: organizations/190265346736

--- a/test-infra/management/upstream/management/cnrm-install/install-system/0-cnrm-system.yaml
+++ b/test-infra/management/upstream/management/cnrm-install/install-system/0-cnrm-system.yaml
@@ -1,0 +1,581 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-deletiondefender
+  namespace: cnrm-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-resource-stats-recorder
+  namespace: cnrm-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-webhook-manager
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-admin
+rules:
+- apiGroups:
+  - accesscontextmanager.cnrm.cloud.google.com
+  - bigquery.cnrm.cloud.google.com
+  - bigtable.cnrm.cloud.google.com
+  - cloudbuild.cnrm.cloud.google.com
+  - compute.cnrm.cloud.google.com
+  - container.cnrm.cloud.google.com
+  - dataflow.cnrm.cloud.google.com
+  - dns.cnrm.cloud.google.com
+  - firestore.cnrm.cloud.google.com
+  - iam.cnrm.cloud.google.com
+  - kms.cnrm.cloud.google.com
+  - pubsub.cnrm.cloud.google.com
+  - redis.cnrm.cloud.google.com
+  - resourcemanager.cnrm.cloud.google.com
+  - servicenetworking.cnrm.cloud.google.com
+  - serviceusage.cnrm.cloud.google.com
+  - sourcerepo.cnrm.cloud.google.com
+  - spanner.cnrm.cloud.google.com
+  - sql.cnrm.cloud.google.com
+  - storage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-deletiondefender-role
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-cluster-role
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - servicemappings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-ns-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-recorder-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-webhook-role
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - servicemappings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-admin-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-admin
+subjects:
+- kind: ServiceAccount
+  name: cnrm-resource-stats-recorder
+  namespace: cnrm-system
+- kind: ServiceAccount
+  name: cnrm-deletiondefender
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-deletiondefender-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-deletiondefender-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-deletiondefender
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-recorder-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-recorder-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-resource-stats-recorder
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-webhook-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-webhook-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-webhook-manager
+  namespace: cnrm-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-deletiondefender
+  namespace: cnrm-system
+spec:
+  ports:
+  - name: deletiondefender
+    port: 443
+  selector:
+    cnrm.cloud.google.com/component: cnrm-deletiondefender
+    cnrm.cloud.google.com/system: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+    prometheus.io/port: "8888"
+    prometheus.io/scrape: "true"
+  labels:
+    cnrm.cloud.google.com/monitored: "true"
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-resource-stats-recorder-service
+  namespace: cnrm-system
+spec:
+  ports:
+  - name: metrics
+    port: 8888
+  selector:
+    cnrm.cloud.google.com/component: cnrm-resource-stats-recorder
+    cnrm.cloud.google.com/system: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/component: cnrm-resource-stats-recorder
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-resource-stats-recorder
+  namespace: cnrm-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cnrm.cloud.google.com/component: cnrm-resource-stats-recorder
+      cnrm.cloud.google.com/system: "true"
+  template:
+    metadata:
+      annotations:
+        cnrm.cloud.google.com/version: 1.7.1
+      labels:
+        cnrm.cloud.google.com/component: cnrm-resource-stats-recorder
+        cnrm.cloud.google.com/system: "true"
+    spec:
+      containers:
+      - args:
+        - --prometheus-scrape-endpoint=:8888
+        - --metric-interval=60
+        command:
+        - /configconnector/recorder
+        env:
+        - name: CONFIG_CONNECTOR_VERSION
+          value: 1.7.1
+        image: gcr.io/cnrm-eap/recorder:f190973
+        imagePullPolicy: Always
+        name: recorder
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+      serviceAccountName: cnrm-resource-stats-recorder
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/component: cnrm-webhook-manager
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-webhook-manager
+  namespace: cnrm-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cnrm.cloud.google.com/component: cnrm-webhook-manager
+      cnrm.cloud.google.com/system: "true"
+  template:
+    metadata:
+      annotations:
+        cnrm.cloud.google.com/version: 1.7.1
+      labels:
+        cnrm.cloud.google.com/component: cnrm-webhook-manager
+        cnrm.cloud.google.com/system: "true"
+    spec:
+      containers:
+      - args:
+        - --stderrthreshold=INFO
+        command:
+        - /configconnector/webhook
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/cnrm-eap/webhook:f190973
+        imagePullPolicy: Always
+        name: webhook
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+      serviceAccountName: cnrm-webhook-manager
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/component: cnrm-deletiondefender
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-deletiondefender
+  namespace: cnrm-system
+spec:
+  selector:
+    matchLabels:
+      cnrm.cloud.google.com/component: cnrm-deletiondefender
+      cnrm.cloud.google.com/system: "true"
+  serviceName: cnrm-deletiondefender
+  template:
+    metadata:
+      annotations:
+        cnrm.cloud.google.com/version: 1.7.1
+      labels:
+        cnrm.cloud.google.com/component: cnrm-deletiondefender
+        cnrm.cloud.google.com/system: "true"
+    spec:
+      containers:
+      - args:
+        - --stderrthreshold=INFO
+        command:
+        - /configconnector/deletiondefender
+        image: gcr.io/cnrm-eap/deletiondefender:f190973
+        imagePullPolicy: Always
+        name: deletiondefender
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+      serviceAccountName: cnrm-deletiondefender
+      terminationGracePeriodSeconds: 10

--- a/test-infra/management/upstream/management/cnrm-install/install-system/crds.yaml
+++ b/test-infra/management/upstream/management/cnrm-install/install-system/crds.yaml
@@ -1,0 +1,17665 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com
+spec:
+  group: accesscontextmanager.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: AccessContextManagerAccessLevel
+    plural: accesscontextmanageraccesslevels
+    shortNames:
+    - gcpaccesscontextmanageraccesslevel
+    - gcpaccesscontextmanageraccesslevels
+    singular: accesscontextmanageraccesslevel
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            accessPolicyRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            basic:
+              description: A set of predefined conditions for the access level and
+                a combining function.
+              properties:
+                combiningFunction:
+                  description: |-
+                    How the conditions list should be combined to determine if a request
+                    is granted this AccessLevel. If AND is used, each Condition in
+                    conditions must be satisfied for the AccessLevel to be applied. If
+                    OR is used, at least one Condition in conditions must be satisfied
+                    for the AccessLevel to be applied. Defaults to AND if unspecified.
+                  type: string
+                conditions:
+                  description: A set of requirements for the AccessLevel to be granted.
+                  items:
+                    properties:
+                      devicePolicy:
+                        description: |-
+                          Device specific restrictions, all restrictions must hold for
+                          the Condition to be true. If not specified, all devices are
+                          allowed.
+                        properties:
+                          allowedDeviceManagementLevels:
+                            description: |-
+                              A list of allowed device management levels.
+                              An empty list allows all management levels.
+                            items:
+                              type: string
+                            type: array
+                          allowedEncryptionStatuses:
+                            description: |-
+                              A list of allowed encryptions statuses.
+                              An empty list allows all statuses.
+                            items:
+                              type: string
+                            type: array
+                          osConstraints:
+                            description: |-
+                              A list of allowed OS versions.
+                              An empty list allows all types and all versions.
+                            items:
+                              properties:
+                                minimumVersion:
+                                  description: |-
+                                    The minimum allowed OS version. If not set, any version
+                                    of this OS satisfies the constraint.
+                                    Format: "major.minor.patch" such as "10.5.301", "9.2.1".
+                                  type: string
+                                osType:
+                                  description: The operating system type of the device.
+                                  type: string
+                              required:
+                              - osType
+                              type: object
+                            type: array
+                          requireAdminApproval:
+                            description: Whether the device needs to be approved by
+                              the customer admin.
+                            type: boolean
+                          requireCorpOwned:
+                            description: Whether the device needs to be corp owned.
+                            type: boolean
+                          requireScreenLock:
+                            description: |-
+                              Whether or not screenlock is required for the DevicePolicy
+                              to be true. Defaults to false.
+                            type: boolean
+                        type: object
+                      ipSubnetworks:
+                        description: |-
+                          A list of CIDR block IP subnetwork specification. May be IPv4
+                          or IPv6.
+                          Note that for a CIDR IP address block, the specified IP address
+                          portion must be properly truncated (i.e. all the host bits must
+                          be zero) or the input is considered malformed. For example,
+                          "192.0.2.0/24" is accepted but "192.0.2.1/24" is not. Similarly,
+                          for IPv6, "2001:db8::/32" is accepted whereas "2001:db8::1/32"
+                          is not. The originating IP of a request must be in one of the
+                          listed subnets in order for this Condition to be true.
+                          If empty, all IP addresses are allowed.
+                        items:
+                          type: string
+                        type: array
+                      members:
+                        items:
+                          properties:
+                            group:
+                              type: string
+                            serviceAccountRef:
+                              oneOf:
+                              - not:
+                                  required:
+                                  - external
+                                required:
+                                - name
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - name
+                                  - required:
+                                    - namespace
+                                required:
+                                - external
+                              properties:
+                                external:
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                              type: object
+                            user:
+                              type: string
+                          type: object
+                        type: array
+                      negate:
+                        description: |-
+                          Whether to negate the Condition. If true, the Condition becomes
+                          a NAND over its non-empty fields, each field must be false for
+                          the Condition overall to be satisfied. Defaults to false.
+                        type: boolean
+                      requiredAccessLevels:
+                        items:
+                          oneOf:
+                          - not:
+                              required:
+                              - external
+                            required:
+                            - name
+                          - not:
+                              anyOf:
+                              - required:
+                                - name
+                              - required:
+                                - namespace
+                            required:
+                            - external
+                          properties:
+                            external:
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+              required:
+              - conditions
+              type: object
+            description:
+              description: Description of the AccessLevel and its use. Does not affect
+                behavior.
+              type: string
+            title:
+              description: Human readable title. Must be unique within the Policy.
+              type: string
+          required:
+          - accessPolicyRef
+          - title
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: accesscontextmanageraccesspolicies.accesscontextmanager.cnrm.cloud.google.com
+spec:
+  group: accesscontextmanager.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: AccessContextManagerAccessPolicy
+    plural: accesscontextmanageraccesspolicies
+    shortNames:
+    - gcpaccesscontextmanageraccesspolicy
+    - gcpaccesscontextmanageraccesspolicies
+    singular: accesscontextmanageraccesspolicy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            title:
+              description: Human readable title. Does not affect behavior.
+              type: string
+          required:
+          - title
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            createTime:
+              description: Time the AccessPolicy was created in UTC.
+              type: string
+            name:
+              description: 'Resource name of the AccessPolicy. Format: {policy_id}'
+              type: string
+            updateTime:
+              description: Time the AccessPolicy was updated in UTC.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: bigquerydatasets.bigquery.cnrm.cloud.google.com
+spec:
+  group: bigquery.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: BigQueryDataset
+    plural: bigquerydatasets
+    shortNames:
+    - gcpbigquerydataset
+    - gcpbigquerydatasets
+    singular: bigquerydataset
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            access:
+              description: An array of objects that define dataset access for one
+                or more entities.
+              items:
+                properties:
+                  domain:
+                    description: |-
+                      A domain to grant access to. Any users signed in with the
+                      domain specified will be granted the specified access
+                    type: string
+                  groupByEmail:
+                    description: An email address of a Google Group to grant access
+                      to.
+                    type: string
+                  role:
+                    description: |-
+                      Describes the rights granted to the user specified by the other
+                      member of the access object. Primitive, Predefined and custom
+                      roles are supported. Predefined roles that have equivalent
+                      primitive roles are swapped by the API to their Primitive
+                      counterparts, and will show a diff post-create. See
+                      [official docs](https://cloud.google.com/bigquery/docs/access-control).
+                    type: string
+                  specialGroup:
+                    description: |-
+                      A special group to grant access to. Possible values include:
+
+
+                      * 'projectOwners': Owners of the enclosing project.
+
+
+                      * 'projectReaders': Readers of the enclosing project.
+
+
+                      * 'projectWriters': Writers of the enclosing project.
+
+
+                      * 'allAuthenticatedUsers': All authenticated BigQuery users.
+                    type: string
+                  userByEmail:
+                    description: |-
+                      An email address of a user to grant access to. For example:
+                      fred@example.com
+                    type: string
+                  view:
+                    description: |-
+                      A view from a different dataset to grant access to. Queries
+                      executed against that view will have read access to tables in
+                      this dataset. The role field is not required when this field is
+                      set. If that view is updated by any user, access to the view
+                      needs to be granted again via an update operation.
+                    properties:
+                      datasetId:
+                        description: The ID of the dataset containing this table.
+                        type: string
+                      projectId:
+                        description: The ID of the project containing this table.
+                        type: string
+                      tableId:
+                        description: |-
+                          The ID of the table. The ID must contain only letters (a-z,
+                          A-Z), numbers (0-9), or underscores (_). The maximum length
+                          is 1,024 characters.
+                        type: string
+                    required:
+                    - datasetId
+                    - projectId
+                    - tableId
+                    type: object
+                type: object
+              type: array
+            defaultEncryptionConfiguration:
+              description: |-
+                The default encryption key for all tables in the dataset. Once this property is set,
+                all newly-created partitioned tables in the dataset will have encryption key set to
+                this value, unless table creation request (or query) overrides the key.
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              required:
+              - kmsKeyRef
+              type: object
+            defaultPartitionExpirationMs:
+              description: |-
+                The default partition expiration for all partitioned tables in
+                the dataset, in milliseconds.
+
+
+                Once this property is set, all newly-created partitioned tables in
+                the dataset will have an 'expirationMs' property in the 'timePartitioning'
+                settings set to this value, and changing the value will only
+                affect new tables, not existing ones. The storage in a partition will
+                have an expiration time of its partition time plus this value.
+                Setting this property overrides the use of 'defaultTableExpirationMs'
+                for partitioned tables: only one of 'defaultTableExpirationMs' and
+                'defaultPartitionExpirationMs' will be used for any new partitioned
+                table. If you provide an explicit 'timePartitioning.expirationMs' when
+                creating or updating a partitioned table, that value takes precedence
+                over the default partition expiration time indicated by this property.
+              type: integer
+            defaultTableExpirationMs:
+              description: |-
+                The default lifetime of all tables in the dataset, in milliseconds.
+                The minimum value is 3600000 milliseconds (one hour).
+
+
+                Once this property is set, all newly-created tables in the dataset
+                will have an 'expirationTime' property set to the creation time plus
+                the value in this property, and changing the value will only affect
+                new tables, not existing ones. When the 'expirationTime' for a given
+                table is reached, that table will be deleted automatically.
+                If a table's 'expirationTime' is modified or removed before the
+                table expires, or if you provide an explicit 'expirationTime' when
+                creating a table, that value takes precedence over the default
+                expiration time indicated by this property.
+              type: integer
+            description:
+              description: A user-friendly description of the dataset
+              type: string
+            friendlyName:
+              description: A descriptive name for the dataset
+              type: string
+            location:
+              description: |-
+                The geographic location where the dataset should reside.
+                See [official docs](https://cloud.google.com/bigquery/docs/dataset-locations).
+
+
+                There are two types of locations, regional or multi-regional. A regional
+                location is a specific geographic place, such as Tokyo, and a multi-regional
+                location is a large geographic area, such as the United States, that
+                contains at least two geographic places.
+
+
+                Possible regional values include: 'asia-east1', 'asia-northeast1',
+                'asia-southeast1', 'australia-southeast1', 'europe-north1',
+                'europe-west2' and 'us-east4'.
+
+
+                Possible multi-regional values: 'EU' and 'US'.
+
+
+                The default value is multi-regional location 'US'.
+                Changing this forces a new resource to be created.
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTime:
+              description: |-
+                The time when this dataset was created, in milliseconds since the
+                epoch.
+              type: integer
+            etag:
+              description: A hash of the resource.
+              type: string
+            lastModifiedTime:
+              description: |-
+                The date when this dataset or any of its tables was last modified, in
+                milliseconds since the epoch.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: bigquerytables.bigquery.cnrm.cloud.google.com
+spec:
+  group: bigquery.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: BigQueryTable
+    plural: bigquerytables
+    shortNames:
+    - gcpbigquerytable
+    - gcpbigquerytables
+    singular: bigquerytable
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clustering:
+              items:
+                type: string
+              type: array
+            datasetRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            description:
+              type: string
+            encryptionConfiguration:
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              required:
+              - kmsKeyRef
+              type: object
+            expirationTime:
+              type: integer
+            externalDataConfiguration:
+              properties:
+                autodetect:
+                  type: boolean
+                compression:
+                  type: string
+                csvOptions:
+                  properties:
+                    allowJaggedRows:
+                      type: boolean
+                    allowQuotedNewlines:
+                      type: boolean
+                    encoding:
+                      type: string
+                    fieldDelimiter:
+                      type: string
+                    quote:
+                      type: string
+                    skipLeadingRows:
+                      type: integer
+                  required:
+                  - quote
+                  type: object
+                googleSheetsOptions:
+                  properties:
+                    range:
+                      type: string
+                    skipLeadingRows:
+                      type: integer
+                  type: object
+                ignoreUnknownValues:
+                  type: boolean
+                maxBadRecords:
+                  type: integer
+                sourceFormat:
+                  type: string
+                sourceUris:
+                  items:
+                    type: string
+                  type: array
+              required:
+              - autodetect
+              - sourceFormat
+              - sourceUris
+              type: object
+            friendlyName:
+              type: string
+            schema:
+              type: string
+            timePartitioning:
+              properties:
+                expirationMs:
+                  type: integer
+                field:
+                  type: string
+                requirePartitionFilter:
+                  type: boolean
+                type:
+                  type: string
+              required:
+              - type
+              type: object
+            view:
+              properties:
+                query:
+                  type: string
+                useLegacySql:
+                  type: boolean
+              required:
+              - query
+              type: object
+          required:
+          - datasetRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTime:
+              type: integer
+            etag:
+              type: string
+            lastModifiedTime:
+              type: integer
+            location:
+              type: string
+            numBytes:
+              type: integer
+            numLongTermBytes:
+              type: integer
+            numRows:
+              type: integer
+            selfLink:
+              type: string
+            type:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: bigtableinstances.bigtable.cnrm.cloud.google.com
+spec:
+  group: bigtable.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: BigtableInstance
+    plural: bigtableinstances
+    shortNames:
+    - gcpbigtableinstance
+    - gcpbigtableinstances
+    singular: bigtableinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            cluster:
+              items:
+                properties:
+                  clusterId:
+                    type: string
+                  numNodes:
+                    type: integer
+                  storageType:
+                    type: string
+                  zone:
+                    type: string
+                required:
+                - clusterId
+                - zone
+                type: object
+              type: array
+            displayName:
+              type: string
+            instanceType:
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com
+spec:
+  group: cloudbuild.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: CloudBuildTrigger
+    plural: cloudbuildtriggers
+    shortNames:
+    - gcpcloudbuildtrigger
+    - gcpcloudbuildtriggers
+    singular: cloudbuildtrigger
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            build:
+              description: Contents of the build template. Either a filename or build
+                template must be provided.
+              properties:
+                images:
+                  description: |-
+                    A list of images to be pushed upon the successful completion of all build steps.
+                    The images are pushed using the builder service account's credentials.
+                    The digests of the pushed images will be stored in the Build resource's results field.
+                    If any of the images fail to be pushed, the build status is marked FAILURE.
+                  items:
+                    type: string
+                  type: array
+                step:
+                  description: The operations to be performed on the workspace.
+                  items:
+                    properties:
+                      args:
+                        description: |-
+                          A list of arguments that will be presented to the step when it is started.
+
+                          If the image used to run the step's container has an entrypoint, the args
+                          are used as arguments to that entrypoint. If the image does not define an
+                          entrypoint, the first element in args is used as the entrypoint, and the
+                          remainder will be used as arguments.
+                        items:
+                          type: string
+                        type: array
+                      dir:
+                        description: |-
+                          Working directory to use when running this step's container.
+
+                          If this value is a relative path, it is relative to the build's working
+                          directory. If this value is absolute, it may be outside the build's working
+                          directory, in which case the contents of the path may not be persisted
+                          across build step executions, unless a 'volume' for that path is specified.
+
+                          If the build specifies a 'RepoSource' with 'dir' and a step with a
+                          'dir',
+                          which specifies an absolute path, the 'RepoSource' 'dir' is ignored
+                          for the step's execution.
+                        type: string
+                      entrypoint:
+                        description: |-
+                          Entrypoint to be used instead of the build step image's
+                          default entrypoint.
+                          If unset, the image's default entrypoint is used
+                        type: string
+                      env:
+                        description: |-
+                          A list of environment variable definitions to be used when
+                          running a step.
+
+                          The elements are of the form "KEY=VALUE" for the environment variable
+                          "KEY" being given the value "VALUE".
+                        items:
+                          type: string
+                        type: array
+                      id:
+                        description: |-
+                          Unique identifier for this build step, used in 'wait_for' to
+                          reference this build step as a dependency.
+                        type: string
+                      name:
+                        description: |-
+                          The name of the container image that will run this particular build step.
+
+                          If the image is available in the host's Docker daemon's cache, it will be
+                          run directly. If not, the host will attempt to pull the image first, using
+                          the builder service account's credentials if necessary.
+
+                          The Docker daemon's cache will already have the latest versions of all of
+                          the officially supported build steps (https://github.com/GoogleCloudPlatform/cloud-builders).
+                          The Docker daemon will also have cached many of the layers for some popular
+                          images, like "ubuntu", "debian", but they will be refreshed at the time
+                          you attempt to use them.
+
+                          If you built an image in a previous build step, it will be stored in the
+                          host's Docker daemon's cache and is available to use as the name for a
+                          later build step.
+                        type: string
+                      secretEnv:
+                        description: |-
+                          A list of environment variables which are encrypted using
+                          a Cloud Key
+                          Management Service crypto key. These values must be specified in
+                          the build's 'Secret'.
+                        items:
+                          type: string
+                        type: array
+                      timeout:
+                        description: |-
+                          Time limit for executing this build step. If not defined,
+                          the step has no
+                          time limit and will be allowed to continue to run until either it
+                          completes or the build itself times out.
+                        type: string
+                      timing:
+                        description: |-
+                          Output only. Stores timing information for executing this
+                          build step.
+                        type: string
+                      volumes:
+                        description: |-
+                          List of volumes to mount into the build step.
+
+                          Each volume is created as an empty volume prior to execution of the
+                          build step. Upon completion of the build, volumes and their contents
+                          are discarded.
+
+                          Using a named volume in only one step is not valid as it is
+                          indicative of a build request with an incorrect configuration.
+                        items:
+                          properties:
+                            name:
+                              description: |-
+                                Name of the volume to mount.
+
+                                Volume names must be unique per build step and must be valid names for
+                                Docker volumes. Each named volume must be used by at least two build steps.
+                              type: string
+                            path:
+                              description: |-
+                                Path at which to mount the volume.
+
+                                Paths must be absolute and cannot conflict with other volume paths on
+                                the same build step or with certain reserved volume paths.
+                              type: string
+                          required:
+                          - name
+                          - path
+                          type: object
+                        type: array
+                      waitFor:
+                        description: |-
+                          The ID(s) of the step(s) that this build step depends on.
+
+                          This build step will not start until all the build steps in 'wait_for'
+                          have completed successfully. If 'wait_for' is empty, this build step
+                          will start when all previous build steps in the 'Build.Steps' list
+                          have completed successfully.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - name
+                    type: object
+                  type: array
+                tags:
+                  description: Tags for annotation of a Build. These are not docker
+                    tags.
+                  items:
+                    type: string
+                  type: array
+                timeout:
+                  description: |-
+                    Amount of time that this build should be allowed to run, to second granularity.
+                    If this amount of time elapses, work on the build will cease and the build status will be TIMEOUT.
+                    This timeout must be equal to or greater than the sum of the timeouts for build steps within the build.
+                    The expected format is the number of seconds followed by s.
+                    Default time is ten minutes (600s).
+                  type: string
+              required:
+              - step
+              type: object
+            description:
+              description: Human-readable description of the trigger.
+              type: string
+            disabled:
+              description: Whether the trigger is disabled or not. If true, the trigger
+                will never result in a build.
+              type: boolean
+            filename:
+              description: Path, from the source root, to a file whose contents is
+                used for the template. Either a filename or build template must be
+                provided.
+              type: string
+            github:
+              description: |-
+                Describes the configuration of a trigger that creates a build whenever a GitHub event is received.
+
+                One of 'trigger_template' or 'github' must be provided.
+              properties:
+                name:
+                  description: |-
+                    Name of the repository. For example: The name for
+                    https://github.com/googlecloudplatform/cloud-builders is "cloud-builders".
+                  type: string
+                owner:
+                  description: |-
+                    Owner of the repository. For example: The owner for
+                    https://github.com/googlecloudplatform/cloud-builders is "googlecloudplatform".
+                  type: string
+                pullRequest:
+                  description: filter to match changes in pull requests.  Specify
+                    only one of pullRequest or push.
+                  properties:
+                    branch:
+                      description: Regex of branches to match.
+                      type: string
+                    commentControl:
+                      description: Whether to block builds on a "/gcbrun" comment
+                        from a repository owner or collaborator.
+                      type: string
+                  required:
+                  - branch
+                  type: object
+                push:
+                  description: filter to match changes in refs, like branches or tags.  Specify
+                    only one of pullRequest or push.
+                  properties:
+                    branch:
+                      description: Regex of branches to match.  Specify only one of
+                        branch or tag.
+                      type: string
+                    tag:
+                      description: Regex of tags to match.  Specify only one of branch
+                        or tag.
+                      type: string
+                  type: object
+              type: object
+            ignoredFiles:
+              description: |-
+                ignoredFiles and includedFiles are file glob matches using http://godoc/pkg/path/filepath#Match
+                extended with support for '**'.
+
+                If ignoredFiles and changed files are both empty, then they are not
+                used to determine whether or not to trigger a build.
+
+                If ignoredFiles is not empty, then we ignore any files that match any
+                of the ignored_file globs. If the change has no files that are outside
+                of the ignoredFiles globs, then we do not trigger a build.
+              items:
+                type: string
+              type: array
+            includedFiles:
+              description: |-
+                ignoredFiles and includedFiles are file glob matches using http://godoc/pkg/path/filepath#Match
+                extended with support for '**'.
+
+                If any of the files altered in the commit pass the ignoredFiles filter
+                and includedFiles is empty, then as far as this filter is concerned, we
+                should trigger the build.
+
+                If any of the files altered in the commit pass the ignoredFiles filter
+                and includedFiles is not empty, then we make sure that at least one of
+                those files matches a includedFiles glob. If not, then we do not trigger
+                a build.
+              items:
+                type: string
+              type: array
+            substitutions:
+              additionalProperties:
+                type: string
+              description: Substitutions data for Build resource.
+              type: object
+            triggerTemplate:
+              description: |-
+                Template describing the types of source changes to trigger a build.
+
+                Branch and tag names in trigger templates are interpreted as regular
+                expressions. Any branch or tag change that matches that regular
+                expression will trigger a build.
+
+                One of 'trigger_template' or 'github' must be provided.
+              properties:
+                branchName:
+                  description: |-
+                    Name of the branch to build. Exactly one a of branch name, tag, or commit SHA must be provided.
+                    This field is a regular expression.
+                  type: string
+                commitSha:
+                  description: Explicit commit SHA to build. Exactly one of a branch
+                    name, tag, or commit SHA must be provided.
+                  type: string
+                dir:
+                  description: |-
+                    Directory, relative to the source root, in which to run the build.
+
+                    This must be a relative path. If a step's dir is specified and
+                    is an absolute path, this value is ignored for that step's
+                    execution.
+                  type: string
+                repoRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                tagName:
+                  description: |-
+                    Name of the tag to build. Exactly one of a branch name, tag, or commit SHA must be provided.
+                    This field is a regular expression.
+                  type: string
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            createTime:
+              description: Time when the trigger was created.
+              type: string
+            triggerId:
+              description: The unique identifier for the trigger.
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeaddresses.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeAddress
+    plural: computeaddresses
+    shortNames:
+    - gcpcomputeaddress
+    - gcpcomputeaddresses
+    singular: computeaddress
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            address:
+              description: |-
+                The static external IP address represented by this resource. Only
+                IPv4 is supported. An address may only be specified for INTERNAL
+                address types. The IP address must be inside the specified subnetwork,
+                if any.
+              type: string
+            addressType:
+              description: |-
+                The type of address to reserve, either INTERNAL or EXTERNAL.
+                If unspecified, defaults to EXTERNAL.
+              type: string
+            description:
+              description: An optional description of this resource.
+              type: string
+            ipVersion:
+              description: |-
+                The IP Version that will be used by this address. Valid options are
+                'IPV4' or 'IPV6'. The default value is 'IPV4'.
+              type: string
+            location:
+              description: 'Location represents the geographical location of the ComputeAddress.
+                Specify a region name or "global" for global resources. Reference:
+                GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            networkTier:
+              description: |-
+                The networking tier used for configuring this address. This field can
+                take the following values: PREMIUM or STANDARD. If this field is not
+                specified, it is assumed to be PREMIUM.
+              type: string
+            prefixLength:
+              description: |-
+                The prefix length of the IP range. If not present, it means the
+                address field is a single IP address.
+
+                This field is not applicable to addresses with addressType=EXTERNAL.
+              type: integer
+            purpose:
+              description: |-
+                The purpose of this resource, which can be one of the following values:
+
+                - GCE_ENDPOINT for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
+
+                This should only be set when using an Internal address.
+              type: string
+            subnetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource.  Used
+                internally during updates.
+              type: string
+            selfLink:
+              type: string
+            users:
+              description: The URLs of the resources that are using this address.
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computebackendbuckets.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeBackendBucket
+    plural: computebackendbuckets
+    shortNames:
+    - gcpcomputebackendbucket
+    - gcpcomputebackendbuckets
+    singular: computebackendbucket
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bucketRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            cdnPolicy:
+              description: Cloud CDN configuration for this Backend Bucket.
+              properties:
+                signedUrlCacheMaxAgeSec:
+                  description: |-
+                    Maximum number of seconds the response to a signed URL request will
+                    be considered fresh. After this time period,
+                    the response will be revalidated before being served.
+                    When serving responses to signed URL requests,
+                    Cloud CDN will internally behave as though
+                    all responses from this backend had a "Cache-Control: public,
+                    max-age=[TTL]" header, regardless of any existing Cache-Control
+                    header. The actual headers served in responses will not be altered.
+                  type: integer
+              required:
+              - signedUrlCacheMaxAgeSec
+              type: object
+            description:
+              description: |-
+                An optional textual description of the resource; provided by the
+                client when the resource is created.
+              type: string
+            enableCdn:
+              description: If true, enable Cloud CDN for this BackendBucket.
+              type: boolean
+          required:
+          - bucketRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computebackendservices.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeBackendService
+    plural: computebackendservices
+    shortNames:
+    - gcpcomputebackendservice
+    - gcpcomputebackendservices
+    singular: computebackendservice
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            affinityCookieTtlSec:
+              description: |-
+                Lifetime of cookies in seconds if session_affinity is
+                GENERATED_COOKIE. If set to 0, the cookie is non-persistent and lasts
+                only until the end of the browser session (or equivalent). The
+                maximum allowed value for TTL is one day.
+
+                When the load balancing scheme is INTERNAL, this field is not used.
+              type: integer
+            backend:
+              description: The set of backends that serve this BackendService.
+              items:
+                properties:
+                  balancingMode:
+                    description: |-
+                      Specifies the balancing mode for this backend.
+
+                      For global HTTP(S) or TCP/SSL load balancing, the default is
+                      UTILIZATION. Valid values are UTILIZATION, RATE (for HTTP(S))
+                      and CONNECTION (for TCP/SSL).
+                    type: string
+                  capacityScaler:
+                    description: |-
+                      A multiplier applied to the group's maximum servicing capacity
+                      (based on UTILIZATION, RATE or CONNECTION).
+
+                      Default value is 1, which means the group will serve up to 100%
+                      of its configured capacity (depending on balancingMode). A
+                      setting of 0 means the group is completely drained, offering
+                      0% of its available Capacity. Valid range is [0.0,1.0].
+                    type: number
+                  description:
+                    description: |-
+                      An optional description of this resource.
+                      Provide this property when you create the resource.
+                    type: string
+                  group:
+                    properties:
+                      instanceGroupRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                      networkEndpointGroupRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                    type: object
+                  maxConnections:
+                    description: |-
+                      The max number of simultaneous connections for the group. Can
+                      be used with either CONNECTION or UTILIZATION balancing modes.
+
+                      For CONNECTION mode, either maxConnections or one
+                      of maxConnectionsPerInstance or maxConnectionsPerEndpoint,
+                      as appropriate for group type, must be set.
+                    type: integer
+                  maxConnectionsPerEndpoint:
+                    description: |-
+                      The max number of simultaneous connections that a single backend
+                      network endpoint can handle. This is used to calculate the
+                      capacity of the group. Can be used in either CONNECTION or
+                      UTILIZATION balancing modes.
+
+                      For CONNECTION mode, either
+                      maxConnections or maxConnectionsPerEndpoint must be set.
+                    type: integer
+                  maxConnectionsPerInstance:
+                    description: |-
+                      The max number of simultaneous connections that a single
+                      backend instance can handle. This is used to calculate the
+                      capacity of the group. Can be used in either CONNECTION or
+                      UTILIZATION balancing modes.
+
+                      For CONNECTION mode, either maxConnections or
+                      maxConnectionsPerInstance must be set.
+                    type: integer
+                  maxRate:
+                    description: |-
+                      The max requests per second (RPS) of the group.
+
+                      Can be used with either RATE or UTILIZATION balancing modes,
+                      but required if RATE mode. For RATE mode, either maxRate or one
+                      of maxRatePerInstance or maxRatePerEndpoint, as appropriate for
+                      group type, must be set.
+                    type: integer
+                  maxRatePerEndpoint:
+                    description: |-
+                      The max requests per second (RPS) that a single backend network
+                      endpoint can handle. This is used to calculate the capacity of
+                      the group. Can be used in either balancing mode. For RATE mode,
+                      either maxRate or maxRatePerEndpoint must be set.
+                    type: number
+                  maxRatePerInstance:
+                    description: |-
+                      The max requests per second (RPS) that a single backend
+                      instance can handle. This is used to calculate the capacity of
+                      the group. Can be used in either balancing mode. For RATE mode,
+                      either maxRate or maxRatePerInstance must be set.
+                    type: number
+                  maxUtilization:
+                    description: |-
+                      Used when balancingMode is UTILIZATION. This ratio defines the
+                      CPU utilization target for the group. The default is 0.8. Valid
+                      range is [0.0, 1.0].
+                    type: number
+                required:
+                - group
+                type: object
+              type: array
+            cdnPolicy:
+              description: Cloud CDN configuration for this BackendService.
+              properties:
+                cacheKeyPolicy:
+                  description: The CacheKeyPolicy for this CdnPolicy.
+                  properties:
+                    includeHost:
+                      description: If true requests to different hosts will be cached
+                        separately.
+                      type: boolean
+                    includeProtocol:
+                      description: If true, http and https requests will be cached
+                        separately.
+                      type: boolean
+                    includeQueryString:
+                      description: |-
+                        If true, include query string parameters in the cache key
+                        according to query_string_whitelist and
+                        query_string_blacklist. If neither is set, the entire query
+                        string will be included.
+
+                        If false, the query string will be excluded from the cache
+                        key entirely.
+                      type: boolean
+                    queryStringBlacklist:
+                      description: |-
+                        Names of query string parameters to exclude in cache keys.
+
+                        All other parameters will be included. Either specify
+                        query_string_whitelist or query_string_blacklist, not both.
+                        '&' and '=' will be percent encoded and not treated as
+                        delimiters.
+                      items:
+                        type: string
+                      type: array
+                    queryStringWhitelist:
+                      description: |-
+                        Names of query string parameters to include in cache keys.
+
+                        All other parameters will be excluded. Either specify
+                        query_string_whitelist or query_string_blacklist, not both.
+                        '&' and '=' will be percent encoded and not treated as
+                        delimiters.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                signedUrlCacheMaxAgeSec:
+                  description: |-
+                    Maximum number of seconds the response to a signed URL request
+                    will be considered fresh, defaults to 1hr (3600s). After this
+                    time period, the response will be revalidated before
+                    being served.
+
+                    When serving responses to signed URL requests, Cloud CDN will
+                    internally behave as though all responses from this backend had a
+                    "Cache-Control: public, max-age=[TTL]" header, regardless of any
+                    existing Cache-Control header. The actual headers served in
+                    responses will not be altered.
+                  type: integer
+              type: object
+            circuitBreakers:
+              description: |-
+                Settings controlling the volume of connections to a backend service. This field
+                is applicable only when the load_balancing_scheme is set to INTERNAL_SELF_MANAGED.
+              properties:
+                connectTimeout:
+                  description: The timeout for new network connections to hosts.
+                  properties:
+                    nanos:
+                      description: |-
+                        Span of time that's a fraction of a second at nanosecond
+                        resolution. Durations less than one second are represented
+                        with a 0 seconds field and a positive nanos field. Must
+                        be from 0 to 999,999,999 inclusive.
+                      type: integer
+                    seconds:
+                      description: |-
+                        Span of time at a resolution of a second.
+                        Must be from 0 to 315,576,000,000 inclusive.
+                      type: integer
+                  required:
+                  - seconds
+                  type: object
+                maxConnections:
+                  description: |-
+                    The maximum number of connections to the backend cluster.
+                    Defaults to 1024.
+                  type: integer
+                maxPendingRequests:
+                  description: |-
+                    The maximum number of pending requests to the backend cluster.
+                    Defaults to 1024.
+                  type: integer
+                maxRequests:
+                  description: |-
+                    The maximum number of parallel requests to the backend cluster.
+                    Defaults to 1024.
+                  type: integer
+                maxRequestsPerConnection:
+                  description: |-
+                    Maximum requests for a single backend connection. This parameter
+                    is respected by both the HTTP/1.1 and HTTP/2 implementations. If
+                    not specified, there is no limit. Setting this parameter to 1
+                    will effectively disable keep alive.
+                  type: integer
+                maxRetries:
+                  description: |-
+                    The maximum number of parallel retries to the backend cluster.
+                    Defaults to 3.
+                  type: integer
+              type: object
+            connectionDrainingTimeoutSec:
+              description: |-
+                Time for which instance will be drained (not accept new
+                connections, but still work to finish started).
+              type: integer
+            consistentHash:
+              description: |-
+                Consistent Hash-based load balancing can be used to provide soft session
+                affinity based on HTTP headers, cookies or other properties. This load balancing
+                policy is applicable only for HTTP connections. The affinity to a particular
+                destination host will be lost when one or more hosts are added/removed from the
+                destination service. This field specifies parameters that control consistent
+                hashing. This field only applies if the load_balancing_scheme is set to
+                INTERNAL_SELF_MANAGED. This field is only applicable when locality_lb_policy is
+                set to MAGLEV or RING_HASH.
+              properties:
+                httpCookie:
+                  description: |-
+                    Hash is based on HTTP Cookie. This field describes a HTTP cookie
+                    that will be used as the hash key for the consistent hash load
+                    balancer. If the cookie is not present, it will be generated.
+                    This field is applicable if the sessionAffinity is set to HTTP_COOKIE.
+                  properties:
+                    name:
+                      description: Name of the cookie.
+                      type: string
+                    path:
+                      description: Path to set for the cookie.
+                      type: string
+                    ttl:
+                      description: Lifetime of the cookie.
+                      properties:
+                        nanos:
+                          description: |-
+                            Span of time that's a fraction of a second at nanosecond
+                            resolution. Durations less than one second are represented
+                            with a 0 seconds field and a positive nanos field. Must
+                            be from 0 to 999,999,999 inclusive.
+                          type: integer
+                        seconds:
+                          description: |-
+                            Span of time at a resolution of a second.
+                            Must be from 0 to 315,576,000,000 inclusive.
+                          type: integer
+                      required:
+                      - seconds
+                      type: object
+                  type: object
+                httpHeaderName:
+                  description: |-
+                    The hash based on the value of the specified header field.
+                    This field is applicable if the sessionAffinity is set to HEADER_FIELD.
+                  type: string
+                minimumRingSize:
+                  description: |-
+                    The minimum number of virtual nodes to use for the hash ring.
+                    Larger ring sizes result in more granular load
+                    distributions. If the number of hosts in the load balancing pool
+                    is larger than the ring size, each host will be assigned a single
+                    virtual node.
+                    Defaults to 1024.
+                  type: integer
+              type: object
+            customRequestHeaders:
+              description: |-
+                Headers that the HTTP/S load balancer should add to proxied
+                requests.
+              items:
+                type: string
+              type: array
+            description:
+              description: An optional description of this resource.
+              type: string
+            enableCdn:
+              description: If true, enable Cloud CDN for this BackendService.
+              type: boolean
+            failoverPolicy:
+              description: Policy for failovers.
+              properties:
+                disableConnectionDrainOnFailover:
+                  description: |-
+                    On failover or failback, this field indicates whether connection drain
+                    will be honored. Setting this to true has the following effect: connections
+                    to the old active pool are not drained. Connections to the new active pool
+                    use the timeout of 10 min (currently fixed). Setting to false has the
+                    following effect: both old and new connections will have a drain timeout
+                    of 10 min.
+                    This can be set to true only if the protocol is TCP.
+                    The default is false.
+                  type: boolean
+                dropTrafficIfUnhealthy:
+                  description: |-
+                    This option is used only when no healthy VMs are detected in the primary
+                    and backup instance groups. When set to true, traffic is dropped. When
+                    set to false, new connections are sent across all VMs in the primary group.
+                    The default is false.
+                  type: boolean
+                failoverRatio:
+                  description: |-
+                    The value of the field must be in [0, 1]. If the ratio of the healthy
+                    VMs in the primary backend is at or below this number, traffic arriving
+                    at the load-balanced IP will be directed to the failover backend.
+                    In case where 'failoverRatio' is not set or all the VMs in the backup
+                    backend are unhealthy, the traffic will be directed back to the primary
+                    backend in the "force" mode, where traffic will be spread to the healthy
+                    VMs with the best effort, or to all VMs when no VM is healthy.
+                    This field is only used with l4 load balancing.
+                  type: number
+              type: object
+            healthChecks:
+              items:
+                properties:
+                  healthCheckRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  httpHealthCheckRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                type: object
+              type: array
+            iap:
+              description: Settings for enabling Cloud Identity Aware Proxy
+              properties:
+                oauth2ClientId:
+                  description: OAuth2 Client ID for IAP
+                  type: string
+                oauth2ClientSecret:
+                  description: OAuth2 Client Secret for IAP
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                oauth2ClientSecretSha256:
+                  description: OAuth2 Client Secret SHA-256 for IAP
+                  type: string
+              required:
+              - oauth2ClientId
+              - oauth2ClientSecret
+              type: object
+            loadBalancingScheme:
+              description: |-
+                Indicates whether the backend service will be used with internal or
+                external load balancing. A backend service created for one type of
+                load balancing cannot be used with the other. Must be 'EXTERNAL' or
+                'INTERNAL_SELF_MANAGED' for a global backend service. Defaults to 'EXTERNAL'.
+              type: string
+            localityLbPolicy:
+              description: |-
+                The load balancing algorithm used within the scope of the locality.
+                The possible values are -
+
+                ROUND_ROBIN - This is a simple policy in which each healthy backend
+                              is selected in round robin order.
+
+                LEAST_REQUEST - An O(1) algorithm which selects two random healthy
+                                hosts and picks the host which has fewer active requests.
+
+                RING_HASH - The ring/modulo hash load balancer implements consistent
+                            hashing to backends. The algorithm has the property that the
+                            addition/removal of a host from a set of N hosts only affects
+                            1/N of the requests.
+
+                RANDOM - The load balancer selects a random healthy host.
+
+                ORIGINAL_DESTINATION - Backend host is selected based on the client
+                                       connection metadata, i.e., connections are opened
+                                       to the same address as the destination address of
+                                       the incoming connection before the connection
+                                       was redirected to the load balancer.
+
+                MAGLEV - used as a drop in replacement for the ring hash load balancer.
+                         Maglev is not as stable as ring hash but has faster table lookup
+                         build times and host selection times. For more information about
+                         Maglev, refer to https://ai.google/research/pubs/pub44824
+
+                This field is applicable only when the load_balancing_scheme is set to
+                INTERNAL_SELF_MANAGED.
+              type: string
+            location:
+              description: 'Location represents the geographical location of the ComputeBackendService.
+                Specify a region name or "global" for global resources. Reference:
+                GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            logConfig:
+              description: |-
+                This field denotes the logging options for the load balancer traffic served by this backend service.
+                If logging is enabled, logs will be exported to Stackdriver.
+              properties:
+                enable:
+                  description: Whether to enable logging for the load balancer traffic
+                    served by this backend service.
+                  type: boolean
+                sampleRate:
+                  description: |-
+                    This field can only be specified if logging is enabled for this backend service. The value of
+                    the field must be in [0, 1]. This configures the sampling rate of requests to the load balancer
+                    where 1.0 means all logged requests are reported and 0.0 means no logged requests are reported.
+                    The default value is 1.0.
+                  type: number
+              type: object
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            outlierDetection:
+              description: |-
+                Settings controlling eviction of unhealthy hosts from the load balancing pool.
+                This field is applicable only when the load_balancing_scheme is set
+                to INTERNAL_SELF_MANAGED.
+              properties:
+                baseEjectionTime:
+                  description: |-
+                    The base time that a host is ejected for. The real time is equal to the base
+                    time multiplied by the number of times the host has been ejected. Defaults to
+                    30000ms or 30s.
+                  properties:
+                    nanos:
+                      description: |-
+                        Span of time that's a fraction of a second at nanosecond resolution. Durations
+                        less than one second are represented with a 0 'seconds' field and a positive
+                        'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                      type: integer
+                    seconds:
+                      description: |-
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                        inclusive.
+                      type: integer
+                  required:
+                  - seconds
+                  type: object
+                consecutiveErrors:
+                  description: |-
+                    Number of errors before a host is ejected from the connection pool. When the
+                    backend host is accessed over HTTP, a 5xx return code qualifies as an error.
+                    Defaults to 5.
+                  type: integer
+                consecutiveGatewayFailure:
+                  description: |-
+                    The number of consecutive gateway failures (502, 503, 504 status or connection
+                    errors that are mapped to one of those status codes) before a consecutive
+                    gateway failure ejection occurs. Defaults to 5.
+                  type: integer
+                enforcingConsecutiveErrors:
+                  description: |-
+                    The percentage chance that a host will be actually ejected when an outlier
+                    status is detected through consecutive 5xx. This setting can be used to disable
+                    ejection or to ramp it up slowly. Defaults to 100.
+                  type: integer
+                enforcingConsecutiveGatewayFailure:
+                  description: |-
+                    The percentage chance that a host will be actually ejected when an outlier
+                    status is detected through consecutive gateway failures. This setting can be
+                    used to disable ejection or to ramp it up slowly. Defaults to 0.
+                  type: integer
+                enforcingSuccessRate:
+                  description: |-
+                    The percentage chance that a host will be actually ejected when an outlier
+                    status is detected through success rate statistics. This setting can be used to
+                    disable ejection or to ramp it up slowly. Defaults to 100.
+                  type: integer
+                interval:
+                  description: |-
+                    Time interval between ejection sweep analysis. This can result in both new
+                    ejections as well as hosts being returned to service. Defaults to 10 seconds.
+                  properties:
+                    nanos:
+                      description: |-
+                        Span of time that's a fraction of a second at nanosecond resolution. Durations
+                        less than one second are represented with a 0 'seconds' field and a positive
+                        'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                      type: integer
+                    seconds:
+                      description: |-
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                        inclusive.
+                      type: integer
+                  required:
+                  - seconds
+                  type: object
+                maxEjectionPercent:
+                  description: |-
+                    Maximum percentage of hosts in the load balancing pool for the backend service
+                    that can be ejected. Defaults to 10%.
+                  type: integer
+                successRateMinimumHosts:
+                  description: |-
+                    The number of hosts in a cluster that must have enough request volume to detect
+                    success rate outliers. If the number of hosts is less than this setting, outlier
+                    detection via success rate statistics is not performed for any host in the
+                    cluster. Defaults to 5.
+                  type: integer
+                successRateRequestVolume:
+                  description: |-
+                    The minimum number of total requests that must be collected in one interval (as
+                    defined by the interval duration above) to include this host in success rate
+                    based outlier detection. If the volume is lower than this setting, outlier
+                    detection via success rate statistics is not performed for that host. Defaults
+                    to 100.
+                  type: integer
+                successRateStdevFactor:
+                  description: |-
+                    This factor is used to determine the ejection threshold for success rate outlier
+                    ejection. The ejection threshold is the difference between the mean success
+                    rate, and the product of this factor and the standard deviation of the mean
+                    success rate: mean - (stdev * success_rate_stdev_factor). This factor is divided
+                    by a thousand to get a double. That is, if the desired factor is 1.9, the
+                    runtime value should be 1900. Defaults to 1900.
+                  type: integer
+              type: object
+            portName:
+              description: |-
+                Name of backend port. The same name should appear in the instance
+                groups referenced by this service. Required when the load balancing
+                scheme is EXTERNAL.
+              type: string
+            protocol:
+              description: |-
+                The protocol this BackendService uses to communicate with backends.
+                Possible values are HTTP, HTTPS, HTTP2, TCP, and SSL. The default is
+                HTTP. **NOTE**: HTTP2 is only valid for beta HTTP/2 load balancer
+                types and may result in errors if used with the GA API.
+              type: string
+            securityPolicyRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            sessionAffinity:
+              description: |-
+                Type of session affinity to use. The default is NONE. Session affinity is
+                not applicable if the protocol is UDP.
+              type: string
+            timeoutSec:
+              description: |-
+                How many seconds to wait for the backend before considering it a
+                failed request. Default is 30 seconds. Valid range is [1, 86400].
+              type: integer
+          required:
+          - healthChecks
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            fingerprint:
+              description: |-
+                Fingerprint of this resource. A hash of the contents stored in this
+                object. This field is used in optimistic locking.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computedisks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeDisk
+    plural: computedisks
+    shortNames:
+    - gcpcomputedisk
+    - gcpcomputedisks
+    singular: computedisk
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            diskEncryptionKey:
+              description: |-
+                Encrypts the disk using a customer-supplied encryption key.
+
+                After you encrypt a disk with a customer-supplied key, you must
+                provide the same key if you use the disk later (e.g. to create a disk
+                snapshot or an image, or to attach the disk to a virtual machine).
+
+                Customer-supplied encryption keys do not protect access to metadata of
+                the disk.
+
+                If you do not provide an encryption key when creating the disk, then
+                the disk will be encrypted using an automatically generated key and
+                you do not need to provide a key to use the disk later.
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                rawKey:
+                  description: |-
+                    Specifies a 256-bit customer-supplied encryption key, encoded in
+                    RFC 4648 base64 to either encrypt or decrypt this resource.
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                sha256:
+                  description: |-
+                    The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
+                    encryption key that protects this resource.
+                  type: string
+              type: object
+            imageRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            location:
+              description: 'Location represents the geographical location of the ComputeDisk.
+                Specify a region name or a zone name. Reference: GCP definition of
+                regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            physicalBlockSizeBytes:
+              description: |-
+                Physical block size of the persistent disk, in bytes. If not present
+                in a request, a default value is used. Currently supported sizes
+                are 4096 and 16384, other sizes may be added in the future.
+                If an unsupported value is requested, the error message will list
+                the supported values for the caller's project.
+              type: integer
+            replicaZones:
+              description: URLs of the zones where the disk should be replicated to.
+              items:
+                type: string
+              type: array
+            resourcePolicies:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            size:
+              description: |-
+                Size of the persistent disk, specified in GB. You can specify this
+                field when creating a persistent disk using the 'image' or
+                'snapshot' parameter, or specify it alone to create an empty
+                persistent disk.
+
+                If you specify this field along with 'image' or 'snapshot',
+                the value must not be less than the size of the image
+                or the size of the snapshot.
+              type: integer
+            snapshotRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            sourceImageEncryptionKey:
+              description: |-
+                The customer-supplied encryption key of the source image. Required if
+                the source image is protected by a customer-supplied encryption key.
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                rawKey:
+                  description: |-
+                    Specifies a 256-bit customer-supplied encryption key, encoded in
+                    RFC 4648 base64 to either encrypt or decrypt this resource.
+                  type: string
+                sha256:
+                  description: |-
+                    The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
+                    encryption key that protects this resource.
+                  type: string
+              type: object
+            sourceSnapshotEncryptionKey:
+              description: |-
+                The customer-supplied encryption key of the source snapshot. Required
+                if the source snapshot is protected by a customer-supplied encryption
+                key.
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                rawKey:
+                  description: |-
+                    Specifies a 256-bit customer-supplied encryption key, encoded in
+                    RFC 4648 base64 to either encrypt or decrypt this resource.
+                  type: string
+                sha256:
+                  description: |-
+                    The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
+                    encryption key that protects this resource.
+                  type: string
+              type: object
+            type:
+              description: |-
+                URL of the disk type resource describing which disk type to use to
+                create the disk. Provide this when creating the disk.
+              type: string
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource.  Used
+                internally during updates.
+              type: string
+            lastAttachTimestamp:
+              description: Last attach timestamp in RFC3339 text format.
+              type: string
+            lastDetachTimestamp:
+              description: Last detach timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+            sourceImageId:
+              description: |-
+                The ID value of the image used to create this disk. This value
+                identifies the exact image that was used to create this persistent
+                disk. For example, if you created the persistent disk from an image
+                that was later deleted and recreated under the same name, the source
+                image ID would identify the exact version of the image that was used.
+              type: string
+            sourceSnapshotId:
+              description: |-
+                The unique ID of the snapshot used to create this disk. This value
+                identifies the exact snapshot that was used to create this persistent
+                disk. For example, if you created the persistent disk from a snapshot
+                that was later deleted and recreated under the same name, the source
+                snapshot ID would identify the exact version of the snapshot that was
+                used.
+              type: string
+            users:
+              description: |-
+                Links to the users of the disk (attached instances) in form:
+                project/zones/zone/instances/instance
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeexternalvpngateways.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeExternalVPNGateway
+    plural: computeexternalvpngateways
+    shortNames:
+    - gcpcomputeexternalvpngateway
+    - gcpcomputeexternalvpngateways
+    singular: computeexternalvpngateway
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            interface:
+              description: A list of interfaces on this external VPN gateway.
+              items:
+                properties:
+                  id:
+                    description: |-
+                      The numberic ID for this interface. Allowed values are based on the redundancy type
+                      of this external VPN gateway
+                      * '0 - SINGLE_IP_INTERNALLY_REDUNDANT'
+                      * '0, 1 - TWO_IPS_REDUNDANCY'
+                      * '0, 1, 2, 3 - FOUR_IPS_REDUNDANCY'
+                    type: integer
+                  ipAddress:
+                    description: |-
+                      IP address of the interface in the external VPN gateway.
+                      Only IPv4 is supported. This IP address can be either from
+                      your on-premise gateway or another Cloud provider’s VPN gateway,
+                      it cannot be an IP address from Google Compute Engine.
+                    type: string
+                type: object
+              type: array
+            redundancyType:
+              description: Indicates the redundancy type of this external VPN gateway
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computefirewalls.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeFirewall
+    plural: computefirewalls
+    shortNames:
+    - gcpcomputefirewall
+    - gcpcomputefirewalls
+    singular: computefirewall
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            allow:
+              description: |-
+                The list of ALLOW rules specified by this firewall. Each rule
+                specifies a protocol and port-range tuple that describes a permitted
+                connection.
+              items:
+                properties:
+                  ports:
+                    description: |-
+                      An optional list of ports to which this rule applies. This field
+                      is only applicable for UDP or TCP protocol. Each entry must be
+                      either an integer or a range. If not specified, this rule
+                      applies to connections through any port.
+
+                      Example inputs include: ["22"], ["80","443"], and
+                      ["12345-12349"].
+                    items:
+                      type: string
+                    type: array
+                  protocol:
+                    description: |-
+                      The IP protocol to which this rule applies. The protocol type is
+                      required when creating a firewall rule. This value can either be
+                      one of the following well known protocol strings (tcp, udp,
+                      icmp, esp, ah, sctp), or the IP protocol number.
+                    type: string
+                required:
+                - protocol
+                type: object
+              type: array
+            deny:
+              description: |-
+                The list of DENY rules specified by this firewall. Each rule specifies
+                a protocol and port-range tuple that describes a denied connection.
+              items:
+                properties:
+                  ports:
+                    description: |-
+                      An optional list of ports to which this rule applies. This field
+                      is only applicable for UDP or TCP protocol. Each entry must be
+                      either an integer or a range. If not specified, this rule
+                      applies to connections through any port.
+
+                      Example inputs include: ["22"], ["80","443"], and
+                      ["12345-12349"].
+                    items:
+                      type: string
+                    type: array
+                  protocol:
+                    description: |-
+                      The IP protocol to which this rule applies. The protocol type is
+                      required when creating a firewall rule. This value can either be
+                      one of the following well known protocol strings (tcp, udp,
+                      icmp, esp, ah, sctp), or the IP protocol number.
+                    type: string
+                required:
+                - protocol
+                type: object
+              type: array
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            destinationRanges:
+              description: |-
+                If destination ranges are specified, the firewall will apply only to
+                traffic that has destination IP address in these ranges. These ranges
+                must be expressed in CIDR format. Only IPv4 is supported.
+              items:
+                type: string
+              type: array
+            direction:
+              description: |-
+                Direction of traffic to which this firewall applies; default is
+                INGRESS. Note: For INGRESS traffic, it is NOT supported to specify
+                destinationRanges; For EGRESS traffic, it is NOT supported to specify
+                sourceRanges OR sourceTags.
+              type: string
+            disabled:
+              description: |-
+                Denotes whether the firewall rule is disabled, i.e not applied to the
+                network it is associated with. When set to true, the firewall rule is
+                not enforced and the network behaves as if it did not exist. If this
+                is unspecified, the firewall rule will be enabled.
+              type: boolean
+            enableLogging:
+              description: |-
+                This field denotes whether to enable logging for a particular
+                firewall rule. If logging is enabled, logs will be exported to
+                Stackdriver.
+              type: boolean
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            priority:
+              description: |-
+                Priority for this rule. This is an integer between 0 and 65535, both
+                inclusive. When not specified, the value assumed is 1000. Relative
+                priorities determine precedence of conflicting rules. Lower value of
+                priority implies higher precedence (eg, a rule with priority 0 has
+                higher precedence than a rule with priority 1). DENY rules take
+                precedence over ALLOW rules having equal priority.
+              type: integer
+            sourceRanges:
+              description: |-
+                If source ranges are specified, the firewall will apply only to
+                traffic that has source IP address in these ranges. These ranges must
+                be expressed in CIDR format. One or both of sourceRanges and
+                sourceTags may be set. If both properties are set, the firewall will
+                apply to traffic that has source IP address within sourceRanges OR the
+                source IP that belongs to a tag listed in the sourceTags property. The
+                connection does not need to match both properties for the firewall to
+                apply. Only IPv4 is supported.
+              items:
+                type: string
+              type: array
+            sourceServiceAccounts:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            sourceTags:
+              description: |-
+                If source tags are specified, the firewall will apply only to traffic
+                with source IP that belongs to a tag listed in source tags. Source
+                tags cannot be used to control traffic to an instance's external IP
+                address. Because tags are associated with an instance, not an IP
+                address. One or both of sourceRanges and sourceTags may be set. If
+                both properties are set, the firewall will apply to traffic that has
+                source IP address within sourceRanges OR the source IP that belongs to
+                a tag listed in the sourceTags property. The connection does not need
+                to match both properties for the firewall to apply.
+              items:
+                type: string
+              type: array
+            targetServiceAccounts:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            targetTags:
+              description: |-
+                A list of instance tags indicating sets of instances located in the
+                network that may make network connections as specified in allowed[].
+                If no targetTags are specified, the firewall rule applies to all
+                instances on the specified network.
+              items:
+                type: string
+              type: array
+          required:
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeforwardingrules.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeForwardingRule
+    plural: computeforwardingrules
+    shortNames:
+    - gcpcomputeforwardingrule
+    - gcpcomputeforwardingrules
+    singular: computeforwardingrule
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            allPorts:
+              description: |-
+                For internal TCP/UDP load balancing (i.e. load balancing scheme is
+                INTERNAL and protocol is TCP/UDP), set this to true to allow packets
+                addressed to any ports to be forwarded to the backends configured
+                with this forwarding rule. Used with backend service. Cannot be set
+                if port or portRange are set.
+              type: boolean
+            allowGlobalAccess:
+              description: |-
+                If true, clients can access ILB from all regions.
+                Otherwise only allows from the local region the ILB is located at.
+              type: boolean
+            backendServiceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            ipAddress:
+              properties:
+                addressRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                ip:
+                  type: string
+              type: object
+            ipProtocol:
+              description: |-
+                The IP protocol to which this rule applies. Valid options are TCP,
+                UDP, ESP, AH, SCTP or ICMP.
+
+                When the load balancing scheme is INTERNAL, only TCP and UDP are
+                valid.
+              type: string
+            ipVersion:
+              description: |-
+                The IP Version that will be used by this global forwarding rule.
+                Valid options are IPV4 or IPV6.
+              type: string
+            loadBalancingScheme:
+              description: |-
+                This signifies what the ForwardingRule will be used for and can be
+                EXTERNAL, INTERNAL, or INTERNAL_MANAGED. EXTERNAL is used for Classic
+                Cloud VPN gateways, protocol forwarding to VMs from an external IP address,
+                and HTTP(S), SSL Proxy, TCP Proxy, and Network TCP/UDP load balancers.
+                INTERNAL is used for protocol forwarding to VMs from an internal IP address,
+                and internal TCP/UDP load balancers.
+                INTERNAL_MANAGED is used for internal HTTP(S) load balancers.
+              type: string
+            location:
+              description: 'Location represents the geographical location of the ComputeForwardingRule.
+                Specify a region name or "global" for global resources. Reference:
+                GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            metadataFilters:
+              description: |-
+                Opaque filter criteria used by Loadbalancer to restrict routing
+                configuration to a limited set xDS compliant clients. In their xDS
+                requests to Loadbalancer, xDS clients present node metadata. If a
+                match takes place, the relevant routing configuration is made available
+                to those proxies.
+
+                For each metadataFilter in this list, if its filterMatchCriteria is set
+                to MATCH_ANY, at least one of the filterLabels must match the
+                corresponding label provided in the metadata. If its filterMatchCriteria
+                is set to MATCH_ALL, then all of its filterLabels must match with
+                corresponding labels in the provided metadata.
+
+                metadataFilters specified here can be overridden by those specified in
+                the UrlMap that this ForwardingRule references.
+
+                metadataFilters only applies to Loadbalancers that have their
+                loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+              items:
+                properties:
+                  filterLabels:
+                    description: |-
+                      The list of label value pairs that must match labels in the
+                      provided metadata based on filterMatchCriteria
+
+                      This list must not be empty and can have at the most 64 entries.
+                    items:
+                      properties:
+                        name:
+                          description: |-
+                            Name of the metadata label. The length must be between
+                            1 and 1024 characters, inclusive.
+                          type: string
+                        value:
+                          description: |-
+                            The value that the label must match. The value has a maximum
+                            length of 1024 characters.
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  filterMatchCriteria:
+                    description: |-
+                      Specifies how individual filterLabel matches within the list of
+                      filterLabels contribute towards the overall metadataFilter match.
+
+                      MATCH_ANY - At least one of the filterLabels must have a matching
+                      label in the provided metadata.
+                      MATCH_ALL - All filterLabels must have matching labels in the
+                      provided metadata.
+                    type: string
+                required:
+                - filterLabels
+                - filterMatchCriteria
+                type: object
+              type: array
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            networkTier:
+              description: |-
+                The networking tier used for configuring this address. This field can
+                take the following values: PREMIUM or STANDARD. If this field is not
+                specified, it is assumed to be PREMIUM.
+              type: string
+            portRange:
+              description: |-
+                This field is used along with the target field for TargetHttpProxy,
+                TargetHttpsProxy, TargetSslProxy, TargetTcpProxy, TargetVpnGateway,
+                TargetPool, TargetInstance.
+
+                Applicable only when IPProtocol is TCP, UDP, or SCTP, only packets
+                addressed to ports in the specified range will be forwarded to target.
+                Forwarding rules with the same [IPAddress, IPProtocol] pair must have
+                disjoint port ranges.
+
+                Some types of forwarding target have constraints on the acceptable
+                ports:
+
+                * TargetHttpProxy: 80, 8080
+                * TargetHttpsProxy: 443
+                * TargetTcpProxy: 25, 43, 110, 143, 195, 443, 465, 587, 700, 993, 995,
+                                  1883, 5222
+                * TargetSslProxy: 25, 43, 110, 143, 195, 443, 465, 587, 700, 993, 995,
+                                  1883, 5222
+                * TargetVpnGateway: 500, 4500
+              type: string
+            ports:
+              description: |-
+                This field is used along with the backend_service field for internal
+                load balancing.
+
+                When the load balancing scheme is INTERNAL, a single port or a comma
+                separated list of ports can be configured. Only packets addressed to
+                these ports will be forwarded to the backends configured with this
+                forwarding rule.
+
+                You may specify a maximum of up to 5 ports.
+              items:
+                type: string
+              type: array
+            serviceLabel:
+              description: |-
+                An optional prefix to the service name for this Forwarding Rule.
+                If specified, will be the first label of the fully qualified service
+                name.
+
+                The label must be 1-63 characters long, and comply with RFC1035.
+                Specifically, the label must be 1-63 characters long and match the
+                regular expression '[a-z]([-a-z0-9]*[a-z0-9])?' which means the first
+                character must be a lowercase letter, and all following characters
+                must be a dash, lowercase letter, or digit, except the last
+                character, which cannot be a dash.
+
+                This field is only used for INTERNAL load balancing.
+              type: string
+            subnetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            target:
+              properties:
+                targetHTTPProxyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                targetHTTPSProxyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                targetVPNGatewayRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              type: object
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource.  Used
+                internally during updates.
+              type: string
+            selfLink:
+              type: string
+            serviceName:
+              description: |-
+                The internal fully qualified service name for this Forwarding Rule.
+                This field is only used for INTERNAL load balancing.
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computehealthchecks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeHealthCheck
+    plural: computehealthchecks
+    shortNames:
+    - gcpcomputehealthcheck
+    - gcpcomputehealthchecks
+    singular: computehealthcheck
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            checkIntervalSec:
+              description: |-
+                How often (in seconds) to send a health check. The default value is 5
+                seconds.
+              type: integer
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            healthyThreshold:
+              description: |-
+                A so-far unhealthy instance will be marked healthy after this many
+                consecutive successes. The default value is 2.
+              type: integer
+            http2HealthCheck:
+              description: A nested object resource
+              properties:
+                host:
+                  description: |-
+                    The value of the host header in the HTTP2 health check request.
+                    If left empty (default value), the public IP on behalf of which this health
+                    check is performed will be used.
+                  type: string
+                port:
+                  description: |-
+                    The TCP port number for the HTTP2 health check request.
+                    The default value is 443.
+                  type: integer
+                portName:
+                  description: |-
+                    Port name as defined in InstanceGroup#NamedPort#name. If both port and
+                    port_name are defined, port takes precedence.
+                  type: string
+                portSpecification:
+                  description: |-
+                    Specifies how port is selected for health checking, can be one of the
+                    following values:
+
+                      * 'USE_FIXED_PORT': The port number in 'port' is used for health checking.
+
+                      * 'USE_NAMED_PORT': The 'portName' is used for health checking.
+
+                      * 'USE_SERVING_PORT': For NetworkEndpointGroup, the port specified for each
+                      network endpoint is used for health checking. For other backends, the
+                      port or named port specified in the Backend Service is used for health
+                      checking.
+
+                    If not specified, HTTP2 health check follows behavior specified in 'port' and
+                    'portName' fields.
+                  type: string
+                proxyHeader:
+                  description: |-
+                    Specifies the type of proxy header to append before sending data to the
+                    backend, either NONE or PROXY_V1. The default is NONE.
+                  type: string
+                requestPath:
+                  description: |-
+                    The request path of the HTTP2 health check request.
+                    The default value is /.
+                  type: string
+                response:
+                  description: |-
+                    The bytes to match against the beginning of the response data. If left empty
+                    (the default value), any response will indicate health. The response data
+                    can only be ASCII.
+                  type: string
+              type: object
+            httpHealthCheck:
+              description: A nested object resource
+              properties:
+                host:
+                  description: |-
+                    The value of the host header in the HTTP health check request.
+                    If left empty (default value), the public IP on behalf of which this health
+                    check is performed will be used.
+                  type: string
+                port:
+                  description: |-
+                    The TCP port number for the HTTP health check request.
+                    The default value is 80.
+                  type: integer
+                portName:
+                  description: |-
+                    Port name as defined in InstanceGroup#NamedPort#name. If both port and
+                    port_name are defined, port takes precedence.
+                  type: string
+                portSpecification:
+                  description: |-
+                    Specifies how port is selected for health checking, can be one of the
+                    following values:
+
+                      * 'USE_FIXED_PORT': The port number in 'port' is used for health checking.
+
+                      * 'USE_NAMED_PORT': The 'portName' is used for health checking.
+
+                      * 'USE_SERVING_PORT': For NetworkEndpointGroup, the port specified for each
+                      network endpoint is used for health checking. For other backends, the
+                      port or named port specified in the Backend Service is used for health
+                      checking.
+
+                    If not specified, HTTP health check follows behavior specified in 'port' and
+                    'portName' fields.
+                  type: string
+                proxyHeader:
+                  description: |-
+                    Specifies the type of proxy header to append before sending data to the
+                    backend, either NONE or PROXY_V1. The default is NONE.
+                  type: string
+                requestPath:
+                  description: |-
+                    The request path of the HTTP health check request.
+                    The default value is /.
+                  type: string
+                response:
+                  description: |-
+                    The bytes to match against the beginning of the response data. If left empty
+                    (the default value), any response will indicate health. The response data
+                    can only be ASCII.
+                  type: string
+              type: object
+            httpsHealthCheck:
+              description: A nested object resource
+              properties:
+                host:
+                  description: |-
+                    The value of the host header in the HTTPS health check request.
+                    If left empty (default value), the public IP on behalf of which this health
+                    check is performed will be used.
+                  type: string
+                port:
+                  description: |-
+                    The TCP port number for the HTTPS health check request.
+                    The default value is 443.
+                  type: integer
+                portName:
+                  description: |-
+                    Port name as defined in InstanceGroup#NamedPort#name. If both port and
+                    port_name are defined, port takes precedence.
+                  type: string
+                portSpecification:
+                  description: |-
+                    Specifies how port is selected for health checking, can be one of the
+                    following values:
+
+                      * 'USE_FIXED_PORT': The port number in 'port' is used for health checking.
+
+                      * 'USE_NAMED_PORT': The 'portName' is used for health checking.
+
+                      * 'USE_SERVING_PORT': For NetworkEndpointGroup, the port specified for each
+                      network endpoint is used for health checking. For other backends, the
+                      port or named port specified in the Backend Service is used for health
+                      checking.
+
+                    If not specified, HTTPS health check follows behavior specified in 'port' and
+                    'portName' fields.
+                  type: string
+                proxyHeader:
+                  description: |-
+                    Specifies the type of proxy header to append before sending data to the
+                    backend, either NONE or PROXY_V1. The default is NONE.
+                  type: string
+                requestPath:
+                  description: |-
+                    The request path of the HTTPS health check request.
+                    The default value is /.
+                  type: string
+                response:
+                  description: |-
+                    The bytes to match against the beginning of the response data. If left empty
+                    (the default value), any response will indicate health. The response data
+                    can only be ASCII.
+                  type: string
+              type: object
+            location:
+              description: 'Location represents the geographical location of the ComputeHealthCheck.
+                Specify a region name or "global" for global resources. Reference:
+                GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            sslHealthCheck:
+              description: A nested object resource
+              properties:
+                port:
+                  description: |-
+                    The TCP port number for the SSL health check request.
+                    The default value is 443.
+                  type: integer
+                portName:
+                  description: |-
+                    Port name as defined in InstanceGroup#NamedPort#name. If both port and
+                    port_name are defined, port takes precedence.
+                  type: string
+                portSpecification:
+                  description: |-
+                    Specifies how port is selected for health checking, can be one of the
+                    following values:
+
+                      * 'USE_FIXED_PORT': The port number in 'port' is used for health checking.
+
+                      * 'USE_NAMED_PORT': The 'portName' is used for health checking.
+
+                      * 'USE_SERVING_PORT': For NetworkEndpointGroup, the port specified for each
+                      network endpoint is used for health checking. For other backends, the
+                      port or named port specified in the Backend Service is used for health
+                      checking.
+
+                    If not specified, SSL health check follows behavior specified in 'port' and
+                    'portName' fields.
+                  type: string
+                proxyHeader:
+                  description: |-
+                    Specifies the type of proxy header to append before sending data to the
+                    backend, either NONE or PROXY_V1. The default is NONE.
+                  type: string
+                request:
+                  description: |-
+                    The application data to send once the SSL connection has been
+                    established (default value is empty). If both request and response are
+                    empty, the connection establishment alone will indicate health. The request
+                    data can only be ASCII.
+                  type: string
+                response:
+                  description: |-
+                    The bytes to match against the beginning of the response data. If left empty
+                    (the default value), any response will indicate health. The response data
+                    can only be ASCII.
+                  type: string
+              type: object
+            tcpHealthCheck:
+              description: A nested object resource
+              properties:
+                port:
+                  description: |-
+                    The TCP port number for the TCP health check request.
+                    The default value is 443.
+                  type: integer
+                portName:
+                  description: |-
+                    Port name as defined in InstanceGroup#NamedPort#name. If both port and
+                    port_name are defined, port takes precedence.
+                  type: string
+                portSpecification:
+                  description: |-
+                    Specifies how port is selected for health checking, can be one of the
+                    following values:
+
+                      * 'USE_FIXED_PORT': The port number in 'port' is used for health checking.
+
+                      * 'USE_NAMED_PORT': The 'portName' is used for health checking.
+
+                      * 'USE_SERVING_PORT': For NetworkEndpointGroup, the port specified for each
+                      network endpoint is used for health checking. For other backends, the
+                      port or named port specified in the Backend Service is used for health
+                      checking.
+
+                    If not specified, TCP health check follows behavior specified in 'port' and
+                    'portName' fields.
+                  type: string
+                proxyHeader:
+                  description: |-
+                    Specifies the type of proxy header to append before sending data to the
+                    backend, either NONE or PROXY_V1. The default is NONE.
+                  type: string
+                request:
+                  description: |-
+                    The application data to send once the TCP connection has been
+                    established (default value is empty). If both request and response are
+                    empty, the connection establishment alone will indicate health. The request
+                    data can only be ASCII.
+                  type: string
+                response:
+                  description: |-
+                    The bytes to match against the beginning of the response data. If left empty
+                    (the default value), any response will indicate health. The response data
+                    can only be ASCII.
+                  type: string
+              type: object
+            timeoutSec:
+              description: |-
+                How long (in seconds) to wait before claiming failure.
+                The default value is 5 seconds.  It is invalid for timeoutSec to have
+                greater value than checkIntervalSec.
+              type: integer
+            unhealthyThreshold:
+              description: |-
+                A so-far healthy instance will be marked unhealthy after this many
+                consecutive failures. The default value is 2.
+              type: integer
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+            type:
+              description: The type of the health check. One of HTTP, HTTPS, TCP,
+                or SSL.
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computehttphealthchecks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeHTTPHealthCheck
+    plural: computehttphealthchecks
+    shortNames:
+    - gcpcomputehttphealthcheck
+    - gcpcomputehttphealthchecks
+    singular: computehttphealthcheck
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            checkIntervalSec:
+              description: |-
+                How often (in seconds) to send a health check. The default value is 5
+                seconds.
+              type: integer
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            healthyThreshold:
+              description: |-
+                A so-far unhealthy instance will be marked healthy after this many
+                consecutive successes. The default value is 2.
+              type: integer
+            host:
+              description: |-
+                The value of the host header in the HTTP health check request. If
+                left empty (default value), the public IP on behalf of which this
+                health check is performed will be used.
+              type: string
+            port:
+              description: |-
+                The TCP port number for the HTTP health check request.
+                The default value is 80.
+              type: integer
+            requestPath:
+              description: |-
+                The request path of the HTTP health check request.
+                The default value is /.
+              type: string
+            timeoutSec:
+              description: |-
+                How long (in seconds) to wait before claiming failure.
+                The default value is 5 seconds.  It is invalid for timeoutSec to have
+                greater value than checkIntervalSec.
+              type: integer
+            unhealthyThreshold:
+              description: |-
+                A so-far healthy instance will be marked unhealthy after this many
+                consecutive failures. The default value is 2.
+              type: integer
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computehttpshealthchecks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeHTTPSHealthCheck
+    plural: computehttpshealthchecks
+    shortNames:
+    - gcpcomputehttpshealthcheck
+    - gcpcomputehttpshealthchecks
+    singular: computehttpshealthcheck
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            checkIntervalSec:
+              description: |-
+                How often (in seconds) to send a health check. The default value is 5
+                seconds.
+              type: integer
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            healthyThreshold:
+              description: |-
+                A so-far unhealthy instance will be marked healthy after this many
+                consecutive successes. The default value is 2.
+              type: integer
+            host:
+              description: |-
+                The value of the host header in the HTTPS health check request. If
+                left empty (default value), the public IP on behalf of which this
+                health check is performed will be used.
+              type: string
+            port:
+              description: |-
+                The TCP port number for the HTTPS health check request.
+                The default value is 80.
+              type: integer
+            requestPath:
+              description: |-
+                The request path of the HTTPS health check request.
+                The default value is /.
+              type: string
+            timeoutSec:
+              description: |-
+                How long (in seconds) to wait before claiming failure.
+                The default value is 5 seconds.  It is invalid for timeoutSec to have
+                greater value than checkIntervalSec.
+              type: integer
+            unhealthyThreshold:
+              description: |-
+                A so-far healthy instance will be marked unhealthy after this many
+                consecutive failures. The default value is 2.
+              type: integer
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeimages.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeImage
+    plural: computeimages
+    shortNames:
+    - gcpcomputeimage
+    - gcpcomputeimages
+    singular: computeimage
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            diskRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            diskSizeGb:
+              description: Size of the image when restored onto a persistent disk
+                (in GB).
+              type: integer
+            family:
+              description: |-
+                The name of the image family to which this image belongs. You can
+                create disks by specifying an image family instead of a specific
+                image name. The image family always returns its latest image that is
+                not deprecated. The name of the image family must comply with
+                RFC1035.
+              type: string
+            guestOsFeatures:
+              description: |-
+                A list of features to enable on the guest operating system.
+                Applicable only for bootable images.
+              items:
+                properties:
+                  type:
+                    description: The type of supported feature. Read [Enabling guest
+                      operating system features](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features)
+                      to see a list of available options.
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
+            licenses:
+              description: Any applicable license URI.
+              items:
+                type: string
+              type: array
+            rawDisk:
+              description: The parameters of the raw disk image.
+              properties:
+                containerType:
+                  description: |-
+                    The format used to encode and transmit the block device, which
+                    should be TAR. This is just a container and transmission format
+                    and not a runtime format. Provided by the client when the disk
+                    image is created.
+                  type: string
+                sha1:
+                  description: |-
+                    An optional SHA1 checksum of the disk image before unpackaging.
+                    This is provided by the client when the disk image is created.
+                  type: string
+                source:
+                  description: |-
+                    The full Google Cloud Storage URL where disk storage is stored
+                    You must provide either this property or the sourceDisk property
+                    but not both.
+                  type: string
+              required:
+              - source
+              type: object
+          type: object
+        status:
+          properties:
+            archiveSizeBytes:
+              description: |-
+                Size of the image tar.gz archive stored in Google Cloud Storage (in
+                bytes).
+              type: integer
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource. Used
+                internally during updates.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeinstancegroups.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeInstanceGroup
+    plural: computeinstancegroups
+    shortNames:
+    - gcpcomputeinstancegroup
+    - gcpcomputeinstancegroups
+    singular: computeinstancegroup
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            instances:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            namedPort:
+              items:
+                properties:
+                  name:
+                    type: string
+                  port:
+                    type: integer
+                required:
+                - name
+                - port
+                type: object
+              type: array
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            zone:
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+            size:
+              type: integer
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeinstances.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeInstance
+    plural: computeinstances
+    shortNames:
+    - gcpcomputeinstance
+    - gcpcomputeinstances
+    singular: computeinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          anyOf:
+          - required:
+            - bootDisk
+            - machineType
+            - networkInterface
+          - required:
+            - instanceTemplateRef
+          properties:
+            attachedDisk:
+              items:
+                properties:
+                  deviceName:
+                    type: string
+                  diskEncryptionKeyRaw:
+                    oneOf:
+                    - not:
+                        required:
+                        - valueFrom
+                      required:
+                      - value
+                    - not:
+                        required:
+                        - value
+                      required:
+                      - valueFrom
+                    properties:
+                      value:
+                        description: Value of the field. Cannot be used if 'valueFrom'
+                          is specified.
+                        type: string
+                      valueFrom:
+                        description: Source for the field's value. Cannot be used
+                          if 'value' is specified.
+                        properties:
+                          secretKeyRef:
+                            description: Reference to a value with the given key in
+                              the given Secret in the resource's namespace.
+                            properties:
+                              key:
+                                description: Key that identifies the value to be extracted.
+                                type: string
+                              name:
+                                description: Name of the Secret to extract a value
+                                  from.
+                                type: string
+                            required:
+                            - name
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  diskEncryptionKeySha256:
+                    type: string
+                  kmsKeyRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  mode:
+                    type: string
+                  sourceDiskRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                required:
+                - sourceDiskRef
+                type: object
+              type: array
+            bootDisk:
+              properties:
+                autoDelete:
+                  type: boolean
+                deviceName:
+                  type: string
+                diskEncryptionKeyRaw:
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                diskEncryptionKeySha256:
+                  type: string
+                initializeParams:
+                  properties:
+                    labels:
+                      type: object
+                    size:
+                      type: integer
+                    sourceImageRef:
+                      oneOf:
+                      - not:
+                          required:
+                          - external
+                        required:
+                        - name
+                      - not:
+                          anyOf:
+                          - required:
+                            - name
+                          - required:
+                            - namespace
+                        required:
+                        - external
+                      properties:
+                        external:
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                      type: object
+                    type:
+                      type: string
+                  type: object
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                mode:
+                  type: string
+                sourceDiskRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              type: object
+            canIpForward:
+              type: boolean
+            deletionProtection:
+              type: boolean
+            description:
+              type: string
+            enableDisplay:
+              type: boolean
+            guestAccelerator:
+              items:
+                properties:
+                  count:
+                    type: integer
+                  type:
+                    type: string
+                required:
+                - count
+                - type
+                type: object
+              type: array
+            hostname:
+              type: string
+            instanceTemplateRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            machineType:
+              type: string
+            metadata:
+              items:
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
+                required:
+                - key
+                - value
+                type: object
+              type: array
+            metadataStartupScript:
+              type: string
+            minCpuPlatform:
+              type: string
+            networkInterface:
+              items:
+                properties:
+                  accessConfig:
+                    items:
+                      properties:
+                        natIpRef:
+                          oneOf:
+                          - not:
+                              required:
+                              - external
+                            required:
+                            - name
+                          - not:
+                              anyOf:
+                              - required:
+                                - name
+                              - required:
+                                - namespace
+                            required:
+                            - external
+                          properties:
+                            external:
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                          type: object
+                        networkTier:
+                          type: string
+                        publicPtrDomainName:
+                          type: string
+                      type: object
+                    type: array
+                  aliasIpRange:
+                    items:
+                      properties:
+                        ipCidrRange:
+                          type: string
+                        subnetworkRangeName:
+                          type: string
+                      required:
+                      - ipCidrRange
+                      type: object
+                    type: array
+                  name:
+                    type: string
+                  networkIp:
+                    type: string
+                  networkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  subnetworkProject:
+                    type: string
+                  subnetworkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                type: object
+              type: array
+            scheduling:
+              properties:
+                automaticRestart:
+                  type: boolean
+                nodeAffinities:
+                  items:
+                    properties:
+                      value:
+                        type: object
+                    type: object
+                  type: array
+                onHostMaintenance:
+                  type: string
+                preemptible:
+                  type: boolean
+              type: object
+            scratchDisk:
+              items:
+                properties:
+                  interface:
+                    type: string
+                required:
+                - interface
+                type: object
+              type: array
+            serviceAccount:
+              properties:
+                scopes:
+                  items:
+                    type: string
+                  type: array
+                serviceAccountRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              required:
+              - scopes
+              type: object
+            shieldedInstanceConfig:
+              properties:
+                enableIntegrityMonitoring:
+                  type: boolean
+                enableSecureBoot:
+                  type: boolean
+                enableVtpm:
+                  type: boolean
+              type: object
+            tags:
+              items:
+                type: string
+              type: array
+            zone:
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            cpuPlatform:
+              type: string
+            instanceId:
+              type: string
+            labelFingerprint:
+              type: string
+            metadataFingerprint:
+              type: string
+            selfLink:
+              type: string
+            tagsFingerprint:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeinstancetemplates.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeInstanceTemplate
+    plural: computeinstancetemplates
+    shortNames:
+    - gcpcomputeinstancetemplate
+    - gcpcomputeinstancetemplates
+    singular: computeinstancetemplate
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            canIpForward:
+              type: boolean
+            description:
+              type: string
+            disk:
+              items:
+                properties:
+                  autoDelete:
+                    type: boolean
+                  boot:
+                    type: boolean
+                  deviceName:
+                    type: string
+                  diskEncryptionKey:
+                    properties:
+                      kmsKeyRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                    required:
+                    - kmsKeyRef
+                    type: object
+                  diskName:
+                    type: string
+                  diskSizeGb:
+                    type: integer
+                  diskType:
+                    type: string
+                  interface:
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  mode:
+                    type: string
+                  sourceDiskRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  sourceImageRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  type:
+                    type: string
+                type: object
+              type: array
+            enableDisplay:
+              type: boolean
+            guestAccelerator:
+              items:
+                properties:
+                  count:
+                    type: integer
+                  type:
+                    type: string
+                required:
+                - count
+                - type
+                type: object
+              type: array
+            instanceDescription:
+              type: string
+            machineType:
+              type: string
+            metadata:
+              items:
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
+                required:
+                - key
+                - value
+                type: object
+              type: array
+            metadataStartupScript:
+              type: string
+            minCpuPlatform:
+              type: string
+            namePrefix:
+              type: string
+            networkInterface:
+              items:
+                properties:
+                  accessConfig:
+                    items:
+                      properties:
+                        natIpRef:
+                          oneOf:
+                          - not:
+                              required:
+                              - external
+                            required:
+                            - name
+                          - not:
+                              anyOf:
+                              - required:
+                                - name
+                              - required:
+                                - namespace
+                            required:
+                            - external
+                          properties:
+                            external:
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                          type: object
+                        networkTier:
+                          type: string
+                      type: object
+                    type: array
+                  aliasIpRange:
+                    items:
+                      properties:
+                        ipCidrRange:
+                          type: string
+                        subnetworkRangeName:
+                          type: string
+                      required:
+                      - ipCidrRange
+                      type: object
+                    type: array
+                  networkIp:
+                    type: string
+                  networkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  subnetworkProject:
+                    type: string
+                  subnetworkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                type: object
+              type: array
+            region:
+              type: string
+            scheduling:
+              properties:
+                automaticRestart:
+                  type: boolean
+                nodeAffinities:
+                  items:
+                    properties:
+                      value:
+                        type: object
+                    type: object
+                  type: array
+                onHostMaintenance:
+                  type: string
+                preemptible:
+                  type: boolean
+              type: object
+            serviceAccount:
+              properties:
+                scopes:
+                  items:
+                    type: string
+                  type: array
+                serviceAccountRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              required:
+              - scopes
+              type: object
+            shieldedInstanceConfig:
+              properties:
+                enableIntegrityMonitoring:
+                  type: boolean
+                enableSecureBoot:
+                  type: boolean
+                enableVtpm:
+                  type: boolean
+              type: object
+            tags:
+              items:
+                type: string
+              type: array
+          required:
+          - disk
+          - machineType
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            metadataFingerprint:
+              type: string
+            selfLink:
+              type: string
+            tagsFingerprint:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeinterconnectattachments.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeInterconnectAttachment
+    plural: computeinterconnectattachments
+    shortNames:
+    - gcpcomputeinterconnectattachment
+    - gcpcomputeinterconnectattachments
+    singular: computeinterconnectattachment
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            adminEnabled:
+              description: |-
+                Whether the VLAN attachment is enabled or disabled.  When using
+                PARTNER type this will Pre-Activate the interconnect attachment
+              type: boolean
+            bandwidth:
+              description: |-
+                Provisioned bandwidth capacity for the interconnect attachment.
+                For attachments of type DEDICATED, the user can set the bandwidth.
+                For attachments of type PARTNER, the Google Partner that is operating the interconnect must set the bandwidth.
+                Output only for PARTNER type, mutable for PARTNER_PROVIDER and DEDICATED,
+                Defaults to BPS_10G
+              type: string
+            candidateSubnets:
+              description: |-
+                Up to 16 candidate prefixes that can be used to restrict the allocation
+                of cloudRouterIpAddress and customerRouterIpAddress for this attachment.
+                All prefixes must be within link-local address space (169.254.0.0/16)
+                and must be /29 or shorter (/28, /27, etc). Google will attempt to select
+                an unused /29 from the supplied candidate prefix(es). The request will
+                fail if all possible /29s are in use on Google's edge. If not supplied,
+                Google will randomly select an unused /29 from all of link-local space.
+              items:
+                type: string
+              type: array
+            description:
+              description: An optional description of this resource.
+              type: string
+            edgeAvailabilityDomain:
+              description: |-
+                Desired availability domain for the attachment. Only available for type
+                PARTNER, at creation time. For improved reliability, customers should
+                configure a pair of attachments with one per availability domain. The
+                selected availability domain will be provided to the Partner via the
+                pairing key so that the provisioned circuit will lie in the specified
+                domain. If not specified, the value will default to AVAILABILITY_DOMAIN_ANY.
+              type: string
+            interconnect:
+              description: |-
+                URL of the underlying Interconnect object that this attachment's
+                traffic will traverse through. Required if type is DEDICATED, must not
+                be set if type is PARTNER.
+              type: string
+            region:
+              description: Region where the regional interconnect attachment resides.
+              type: string
+            routerRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            type:
+              description: |-
+                The type of InterconnectAttachment you wish to create. Defaults to
+                DEDICATED.
+              type: string
+            vlanTag8021q:
+              description: |-
+                The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. When
+                using PARTNER type this will be managed upstream.
+              type: integer
+          required:
+          - routerRef
+          type: object
+        status:
+          properties:
+            cloudRouterIpAddress:
+              description: |-
+                IPv4 address + prefix length to be configured on Cloud Router
+                Interface for this interconnect attachment.
+              type: string
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            customerRouterIpAddress:
+              description: |-
+                IPv4 address + prefix length to be configured on the customer
+                router subinterface for this interconnect attachment.
+              type: string
+            googleReferenceId:
+              description: |-
+                Google reference ID, to be used when raising support tickets with
+                Google or otherwise to debug backend connectivity issues.
+              type: string
+            pairingKey:
+              description: |-
+                [Output only for type PARTNER. Not present for DEDICATED]. The opaque
+                identifier of an PARTNER attachment used to initiate provisioning with
+                a selected partner. Of the form "XXXXX/region/domain"
+              type: string
+            partnerAsn:
+              description: |-
+                [Output only for type PARTNER. Not present for DEDICATED]. Optional
+                BGP ASN for the router that should be supplied by a layer 3 Partner if
+                they configured BGP on behalf of the customer.
+              type: string
+            privateInterconnectInfo:
+              description: |-
+                Information specific to an InterconnectAttachment. This property
+                is populated if the interconnect that this is attached to is of type DEDICATED.
+              properties:
+                tag8021q:
+                  description: |-
+                    802.1q encapsulation tag to be used for traffic between
+                    Google and the customer, going to and from this network and region.
+                  type: integer
+              type: object
+            selfLink:
+              type: string
+            state:
+              description: '[Output Only] The current state of this attachment''s
+                functionality.'
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computenetworkendpointgroups.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeNetworkEndpointGroup
+    plural: computenetworkendpointgroups
+    shortNames:
+    - gcpcomputenetworkendpointgroup
+    - gcpcomputenetworkendpointgroups
+    singular: computenetworkendpointgroup
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            defaultPort:
+              description: |-
+                The default port used if the port number is not specified in the
+                network endpoint.
+              type: integer
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource.
+              type: string
+            location:
+              description: 'Location represents the geographical location of the ComputeNetworkEndpointGroup.
+                Specify a zone name. Reference: GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/)'
+              type: string
+            networkEndpointType:
+              description: |-
+                Type of network endpoints in this network endpoint group. Currently
+                the only supported value is GCE_VM_IP_PORT.
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            subnetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - location
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+            size:
+              description: Number of network endpoints in the network endpoint group.
+              type: integer
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computenetworkpeerings.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeNetworkPeering
+    plural: computenetworkpeerings
+    shortNames:
+    - gcpcomputenetworkpeering
+    - gcpcomputenetworkpeerings
+    singular: computenetworkpeering
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            exportCustomRoutes:
+              type: boolean
+            importCustomRoutes:
+              type: boolean
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            peerNetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - networkRef
+          - peerNetworkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            state:
+              type: string
+            stateDetails:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computenetworks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeNetwork
+    plural: computenetworks
+    shortNames:
+    - gcpcomputenetwork
+    - gcpcomputenetworks
+    singular: computenetwork
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            autoCreateSubnetworks:
+              description: |-
+                When set to 'true', the network is created in "auto subnet mode" and
+                it will create a subnet for each region automatically across the
+                '10.128.0.0/9' address range.
+
+                When set to 'false', the network is created in "custom subnet mode" so
+                the user can explicitly connect subnetwork resources.
+              type: boolean
+            deleteDefaultRoutesOnCreate:
+              type: boolean
+            description:
+              description: |-
+                An optional description of this resource. The resource must be
+                recreated to modify this field.
+              type: string
+            routingMode:
+              description: |-
+                The network-wide routing mode to use. If set to 'REGIONAL', this
+                network's cloud routers will only advertise routes with subnetworks
+                of this network in the same region as the router. If set to 'GLOBAL',
+                this network's cloud routers will advertise routes with all
+                subnetworks of this network, across regions.
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            gatewayIpv4:
+              description: |-
+                The gateway address for default routing out of the network. This value
+                is selected by GCP.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computenodegroups.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeNodeGroup
+    plural: computenodegroups
+    shortNames:
+    - gcpcomputenodegroup
+    - gcpcomputenodegroups
+    singular: computenodegroup
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional textual description of the resource.
+              type: string
+            nodeTemplateRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            size:
+              description: The total number of nodes in the node group.
+              type: integer
+            zone:
+              description: Zone where this node group is located
+              type: string
+          required:
+          - nodeTemplateRef
+          - size
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computenodetemplates.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeNodeTemplate
+    plural: computenodetemplates
+    shortNames:
+    - gcpcomputenodetemplate
+    - gcpcomputenodetemplates
+    singular: computenodetemplate
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional textual description of the resource.
+              type: string
+            nodeType:
+              description: |-
+                Node type to use for nodes group that are created from this template.
+                Only one of nodeTypeFlexibility and nodeType can be specified.
+              type: string
+            nodeTypeFlexibility:
+              description: |-
+                Flexible properties for the desired node type. Node groups that
+                use this node template will create nodes of a type that matches
+                these properties. Only one of nodeTypeFlexibility and nodeType can
+                be specified.
+              properties:
+                cpus:
+                  description: Number of virtual CPUs to use.
+                  type: string
+                localSsd:
+                  description: Use local SSD
+                  type: string
+                memory:
+                  description: Physical memory available to the node, defined in MB.
+                  type: string
+              type: object
+            region:
+              description: |-
+                Region where nodes using the node template will be created.
+                If it is not provided, the provider region is used.
+              type: string
+            serverBinding:
+              description: |-
+                The server binding policy for nodes using this template. Determines
+                where the nodes should restart following a maintenance event.
+              properties:
+                type:
+                  description: |-
+                    Type of server binding policy. If 'RESTART_NODE_ON_ANY_SERVER',
+                    nodes using this template will restart on any physical server
+                    following a maintenance event.
+
+                    If 'RESTART_NODE_ON_MINIMAL_SERVER', nodes using this template
+                    will restart on the same physical server following a maintenance
+                    event, instead of being live migrated to or restarted on a new
+                    physical server. This option may be useful if you are using
+                    software licenses tied to the underlying server characteristics
+                    such as physical sockets or cores, to avoid the need for
+                    additional licenses when maintenance occurs. However, VMs on such
+                    nodes will experience outages while maintenance is applied.
+                  type: string
+              required:
+              - type
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computereservations.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeReservation
+    plural: computereservations
+    shortNames:
+    - gcpcomputereservation
+    - gcpcomputereservations
+    singular: computereservation
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            specificReservation:
+              description: Reservation for instances with specific machine shapes.
+              properties:
+                count:
+                  description: The number of resources that are allocated.
+                  type: integer
+                inUseCount:
+                  description: How many instances are in use.
+                  type: integer
+                instanceProperties:
+                  description: The instance properties for the reservation.
+                  properties:
+                    guestAccelerators:
+                      description: Guest accelerator type and count.
+                      items:
+                        properties:
+                          acceleratorCount:
+                            description: |-
+                              The number of the guest accelerator cards exposed to
+                              this instance.
+                            type: integer
+                          acceleratorType:
+                            description: |-
+                              The full or partial URL of the accelerator type to
+                              attach to this instance. For example:
+                              'projects/my-project/zones/us-central1-c/acceleratorTypes/nvidia-tesla-p100'
+
+                              If you are creating an instance template, specify only the accelerator name.
+                            type: string
+                        required:
+                        - acceleratorCount
+                        - acceleratorType
+                        type: object
+                      type: array
+                    localSsds:
+                      description: |-
+                        The amount of local ssd to reserve with each instance. This
+                        reserves disks of type 'local-ssd'.
+                      items:
+                        properties:
+                          diskSizeGb:
+                            description: The size of the disk in base-2 GB.
+                            type: integer
+                          interface:
+                            description: |-
+                              The disk interface to use for attaching this disk, one
+                              of 'SCSI' or 'NVME'. The default is 'SCSI'.
+                            type: string
+                        required:
+                        - diskSizeGb
+                        type: object
+                      type: array
+                    machineType:
+                      description: The name of the machine type to reserve.
+                      type: string
+                    minCpuPlatform:
+                      description: |-
+                        The minimum CPU platform for the reservation. For example,
+                        '"Intel Skylake"'. See
+                        the CPU platform availability reference](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones)
+                        for information on available CPU platforms.
+                      type: string
+                  required:
+                  - machineType
+                  type: object
+              required:
+              - count
+              - instanceProperties
+              type: object
+            specificReservationRequired:
+              description: |-
+                When set to true, only VMs that target this reservation by name can
+                consume this reservation. Otherwise, it can be consumed by VMs with
+                affinity for any reservation. Defaults to false.
+              type: boolean
+            zone:
+              description: The zone where the reservation is made.
+              type: string
+          required:
+          - specificReservation
+          - zone
+          type: object
+        status:
+          properties:
+            commitment:
+              description: |-
+                Full or partial URL to a parent commitment. This field displays for
+                reservations that are tied to a commitment.
+              type: string
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+            status:
+              description: The status of the reservation.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeresourcepolicies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeResourcePolicy
+    plural: computeresourcepolicies
+    shortNames:
+    - gcpcomputeresourcepolicy
+    - gcpcomputeresourcepolicies
+    singular: computeresourcepolicy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            region:
+              description: Region where resource policy resides.
+              type: string
+            snapshotSchedulePolicy:
+              description: Policy for creating snapshots of persistent disks.
+              properties:
+                retentionPolicy:
+                  description: Retention policy applied to snapshots created by this
+                    resource policy.
+                  properties:
+                    maxRetentionDays:
+                      description: Maximum age of the snapshot that is allowed to
+                        be kept.
+                      type: integer
+                    onSourceDiskDelete:
+                      description: |-
+                        Specifies the behavior to apply to scheduled snapshots when
+                        the source disk is deleted.
+                        Valid options are KEEP_AUTO_SNAPSHOTS and APPLY_RETENTION_POLICY
+                      type: string
+                  required:
+                  - maxRetentionDays
+                  type: object
+                schedule:
+                  description: Contains one of an 'hourlySchedule', 'dailySchedule',
+                    or 'weeklySchedule'.
+                  properties:
+                    dailySchedule:
+                      description: The policy will execute every nth day at the specified
+                        time.
+                      properties:
+                        daysInCycle:
+                          description: The number of days between snapshots.
+                          type: integer
+                        startTime:
+                          description: |-
+                            This must be in UTC format that resolves to one of
+                            00:00, 04:00, 08:00, 12:00, 16:00, or 20:00. For example,
+                            both 13:00-5 and 08:00 are valid.
+                          type: string
+                      required:
+                      - daysInCycle
+                      - startTime
+                      type: object
+                    hourlySchedule:
+                      description: The policy will execute every nth hour starting
+                        at the specified time.
+                      properties:
+                        hoursInCycle:
+                          description: The number of hours between snapshots.
+                          type: integer
+                        startTime:
+                          description: |-
+                            Time within the window to start the operations.
+                            It must be in format "HH:MM",
+                            where HH : [00-23] and MM : [00-00] GMT.
+                          type: string
+                      required:
+                      - hoursInCycle
+                      - startTime
+                      type: object
+                    weeklySchedule:
+                      description: Allows specifying a snapshot time for each day
+                        of the week.
+                      properties:
+                        dayOfWeeks:
+                          description: May contain up to seven (one for each day of
+                            the week) snapshot times.
+                          items:
+                            properties:
+                              day:
+                                description: The day of the week to create the snapshot.
+                                  e.g. MONDAY
+                                type: string
+                              startTime:
+                                description: |-
+                                  Time within the window to start the operations.
+                                  It must be in format "HH:MM", where HH : [00-23] and MM : [00-00] GMT.
+                                type: string
+                            required:
+                            - day
+                            - startTime
+                            type: object
+                          type: array
+                      required:
+                      - dayOfWeeks
+                      type: object
+                  type: object
+                snapshotProperties:
+                  description: Properties with which the snapshots are created, such
+                    as labels.
+                  properties:
+                    guestFlush:
+                      description: Whether to perform a 'guest aware' snapshot.
+                      type: boolean
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: A set of key-value pairs.
+                      type: object
+                    storageLocations:
+                      description: Cloud Storage bucket location in which to store
+                        the snapshot (regional or multi-regional).
+                      items:
+                        type: string
+                      type: array
+                  type: object
+              required:
+              - schedule
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computerouterinterfaces.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeRouterInterface
+    plural: computerouterinterfaces
+    shortNames:
+    - gcpcomputerouterinterface
+    - gcpcomputerouterinterfaces
+    singular: computerouterinterface
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            interconnectAttachmentRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            ipRange:
+              type: string
+            region:
+              type: string
+            routerRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            vpnTunnelRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - routerRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computerouternats.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeRouterNAT
+    plural: computerouternats
+    shortNames:
+    - gcpcomputerouternat
+    - gcpcomputerouternats
+    singular: computerouternat
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            drainNatIps:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            icmpIdleTimeoutSec:
+              description: Timeout (in seconds) for ICMP connections. Defaults to
+                30s if not set.
+              type: integer
+            logConfig:
+              description: Configuration for logging on NAT
+              properties:
+                enable:
+                  description: Indicates whether or not to export logs.
+                  type: boolean
+                filter:
+                  description: |-
+                    Specifies the desired filtering of logs on this NAT. Valid
+                    values are: '"ERRORS_ONLY"', '"TRANSLATIONS_ONLY"', '"ALL"'
+                  type: string
+              required:
+              - enable
+              - filter
+              type: object
+            minPortsPerVm:
+              description: Minimum number of ports allocated to a VM from this NAT.
+              type: integer
+            natIpAllocateOption:
+              description: |-
+                How external IPs should be allocated for this NAT. Valid values are
+                'AUTO_ONLY' for only allowing NAT IPs allocated by Google Cloud
+                Platform, or 'MANUAL_ONLY' for only user-allocated NAT IP addresses.
+              type: string
+            natIps:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            region:
+              description: Region where the router and NAT reside.
+              type: string
+            routerRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            sourceSubnetworkIpRangesToNat:
+              description: |-
+                How NAT should be configured per Subnetwork.
+                If 'ALL_SUBNETWORKS_ALL_IP_RANGES', all of the
+                IP ranges in every Subnetwork are allowed to Nat.
+                If 'ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES', all of the primary IP
+                ranges in every Subnetwork are allowed to Nat.
+                'LIST_OF_SUBNETWORKS': A list of Subnetworks are allowed to Nat
+                (specified in the field subnetwork below). Note that if this field
+                contains ALL_SUBNETWORKS_ALL_IP_RANGES or
+                ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES, then there should not be any
+                other RouterNat section in any Router for this network in this region.
+              type: string
+            subnetwork:
+              description: |-
+                One or more subnetwork NAT configurations. Only used if
+                'source_subnetwork_ip_ranges_to_nat' is set to 'LIST_OF_SUBNETWORKS'
+              items:
+                properties:
+                  secondaryIpRangeNames:
+                    description: |-
+                      List of the secondary ranges of the subnetwork that are allowed
+                      to use NAT. This can be populated only if
+                      'LIST_OF_SECONDARY_IP_RANGES' is one of the values in
+                      sourceIpRangesToNat
+                    items:
+                      type: string
+                    type: array
+                  sourceIpRangesToNat:
+                    description: |-
+                      List of options for which source IPs in the subnetwork
+                      should have NAT enabled. Supported values include:
+                      'ALL_IP_RANGES', 'LIST_OF_SECONDARY_IP_RANGES',
+                      'PRIMARY_IP_RANGE'.
+                    items:
+                      type: string
+                    type: array
+                  subnetworkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                required:
+                - sourceIpRangesToNat
+                - subnetworkRef
+                type: object
+              type: array
+            tcpEstablishedIdleTimeoutSec:
+              description: |-
+                Timeout (in seconds) for TCP established connections.
+                Defaults to 1200s if not set.
+              type: integer
+            tcpTransitoryIdleTimeoutSec:
+              description: |-
+                Timeout (in seconds) for TCP transitory connections.
+                Defaults to 30s if not set.
+              type: integer
+            udpIdleTimeoutSec:
+              description: Timeout (in seconds) for UDP connections. Defaults to 30s
+                if not set.
+              type: integer
+          required:
+          - natIpAllocateOption
+          - routerRef
+          - sourceSubnetworkIpRangesToNat
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computerouterpeers.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeRouterPeer
+    plural: computerouterpeers
+    shortNames:
+    - gcpcomputerouterpeer
+    - gcpcomputerouterpeers
+    singular: computerouterpeer
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            advertiseMode:
+              description: |-
+                User-specified flag to indicate which mode to use for advertisement.
+                Valid values of this enum field are: 'DEFAULT', 'CUSTOM'
+              type: string
+            advertisedGroups:
+              description: |-
+                User-specified list of prefix groups to advertise in custom
+                mode, which can take one of the following options:
+
+                * 'ALL_SUBNETS': Advertises all available subnets, including peer VPC subnets.
+                * 'ALL_VPC_SUBNETS': Advertises the router's own VPC subnets.
+                * 'ALL_PEER_VPC_SUBNETS': Advertises peer subnets of the router's VPC network.
+
+
+                Note that this field can only be populated if advertiseMode is 'CUSTOM'
+                and overrides the list defined for the router (in the "bgp" message).
+                These groups are advertised in addition to any specified prefixes.
+                Leave this field blank to advertise no custom groups.
+              items:
+                type: string
+              type: array
+            advertisedIpRanges:
+              description: |-
+                User-specified list of individual IP ranges to advertise in
+                custom mode. This field can only be populated if advertiseMode
+                is 'CUSTOM' and is advertised to all peers of the router. These IP
+                ranges will be advertised in addition to any specified groups.
+                Leave this field blank to advertise no custom IP ranges.
+              items:
+                properties:
+                  description:
+                    description: User-specified description for the IP range.
+                    type: string
+                  range:
+                    description: |-
+                      The IP range to advertise. The value must be a
+                      CIDR-formatted string.
+                    type: string
+                required:
+                - range
+                type: object
+              type: array
+            advertisedRoutePriority:
+              description: |-
+                The priority of routes advertised to this BGP peer.
+                Where there is more than one matching route of maximum
+                length, the routes with the lowest priority value win.
+              type: integer
+            peerAsn:
+              description: |-
+                Peer BGP Autonomous System Number (ASN).
+                Each BGP interface may use a different value.
+              type: integer
+            peerIpAddress:
+              description: |-
+                IP address of the BGP interface outside Google Cloud Platform.
+                Only IPv4 is supported.
+              type: string
+            region:
+              description: |-
+                Region where the router and BgpPeer reside.
+                If it is not provided, the provider region is used.
+              type: string
+            routerInterfaceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            routerRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - peerAsn
+          - peerIpAddress
+          - routerInterfaceRef
+          - routerRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            ipAddress:
+              description: |-
+                IP address of the interface inside Google Cloud Platform.
+                Only IPv4 is supported.
+              type: string
+            managementType:
+              description: |-
+                The resource that configures and manages this BGP peer.
+
+                * 'MANAGED_BY_USER' is the default value and can be managed by
+                you or other users
+                * 'MANAGED_BY_ATTACHMENT' is a BGP peer that is configured and
+                managed by Cloud Interconnect, specifically by an
+                InterconnectAttachment of type PARTNER. Google automatically
+                creates, updates, and deletes this type of BGP peer when the
+                PARTNER InterconnectAttachment is created, updated,
+                or deleted.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computerouters.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeRouter
+    plural: computerouters
+    shortNames:
+    - gcpcomputerouter
+    - gcpcomputerouters
+    singular: computerouter
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bgp:
+              description: BGP information specific to this router.
+              properties:
+                advertiseMode:
+                  description: |-
+                    User-specified flag to indicate which mode to use for advertisement.
+
+                    Valid values of this enum field are: DEFAULT, CUSTOM
+                  type: string
+                advertisedGroups:
+                  description: |-
+                    User-specified list of prefix groups to advertise in custom mode.
+                    This field can only be populated if advertiseMode is CUSTOM and
+                    is advertised to all peers of the router. These groups will be
+                    advertised in addition to any specified prefixes. Leave this field
+                    blank to advertise no custom groups.
+
+                    This enum field has the one valid value: ALL_SUBNETS
+                  items:
+                    type: string
+                  type: array
+                advertisedIpRanges:
+                  description: |-
+                    User-specified list of individual IP ranges to advertise in
+                    custom mode. This field can only be populated if advertiseMode
+                    is CUSTOM and is advertised to all peers of the router. These IP
+                    ranges will be advertised in addition to any specified groups.
+                    Leave this field blank to advertise no custom IP ranges.
+                  items:
+                    properties:
+                      description:
+                        description: User-specified description for the IP range.
+                        type: string
+                      range:
+                        description: |-
+                          The IP range to advertise. The value must be a
+                          CIDR-formatted string.
+                        type: string
+                    required:
+                    - range
+                    type: object
+                  type: array
+                asn:
+                  description: |-
+                    Local BGP Autonomous System Number (ASN). Must be an RFC6996
+                    private ASN, either 16-bit or 32-bit. The value will be fixed for
+                    this router resource. All VPN tunnels that link to this router
+                    will have the same local ASN.
+                  type: integer
+              required:
+              - asn
+              type: object
+            description:
+              description: An optional description of this resource.
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            region:
+              description: Region where the router resides.
+              type: string
+          required:
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeroutes.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeRoute
+    plural: computeroutes
+    shortNames:
+    - gcpcomputeroute
+    - gcpcomputeroutes
+    singular: computeroute
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: |-
+                An optional description of this resource. Provide this property
+                when you create the resource.
+              type: string
+            destRange:
+              description: |-
+                The destination range of outgoing packets that this route applies to.
+                Only IPv4 is supported.
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            nextHopGateway:
+              description: |-
+                URL to a gateway that should handle matching packets.
+                Currently, you can only specify the internet gateway, using a full or
+                partial valid URL:
+                * 'https://www.googleapis.com/compute/v1/projects/project/global/gateways/default-internet-gateway'
+                * 'projects/project/global/gateways/default-internet-gateway'
+                * 'global/gateways/default-internet-gateway'
+                * The string 'default-internet-gateway'.
+              type: string
+            nextHopILBRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            nextHopInstanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            nextHopIp:
+              description: Network IP address of an instance that should handle matching
+                packets.
+              type: string
+            nextHopVPNTunnelRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            priority:
+              description: |-
+                The priority of this route. Priority is used to break ties in cases
+                where there is more than one matching route of equal prefix length.
+
+                In the case of two routes with equal prefix length, the one with the
+                lowest-numbered priority value wins.
+
+                Default value is 1000. Valid range is 0 through 65535.
+              type: integer
+            tags:
+              description: A list of instance tags to which this route applies.
+              items:
+                type: string
+              type: array
+          required:
+          - destRange
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            nextHopNetwork:
+              description: URL to a Network that should handle matching packets.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesecuritypolicies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSecurityPolicy
+    plural: computesecuritypolicies
+    shortNames:
+    - gcpcomputesecuritypolicy
+    - gcpcomputesecuritypolicies
+    singular: computesecuritypolicy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            rule:
+              items:
+                properties:
+                  action:
+                    type: string
+                  description:
+                    type: string
+                  match:
+                    properties:
+                      config:
+                        properties:
+                          srcIpRanges:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - srcIpRanges
+                        type: object
+                      expr:
+                        properties:
+                          expression:
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      versionedExpr:
+                        type: string
+                    type: object
+                  preview:
+                    type: boolean
+                  priority:
+                    type: integer
+                required:
+                - action
+                - match
+                - priority
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            fingerprint:
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesharedvpchostprojects.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSharedVPCHostProject
+    plural: computesharedvpchostprojects
+    shortNames:
+    - gcpcomputesharedvpchostproject
+    - gcpcomputesharedvpchostprojects
+    singular: computesharedvpchostproject
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesharedvpcserviceprojects.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSharedVPCServiceProject
+    plural: computesharedvpcserviceprojects
+    shortNames:
+    - gcpcomputesharedvpcserviceproject
+    - gcpcomputesharedvpcserviceprojects
+    singular: computesharedvpcserviceproject
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            projectRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - projectRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesnapshots.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSnapshot
+    plural: computesnapshots
+    shortNames:
+    - gcpcomputesnapshot
+    - gcpcomputesnapshots
+    singular: computesnapshot
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            snapshotEncryptionKey:
+              description: |-
+                The customer-supplied encryption key of the snapshot. Required if the
+                source snapshot is protected by a customer-supplied encryption key.
+              properties:
+                rawKey:
+                  description: |-
+                    Specifies a 256-bit customer-supplied encryption key, encoded in
+                    RFC 4648 base64 to either encrypt or decrypt this resource.
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                sha256:
+                  description: |-
+                    The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
+                    encryption key that protects this resource.
+                  type: string
+              required:
+              - rawKey
+              type: object
+            sourceDiskEncryptionKey:
+              description: |-
+                The customer-supplied encryption key of the source snapshot. Required
+                if the source snapshot is protected by a customer-supplied encryption
+                key.
+              properties:
+                rawKey:
+                  description: |-
+                    Specifies a 256-bit customer-supplied encryption key, encoded in
+                    RFC 4648 base64 to either encrypt or decrypt this resource.
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+              type: object
+            sourceDiskRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            zone:
+              description: A reference to the zone where the disk is hosted.
+              type: string
+          required:
+          - sourceDiskRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            diskSizeGb:
+              description: Size of the snapshot, specified in GB.
+              type: integer
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource. Used
+                internally during updates.
+              type: string
+            licenses:
+              description: |-
+                A list of public visible licenses that apply to this snapshot. This
+                can be because the original image had licenses attached (such as a
+                Windows image).  snapshotEncryptionKey nested object Encrypts the
+                snapshot using a customer-supplied encryption key.
+              items:
+                type: string
+              type: array
+            selfLink:
+              type: string
+            snapshotId:
+              description: The unique identifier for the resource.
+              type: integer
+            sourceDiskLink:
+              type: string
+            storageBytes:
+              description: |-
+                A size of the storage used by the snapshot. As snapshots share
+                storage, this number is expected to change with snapshot
+                creation/deletion.
+              type: integer
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesslcertificates.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSSLCertificate
+    plural: computesslcertificates
+    shortNames:
+    - gcpcomputesslcertificate
+    - gcpcomputesslcertificates
+    singular: computesslcertificate
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            certificate:
+              description: |-
+                The certificate in PEM format.
+                The certificate chain must be no greater than 5 certs long.
+                The chain must include at least one intermediate cert.
+              oneOf:
+              - not:
+                  required:
+                  - valueFrom
+                required:
+                - value
+              - not:
+                  required:
+                  - value
+                required:
+                - valueFrom
+              properties:
+                value:
+                  description: Value of the field. Cannot be used if 'valueFrom' is
+                    specified.
+                  type: string
+                valueFrom:
+                  description: Source for the field's value. Cannot be used if 'value'
+                    is specified.
+                  properties:
+                    secretKeyRef:
+                      description: Reference to a value with the given key in the
+                        given Secret in the resource's namespace.
+                      properties:
+                        key:
+                          description: Key that identifies the value to be extracted.
+                          type: string
+                        name:
+                          description: Name of the Secret to extract a value from.
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+              type: object
+            description:
+              description: An optional description of this resource.
+              type: string
+            location:
+              description: Location represents the geographical location of the ComputeSSLCertificate.
+                Specify "global" for global resources.
+              type: string
+            privateKey:
+              description: The write-only private key in PEM format.
+              oneOf:
+              - not:
+                  required:
+                  - valueFrom
+                required:
+                - value
+              - not:
+                  required:
+                  - value
+                required:
+                - valueFrom
+              properties:
+                value:
+                  description: Value of the field. Cannot be used if 'valueFrom' is
+                    specified.
+                  type: string
+                valueFrom:
+                  description: Source for the field's value. Cannot be used if 'value'
+                    is specified.
+                  properties:
+                    secretKeyRef:
+                      description: Reference to a value with the given key in the
+                        given Secret in the resource's namespace.
+                      properties:
+                        key:
+                          description: Key that identifies the value to be extracted.
+                          type: string
+                        name:
+                          description: Name of the Secret to extract a value from.
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+              type: object
+          required:
+          - certificate
+          - location
+          - privateKey
+          type: object
+        status:
+          properties:
+            certificateId:
+              description: The unique identifier for the resource.
+              type: integer
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesslpolicies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSSLPolicy
+    plural: computesslpolicies
+    shortNames:
+    - gcpcomputesslpolicy
+    - gcpcomputesslpolicies
+    singular: computesslpolicy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            customFeatures:
+              description: |-
+                Profile specifies the set of SSL features that can be used by the
+                load balancer when negotiating SSL with clients. This can be one of
+                'COMPATIBLE', 'MODERN', 'RESTRICTED', or 'CUSTOM'. If using 'CUSTOM',
+                the set of SSL features to enable must be specified in the
+                'customFeatures' field.
+
+                See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
+                for which ciphers are available to use. **Note**: this argument
+                *must* be present when using the 'CUSTOM' profile. This argument
+                *must not* be present when using any other profile.
+              items:
+                type: string
+              type: array
+            description:
+              description: An optional description of this resource.
+              type: string
+            minTlsVersion:
+              description: |-
+                The minimum version of SSL protocol that can be used by the clients
+                to establish a connection with the load balancer. This can be one of
+                'TLS_1_0', 'TLS_1_1', 'TLS_1_2'.
+                 Default is 'TLS_1_0'.
+              type: string
+            profile:
+              description: |-
+                Profile specifies the set of SSL features that can be used by the
+                load balancer when negotiating SSL with clients. This can be one of
+                'COMPATIBLE', 'MODERN', 'RESTRICTED', or 'CUSTOM'. If using 'CUSTOM',
+                the set of SSL features to enable must be specified in the
+                'customFeatures' field.
+
+                See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
+                for information on what cipher suites each profile provides. If
+                'CUSTOM' is used, the 'custom_features' attribute **must be set**.
+                Default is 'COMPATIBLE'.
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            enabledFeatures:
+              description: The list of features enabled in the SSL policy.
+              items:
+                type: string
+              type: array
+            fingerprint:
+              description: |-
+                Fingerprint of this resource. A hash of the contents stored in this
+                object. This field is used in optimistic locking.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computesubnetworks.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeSubnetwork
+    plural: computesubnetworks
+    shortNames:
+    - gcpcomputesubnetwork
+    - gcpcomputesubnetworks
+    singular: computesubnetwork
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when
+                you create the resource. This field can be set only at resource
+                creation time.
+              type: string
+            ipCidrRange:
+              description: |-
+                The range of internal addresses that are owned by this subnetwork.
+                Provide this property when you create the subnetwork. For example,
+                10.0.0.0/8 or 192.168.0.0/16. Ranges must be unique and
+                non-overlapping within a network. Only IPv4 is supported.
+              type: string
+            logConfig:
+              description: |-
+                Denotes the logging options for the subnetwork flow logs. If logging is enabled
+                logs will be exported to Stackdriver. This field cannot be set if the 'purpose' of this
+                subnetwork is 'INTERNAL_HTTPS_LOAD_BALANCER'
+              properties:
+                aggregationInterval:
+                  description: |-
+                    Can only be specified if VPC flow logging for this subnetwork is enabled.
+                    Toggles the aggregation interval for collecting flow logs. Increasing the
+                    interval time will reduce the amount of generated flow logs for long
+                    lasting connections. Default is an interval of 5 seconds per connection.
+                    Possible values are INTERVAL_5_SEC, INTERVAL_30_SEC, INTERVAL_1_MIN,
+                    INTERVAL_5_MIN, INTERVAL_10_MIN, INTERVAL_15_MIN
+                  type: string
+                flowSampling:
+                  description: |-
+                    Can only be specified if VPC flow logging for this subnetwork is enabled.
+                    The value of the field must be in [0, 1]. Set the sampling rate of VPC
+                    flow logs within the subnetwork where 1.0 means all collected logs are
+                    reported and 0.0 means no logs are reported. Default is 0.5 which means
+                    half of all collected logs are reported.
+                  type: number
+                metadata:
+                  description: |-
+                    Can only be specified if VPC flow logging for this subnetwork is enabled.
+                    Configures whether metadata fields should be added to the reported VPC
+                    flow logs. Default is 'INCLUDE_ALL_METADATA'.
+                  type: string
+              type: object
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            privateIpGoogleAccess:
+              description: |-
+                When enabled, VMs in this subnetwork without external IP addresses can
+                access Google APIs and services by using Private Google Access.
+              type: boolean
+            purpose:
+              description: |-
+                The purpose of the resource. This field can be either PRIVATE
+                or INTERNAL_HTTPS_LOAD_BALANCER. A subnetwork with purpose set to
+                INTERNAL_HTTPS_LOAD_BALANCER is a user-created subnetwork that is
+                reserved for Internal HTTP(S) Load Balancing. If unspecified, the
+                purpose defaults to PRIVATE.
+
+                If set to INTERNAL_HTTPS_LOAD_BALANCER you must also set the role.
+              type: string
+            region:
+              description: URL of the GCP region for this subnetwork.
+              type: string
+            role:
+              description: |-
+                The role of subnetwork. Currently, this field is only used when
+                purpose = INTERNAL_HTTPS_LOAD_BALANCER. The value can be set to ACTIVE
+                or BACKUP. An ACTIVE subnetwork is one that is currently being used
+                for Internal HTTP(S) Load Balancing. A BACKUP subnetwork is one that
+                is ready to be promoted to ACTIVE or is currently draining.
+              type: string
+            secondaryIpRange:
+              items:
+                properties:
+                  ipCidrRange:
+                    description: |-
+                      The range of IP addresses belonging to this subnetwork secondary
+                      range. Provide this property when you create the subnetwork.
+                      Ranges must be unique and non-overlapping with all primary and
+                      secondary IP ranges within a network. Only IPv4 is supported.
+                    type: string
+                  rangeName:
+                    description: |-
+                      The name associated with this subnetwork secondary range, used
+                      when adding an alias IP range to a VM instance. The name must
+                      be 1-63 characters long, and comply with RFC1035. The name
+                      must be unique within the subnetwork.
+                    type: string
+                required:
+                - ipCidrRange
+                - rangeName
+                type: object
+              type: array
+          required:
+          - ipCidrRange
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            fingerprint:
+              description: DEPRECATED — This field is not useful for users, and has
+                been removed as an output. Fingerprint of this resource. This field
+                is used internally during updates of this resource.
+              type: string
+            gatewayAddress:
+              description: |-
+                The gateway address for default routes to reach destination addresses
+                outside this subnetwork.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargethttpproxies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetHTTPProxy
+    plural: computetargethttpproxies
+    shortNames:
+    - gcpcomputetargethttpproxy
+    - gcpcomputetargethttpproxies
+    singular: computetargethttpproxy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            location:
+              description: Location represents the geographical location of the ComputeTargetHTTPProxy.
+                Specify "global" for global resources.
+              type: string
+            urlMapRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - location
+          - urlMapRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            proxyId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargethttpsproxies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetHTTPSProxy
+    plural: computetargethttpsproxies
+    shortNames:
+    - gcpcomputetargethttpsproxy
+    - gcpcomputetargethttpsproxies
+    singular: computetargethttpsproxy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            location:
+              description: Location represents the geographical location of the ComputeTargetHTTPSProxy.
+                Specify "global" for global resources.
+              type: string
+            quicOverride:
+              description: |-
+                Specifies the QUIC override policy for this resource. This determines
+                whether the load balancer will attempt to negotiate QUIC with clients
+                or not. Can specify one of NONE, ENABLE, or DISABLE. If NONE is
+                specified, uses the QUIC policy with no user overrides, which is
+                equivalent to DISABLE. Not specifying this field is equivalent to
+                specifying NONE.
+              type: string
+            sslCertificates:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            sslPolicyRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            urlMapRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - location
+          - sslCertificates
+          - urlMapRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            proxyId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargetinstances.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetInstance
+    plural: computetargetinstances
+    shortNames:
+    - gcpcomputetargetinstance
+    - gcpcomputetargetinstances
+    singular: computetargetinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            instanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            natPolicy:
+              description: |-
+                NAT option controlling how IPs are NAT'ed to the instance.
+                Currently only NO_NAT (default value) is supported.
+              type: string
+            zone:
+              description: URL of the zone where the target instance resides.
+              type: string
+          required:
+          - instanceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargetpools.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetPool
+    plural: computetargetpools
+    shortNames:
+    - gcpcomputetargetpool
+    - gcpcomputetargetpools
+    singular: computetargetpool
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            backupTargetPoolRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            description:
+              type: string
+            failoverRatio:
+              type: number
+            healthChecks:
+              items:
+                properties:
+                  httpHealthCheckRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                type: object
+              type: array
+            instances:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            region:
+              type: string
+            sessionAffinity:
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargetsslproxies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetSSLProxy
+    plural: computetargetsslproxies
+    shortNames:
+    - gcpcomputetargetsslproxy
+    - gcpcomputetargetsslproxies
+    singular: computetargetsslproxy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            backendServiceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            description:
+              description: An optional description of this resource.
+              type: string
+            proxyHeader:
+              description: |-
+                Specifies the type of proxy header to append before sending data to
+                the backend, either NONE or PROXY_V1. The default is NONE.
+              type: string
+            sslCertificates:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            sslPolicyRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - backendServiceRef
+          - sslCertificates
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            proxyId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargettcpproxies.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetTCPProxy
+    plural: computetargettcpproxies
+    shortNames:
+    - gcpcomputetargettcpproxy
+    - gcpcomputetargettcpproxies
+    singular: computetargettcpproxy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            backendServiceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            description:
+              description: An optional description of this resource.
+              type: string
+            proxyHeader:
+              description: |-
+                Specifies the type of proxy header to append before sending data to
+                the backend, either NONE or PROXY_V1. The default is NONE.
+              type: string
+          required:
+          - backendServiceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            proxyId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computetargetvpngateways.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeTargetVPNGateway
+    plural: computetargetvpngateways
+    shortNames:
+    - gcpcomputetargetvpngateway
+    - gcpcomputetargetvpngateways
+    singular: computetargetvpngateway
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            region:
+              description: The region this gateway should sit in.
+              type: string
+          required:
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            gatewayId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computeurlmaps.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeURLMap
+    plural: computeurlmaps
+    shortNames:
+    - gcpcomputeurlmap
+    - gcpcomputeurlmaps
+    singular: computeurlmap
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            defaultService:
+              properties:
+                backendBucketRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                backendServiceRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              type: object
+            description:
+              description: |-
+                An optional description of this resource. Provide this property when you create
+                the resource.
+              type: string
+            headerAction:
+              description: |-
+                Specifies changes to request and response headers that need to take effect for
+                the selected backendService. The headerAction specified here take effect after
+                headerAction specified under pathMatcher.
+              properties:
+                requestHeadersToAdd:
+                  description: |-
+                    Headers to add to a matching request prior to forwarding the request to the
+                    backendService.
+                  items:
+                    properties:
+                      headerName:
+                        description: The name of the header.
+                        type: string
+                      headerValue:
+                        description: The value of the header to add.
+                        type: string
+                      replace:
+                        description: |-
+                          If false, headerValue is appended to any values that already exist for the
+                          header. If true, headerValue is set for the header, discarding any values that
+                          were set for that header.
+                        type: boolean
+                    required:
+                    - headerName
+                    - headerValue
+                    - replace
+                    type: object
+                  type: array
+                requestHeadersToRemove:
+                  description: |-
+                    A list of header names for headers that need to be removed from the request
+                    prior to forwarding the request to the backendService.
+                  items:
+                    type: string
+                  type: array
+                responseHeadersToAdd:
+                  description: Headers to add the response prior to sending the response
+                    back to the client.
+                  items:
+                    properties:
+                      headerName:
+                        description: The name of the header.
+                        type: string
+                      headerValue:
+                        description: The value of the header to add.
+                        type: string
+                      replace:
+                        description: |-
+                          If false, headerValue is appended to any values that already exist for the
+                          header. If true, headerValue is set for the header, discarding any values that
+                          were set for that header.
+                        type: boolean
+                    required:
+                    - headerName
+                    - headerValue
+                    - replace
+                    type: object
+                  type: array
+                responseHeadersToRemove:
+                  description: |-
+                    A list of header names for headers that need to be removed from the response
+                    prior to sending the response back to the client.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            hostRule:
+              description: The list of HostRules to use against the URL.
+              items:
+                properties:
+                  description:
+                    description: |-
+                      An optional description of this resource. Provide this property when you create
+                      the resource.
+                    type: string
+                  hosts:
+                    description: |-
+                      The list of host patterns to match. They must be valid hostnames, except * will
+                      match any string of ([a-z0-9-.]*). In that case, * must be the first character
+                      and must be followed in the pattern by either - or ..
+                    items:
+                      type: string
+                    type: array
+                  pathMatcher:
+                    description: |-
+                      The name of the PathMatcher to use to match the path portion of the URL if the
+                      hostRule matches the URL's host portion.
+                    type: string
+                required:
+                - hosts
+                - pathMatcher
+                type: object
+              type: array
+            location:
+              description: Location represents the geographical location of the ComputeURLMap.
+                Specify "global" for global resources.
+              type: string
+            pathMatcher:
+              description: The list of named PathMatchers to use against the URL.
+              items:
+                properties:
+                  defaultService:
+                    properties:
+                      backendBucketRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                      backendServiceRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                    type: object
+                  description:
+                    description: |-
+                      An optional description of this resource. Provide this property when you create
+                      the resource.
+                    type: string
+                  headerAction:
+                    description: |-
+                      Specifies changes to request and response headers that need to take effect for
+                      the selected backendService. HeaderAction specified here are applied after the
+                      matching HttpRouteRule HeaderAction and before the HeaderAction in the UrlMap
+                    properties:
+                      requestHeadersToAdd:
+                        description: |-
+                          Headers to add to a matching request prior to forwarding the request to the
+                          backendService.
+                        items:
+                          properties:
+                            headerName:
+                              description: The name of the header.
+                              type: string
+                            headerValue:
+                              description: The value of the header to add.
+                              type: string
+                            replace:
+                              description: |-
+                                If false, headerValue is appended to any values that already exist for the
+                                header. If true, headerValue is set for the header, discarding any values that
+                                were set for that header.
+                              type: boolean
+                          required:
+                          - headerName
+                          - headerValue
+                          - replace
+                          type: object
+                        type: array
+                      requestHeadersToRemove:
+                        description: |-
+                          A list of header names for headers that need to be removed from the request
+                          prior to forwarding the request to the backendService.
+                        items:
+                          type: string
+                        type: array
+                      responseHeadersToAdd:
+                        description: Headers to add the response prior to sending
+                          the response back to the client.
+                        items:
+                          properties:
+                            headerName:
+                              description: The name of the header.
+                              type: string
+                            headerValue:
+                              description: The value of the header to add.
+                              type: string
+                            replace:
+                              description: |-
+                                If false, headerValue is appended to any values that already exist for the
+                                header. If true, headerValue is set for the header, discarding any values that
+                                were set for that header.
+                              type: boolean
+                          required:
+                          - headerName
+                          - headerValue
+                          - replace
+                          type: object
+                        type: array
+                      responseHeadersToRemove:
+                        description: |-
+                          A list of header names for headers that need to be removed from the response
+                          prior to sending the response back to the client.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  name:
+                    description: The name to which this PathMatcher is referred by
+                      the HostRule.
+                    type: string
+                  pathRule:
+                    description: |-
+                      The list of path rules. Use this list instead of routeRules when routing based
+                      on simple path matching is all that's required. The order by which path rules
+                      are specified does not matter. Matches are always done on the longest-path-first
+                      basis. For example: a pathRule with a path /a/b/c/* will match before /a/b/*
+                      irrespective of the order in which those paths appear in this list. Within a
+                      given pathMatcher, only one of pathRules or routeRules must be set.
+                    items:
+                      properties:
+                        paths:
+                          description: |-
+                            The list of path patterns to match. Each must start with / and the only place a
+                            * is allowed is at the end following a /. The string fed to the path matcher
+                            does not include any text after the first ? or #, and those chars are not
+                            allowed here.
+                          items:
+                            type: string
+                          type: array
+                        routeAction:
+                          description: |-
+                            In response to a matching path, the load balancer performs advanced routing
+                            actions like URL rewrites, header transformations, etc. prior to forwarding the
+                            request to the selected backend. If routeAction specifies any
+                            weightedBackendServices, service must not be set. Conversely if service is set,
+                            routeAction cannot contain any  weightedBackendServices. Only one of routeAction
+                            or urlRedirect must be set.
+                          properties:
+                            corsPolicy:
+                              description: |-
+                                The specification for allowing client side cross-origin requests. Please see W3C
+                                Recommendation for Cross Origin Resource Sharing
+                              properties:
+                                allowCredentials:
+                                  description: |-
+                                    In response to a preflight request, setting this to true indicates that the
+                                    actual request can include user credentials. This translates to the Access-
+                                    Control-Allow-Credentials header. Defaults to false.
+                                  type: boolean
+                                allowHeaders:
+                                  description: Specifies the content for the Access-Control-Allow-Headers
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowMethods:
+                                  description: Specifies the content for the Access-Control-Allow-Methods
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowOriginRegexes:
+                                  description: |-
+                                    Specifies the regualar expression patterns that match allowed origins. For
+                                    regular expression grammar please see en.cppreference.com/w/cpp/regex/ecmascript
+                                    An origin is allowed if it matches either allow_origins or allow_origin_regex.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowOrigins:
+                                  description: |-
+                                    Specifies the list of origins that will be allowed to do CORS requests. An
+                                    origin is allowed if it matches either allow_origins or allow_origin_regex.
+                                  items:
+                                    type: string
+                                  type: array
+                                disabled:
+                                  description: If true, specifies the CORS policy
+                                    is disabled.
+                                  type: boolean
+                                exposeHeaders:
+                                  description: Specifies the content for the Access-Control-Expose-Headers
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                maxAge:
+                                  description: |-
+                                    Specifies how long the results of a preflight request can be cached. This
+                                    translates to the content for the Access-Control-Max-Age header.
+                                  type: integer
+                              required:
+                              - disabled
+                              type: object
+                            faultInjectionPolicy:
+                              description: |-
+                                The specification for fault injection introduced into traffic to test the
+                                resiliency of clients to backend service failure. As part of fault injection,
+                                when clients send requests to a backend service, delays can be introduced by
+                                Loadbalancer on a percentage of requests before sending those request to the
+                                backend service. Similarly requests from clients can be aborted by the
+                                Loadbalancer for a percentage of requests. timeout and retry_policy will be
+                                ignored by clients that are configured with a fault_injection_policy.
+                              properties:
+                                abort:
+                                  description: |-
+                                    The specification for how client requests are aborted as part of fault
+                                    injection.
+                                  properties:
+                                    httpStatus:
+                                      description: |-
+                                        The HTTP status code used to abort the request. The value must be between 200
+                                        and 599 inclusive.
+                                      type: integer
+                                    percentage:
+                                      description: |-
+                                        The percentage of traffic (connections/operations/requests) which will be
+                                        aborted as part of fault injection. The value must be between 0.0 and 100.0
+                                        inclusive.
+                                      type: number
+                                  required:
+                                  - httpStatus
+                                  - percentage
+                                  type: object
+                                delay:
+                                  description: |-
+                                    The specification for how client requests are delayed as part of fault
+                                    injection, before being sent to a backend service.
+                                  properties:
+                                    fixedDelay:
+                                      description: Specifies the value of the fixed
+                                        delay interval.
+                                      properties:
+                                        nanos:
+                                          description: |-
+                                            Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                            less than one second are represented with a 0 'seconds' field and a positive
+                                            'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                          type: integer
+                                        seconds:
+                                          description: |-
+                                            Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                            inclusive.
+                                          type: string
+                                      required:
+                                      - seconds
+                                      type: object
+                                    percentage:
+                                      description: |-
+                                        The percentage of traffic (connections/operations/requests) on which delay will
+                                        be introduced as part of fault injection. The value must be between 0.0 and
+                                        100.0 inclusive.
+                                      type: number
+                                  required:
+                                  - fixedDelay
+                                  - percentage
+                                  type: object
+                              type: object
+                            requestMirrorPolicy:
+                              description: |-
+                                Specifies the policy on how requests intended for the route's backends are
+                                shadowed to a separate mirrored backend service. Loadbalancer does not wait for
+                                responses from the shadow service. Prior to sending traffic to the shadow
+                                service, the host / authority header is suffixed with -shadow.
+                              properties:
+                                backendService:
+                                  description: The BackendService resource being mirrored
+                                    to.
+                                  type: string
+                              required:
+                              - backendService
+                              type: object
+                            retryPolicy:
+                              description: Specifies the retry policy associated with
+                                this route.
+                              properties:
+                                numRetries:
+                                  description: Specifies the allowed number retries.
+                                    This number must be > 0.
+                                  type: integer
+                                perTryTimeout:
+                                  description: Specifies a non-zero timeout per retry
+                                    attempt.
+                                  properties:
+                                    nanos:
+                                      description: |-
+                                        Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                        less than one second are represented with a 0 'seconds' field and a positive
+                                        'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                      type: integer
+                                    seconds:
+                                      description: |-
+                                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                        inclusive.
+                                      type: string
+                                  required:
+                                  - seconds
+                                  type: object
+                                retryConditions:
+                                  description: |-
+                                    Specifies one or more conditions when this retry rule applies. Valid values are:
+                                    - 5xx: Loadbalancer will attempt a retry if the backend service responds with
+                                    any 5xx response code, or if the backend service does not respond at all,
+                                    example: disconnects, reset, read timeout, connection failure, and refused
+                                    streams.
+                                    - gateway-error: Similar to 5xx, but only applies to response codes
+                                    502, 503 or 504.
+                                    - connect-failure: Loadbalancer will retry on failures
+                                    connecting to backend services, for example due to connection timeouts.
+                                    - retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                                    Currently the only retriable error supported is 409.
+                                    - refused-stream: Loadbalancer will retry if the backend service resets the stream with a
+                                    REFUSED_STREAM error code. This reset type indicates that it is safe to retry.
+                                    - cancelled: Loadbalancer will retry if the gRPC status code in the response
+                                    header is set to cancelled
+                                    - deadline-exceeded: Loadbalancer will retry if the
+                                    gRPC status code in the response header is set to deadline-exceeded
+                                    - resource-exhausted: Loadbalancer will retry if the gRPC status code in the response
+                                    header is set to resource-exhausted
+                                    - unavailable: Loadbalancer will retry if
+                                    the gRPC status code in the response header is set to unavailable
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            timeout:
+                              description: |-
+                                Specifies the timeout for the selected route. Timeout is computed from the time
+                                the request is has been fully processed (i.e. end-of-stream) up until the
+                                response has been completely processed. Timeout includes all retries. If not
+                                specified, the default value is 15 seconds.
+                              properties:
+                                nanos:
+                                  description: |-
+                                    Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                    less than one second are represented with a 0 'seconds' field and a positive
+                                    'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                  type: integer
+                                seconds:
+                                  description: |-
+                                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                    inclusive.
+                                  type: string
+                              required:
+                              - seconds
+                              type: object
+                            urlRewrite:
+                              description: |-
+                                The spec to modify the URL of the request, prior to forwarding the request to
+                                the matched service
+                              properties:
+                                hostRewrite:
+                                  description: |-
+                                    Prior to forwarding the request to the selected service, the request's host
+                                    header is replaced with contents of hostRewrite. The value must be between 1 and
+                                    255 characters.
+                                  type: string
+                                pathPrefixRewrite:
+                                  description: |-
+                                    Prior to forwarding the request to the selected backend service, the matching
+                                    portion of the request's path is replaced by pathPrefixRewrite. The value must
+                                    be between 1 and 1024 characters.
+                                  type: string
+                              type: object
+                            weightedBackendServices:
+                              description: |-
+                                A list of weighted backend services to send traffic to when a route match
+                                occurs. The weights determine the fraction of traffic that flows to their
+                                corresponding backend service. If all traffic needs to go to a single backend
+                                service, there must be one  weightedBackendService with weight set to a non 0
+                                number. Once a backendService is identified and before forwarding the request to
+                                the backend service, advanced routing actions like Url rewrites and header
+                                transformations are applied depending on additional settings specified in this
+                                HttpRouteAction.
+                              items:
+                                properties:
+                                  backendServiceRef:
+                                    oneOf:
+                                    - not:
+                                        required:
+                                        - external
+                                      required:
+                                      - name
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - name
+                                        - required:
+                                          - namespace
+                                      required:
+                                      - external
+                                    properties:
+                                      external:
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      namespace:
+                                        description: 'Namespace of the referent. More
+                                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                        type: string
+                                    type: object
+                                  headerAction:
+                                    description: |-
+                                      Specifies changes to request and response headers that need to take effect for
+                                      the selected backendService. headerAction specified here take effect before
+                                      headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+                                    properties:
+                                      requestHeadersToAdd:
+                                        description: |-
+                                          Headers to add to a matching request prior to forwarding the request to the
+                                          backendService.
+                                        items:
+                                          properties:
+                                            headerName:
+                                              description: The name of the header.
+                                              type: string
+                                            headerValue:
+                                              description: The value of the header
+                                                to add.
+                                              type: string
+                                            replace:
+                                              description: |-
+                                                If false, headerValue is appended to any values that already exist for the
+                                                header. If true, headerValue is set for the header, discarding any values that
+                                                were set for that header.
+                                              type: boolean
+                                          required:
+                                          - headerName
+                                          - headerValue
+                                          - replace
+                                          type: object
+                                        type: array
+                                      requestHeadersToRemove:
+                                        description: |-
+                                          A list of header names for headers that need to be removed from the request
+                                          prior to forwarding the request to the backendService.
+                                        items:
+                                          type: string
+                                        type: array
+                                      responseHeadersToAdd:
+                                        description: Headers to add the response prior
+                                          to sending the response back to the client.
+                                        items:
+                                          properties:
+                                            headerName:
+                                              description: The name of the header.
+                                              type: string
+                                            headerValue:
+                                              description: The value of the header
+                                                to add.
+                                              type: string
+                                            replace:
+                                              description: |-
+                                                If false, headerValue is appended to any values that already exist for the
+                                                header. If true, headerValue is set for the header, discarding any values that
+                                                were set for that header.
+                                              type: boolean
+                                          required:
+                                          - headerName
+                                          - headerValue
+                                          - replace
+                                          type: object
+                                        type: array
+                                      responseHeadersToRemove:
+                                        description: |-
+                                          A list of header names for headers that need to be removed from the response
+                                          prior to sending the response back to the client.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      Specifies the fraction of traffic sent to backendService, computed as weight /
+                                      (sum of all weightedBackendService weights in routeAction) . The selection of a
+                                      backend service is determined only for new traffic. Once a user's request has
+                                      been directed to a backendService, subsequent requests will be sent to the same
+                                      backendService as determined by the BackendService's session affinity policy.
+                                      The value must be between 0 and 1000
+                                    type: integer
+                                required:
+                                - backendServiceRef
+                                - weight
+                                type: object
+                              type: array
+                          type: object
+                        service:
+                          properties:
+                            backendBucketRef:
+                              oneOf:
+                              - not:
+                                  required:
+                                  - external
+                                required:
+                                - name
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - name
+                                  - required:
+                                    - namespace
+                                required:
+                                - external
+                              properties:
+                                external:
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                              type: object
+                            backendServiceRef:
+                              oneOf:
+                              - not:
+                                  required:
+                                  - external
+                                required:
+                                - name
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - name
+                                  - required:
+                                    - namespace
+                                required:
+                                - external
+                              properties:
+                                external:
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                              type: object
+                          type: object
+                        urlRedirect:
+                          description: |-
+                            When a path pattern is matched, the request is redirected to a URL specified by
+                            urlRedirect. If urlRedirect is specified, service or routeAction must not be
+                            set.
+                          properties:
+                            hostRedirect:
+                              description: |-
+                                The host that will be used in the redirect response instead of the one that was
+                                supplied in the request. The value must be between 1 and 255 characters.
+                              type: string
+                            httpsRedirect:
+                              description: |-
+                                If set to true, the URL scheme in the redirected request is set to https. If set
+                                to false, the URL scheme of the redirected request will remain the same as that
+                                of the request. This must only be set for UrlMaps used in TargetHttpProxys.
+                                Setting this true for TargetHttpsProxy is not permitted. Defaults to false.
+                              type: boolean
+                            pathRedirect:
+                              description: |-
+                                The path that will be used in the redirect response instead of the one that was
+                                supplied in the request. Only one of pathRedirect or prefixRedirect must be
+                                specified. The value must be between 1 and 1024 characters.
+                              type: string
+                            prefixRedirect:
+                              description: |-
+                                The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
+                                retaining the remaining portion of the URL before redirecting the request.
+                              type: string
+                            redirectResponseCode:
+                              description: |-
+                                The HTTP Status code to use for this RedirectAction. Supported values are:
+                                - MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+                                - FOUND, which corresponds to 302.
+                                - SEE_OTHER which corresponds to 303.
+                                - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                                will be retained.
+                                - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                                the request method will be retained.
+                              type: string
+                            stripQuery:
+                              description: |-
+                                If set to true, any accompanying query portion of the original URL is removed
+                                prior to redirecting the request. If set to false, the query portion of the
+                                original URL is retained.
+                              type: boolean
+                          required:
+                          - stripQuery
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  routeRules:
+                    description: |-
+                      The list of ordered HTTP route rules. Use this list instead of pathRules when
+                      advanced route matching and routing actions are desired. The order of specifying
+                      routeRules matters: the first rule that matches will cause its specified routing
+                      action to take effect. Within a given pathMatcher, only one of pathRules or
+                      routeRules must be set. routeRules are not supported in UrlMaps intended for
+                      External load balancers.
+                    items:
+                      properties:
+                        headerAction:
+                          description: |-
+                            Specifies changes to request and response headers that need to take effect for
+                            the selected backendService. The headerAction specified here are applied before
+                            the matching pathMatchers[].headerAction and after pathMatchers[].routeRules[].r
+                            outeAction.weightedBackendService.backendServiceWeightAction[].headerAction
+                          properties:
+                            requestHeadersToAdd:
+                              description: |-
+                                Headers to add to a matching request prior to forwarding the request to the
+                                backendService.
+                              items:
+                                properties:
+                                  headerName:
+                                    description: The name of the header.
+                                    type: string
+                                  headerValue:
+                                    description: The value of the header to add.
+                                    type: string
+                                  replace:
+                                    description: |-
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    type: boolean
+                                required:
+                                - headerName
+                                - headerValue
+                                - replace
+                                type: object
+                              type: array
+                            requestHeadersToRemove:
+                              description: |-
+                                A list of header names for headers that need to be removed from the request
+                                prior to forwarding the request to the backendService.
+                              items:
+                                type: string
+                              type: array
+                            responseHeadersToAdd:
+                              description: Headers to add the response prior to sending
+                                the response back to the client.
+                              items:
+                                properties:
+                                  headerName:
+                                    description: The name of the header.
+                                    type: string
+                                  headerValue:
+                                    description: The value of the header to add.
+                                    type: string
+                                  replace:
+                                    description: |-
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    type: boolean
+                                required:
+                                - headerName
+                                - headerValue
+                                - replace
+                                type: object
+                              type: array
+                            responseHeadersToRemove:
+                              description: |-
+                                A list of header names for headers that need to be removed from the response
+                                prior to sending the response back to the client.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        matchRules:
+                          description: The rules for determining a match.
+                          items:
+                            properties:
+                              fullPathMatch:
+                                description: |-
+                                  For satifying the matchRule condition, the path of the request must exactly
+                                  match the value specified in fullPathMatch after removing any query parameters
+                                  and anchor that may be part of the original URL. FullPathMatch must be between 1
+                                  and 1024 characters. Only one of prefixMatch, fullPathMatch or regexMatch must
+                                  be specified.
+                                type: string
+                              headerMatches:
+                                description: |-
+                                  Specifies a list of header match criteria, all of which must match corresponding
+                                  headers in the request.
+                                items:
+                                  properties:
+                                    exactMatch:
+                                      description: |-
+                                        The value should exactly match contents of exactMatch. Only one of exactMatch,
+                                        prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
+                                      type: string
+                                    headerName:
+                                      description: |-
+                                        The name of the HTTP header to match. For matching against the HTTP request's
+                                        authority, use a headerMatch with the header name ":authority". For matching a
+                                        request's method, use the headerName ":method".
+                                      type: string
+                                    invertMatch:
+                                      description: |-
+                                        If set to false, the headerMatch is considered a match if the match criteria
+                                        above are met. If set to true, the headerMatch is considered a match if the
+                                        match criteria above are NOT met. Defaults to false.
+                                      type: boolean
+                                    prefixMatch:
+                                      description: |-
+                                        The value of the header must start with the contents of prefixMatch. Only one of
+                                        exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                                        must be set.
+                                      type: string
+                                    presentMatch:
+                                      description: |-
+                                        A header with the contents of headerName must exist. The match takes place
+                                        whether or not the request's header has a value or not. Only one of exactMatch,
+                                        prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
+                                      type: boolean
+                                    rangeMatch:
+                                      description: |-
+                                        The header value must be an integer and its value must be in the range specified
+                                        in rangeMatch. If the header does not contain an integer, number or is empty,
+                                        the match fails. For example for a range [-5, 0]   - -3 will match.  - 0 will
+                                        not match.  - 0.25 will not match.  - -3someString will not match.   Only one of
+                                        exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                                        must be set.
+                                      properties:
+                                        rangeEnd:
+                                          description: The end of the range (exclusive).
+                                          type: integer
+                                        rangeStart:
+                                          description: The start of the range (inclusive).
+                                          type: integer
+                                      required:
+                                      - rangeEnd
+                                      - rangeStart
+                                      type: object
+                                    regexMatch:
+                                      description: |-
+                                        The value of the header must match the regualar expression specified in
+                                        regexMatch. For regular expression grammar, please see:
+                                        en.cppreference.com/w/cpp/regex/ecmascript  For matching against a port
+                                        specified in the HTTP request, use a headerMatch with headerName set to PORT and
+                                        a regular expression that satisfies the RFC2616 Host header's port specifier.
+                                        Only one of exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or
+                                        rangeMatch must be set.
+                                      type: string
+                                    suffixMatch:
+                                      description: |-
+                                        The value of the header must end with the contents of suffixMatch. Only one of
+                                        exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                                        must be set.
+                                      type: string
+                                  required:
+                                  - headerName
+                                  type: object
+                                type: array
+                              ignoreCase:
+                                description: |-
+                                  Specifies that prefixMatch and fullPathMatch matches are case sensitive.
+                                  Defaults to false.
+                                type: boolean
+                              metadataFilters:
+                                description: |-
+                                  Opaque filter criteria used by Loadbalancer to restrict routing configuration to
+                                  a limited set xDS compliant clients. In their xDS requests to Loadbalancer, xDS
+                                  clients present node metadata. If a match takes place, the relevant routing
+                                  configuration is made available to those proxies. For each metadataFilter in
+                                  this list, if its filterMatchCriteria is set to MATCH_ANY, at least one of the
+                                  filterLabels must match the corresponding label provided in the metadata. If its
+                                  filterMatchCriteria is set to MATCH_ALL, then all of its filterLabels must match
+                                  with corresponding labels in the provided metadata. metadataFilters specified
+                                  here can be overrides those specified in ForwardingRule that refers to this
+                                  UrlMap. metadataFilters only applies to Loadbalancers that have their
+                                  loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+                                items:
+                                  properties:
+                                    filterLabels:
+                                      description: |-
+                                        The list of label value pairs that must match labels in the provided metadata
+                                        based on filterMatchCriteria  This list must not be empty and can have at the
+                                        most 64 entries.
+                                      items:
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of metadata label. The name can have a maximum length of 1024 characters
+                                              and must be at least 1 character long.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              The value of the label must match the specified value. value can have a maximum
+                                              length of 1024 characters.
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    filterMatchCriteria:
+                                      description: |-
+                                        Specifies how individual filterLabel matches within the list of filterLabels
+                                        contribute towards the overall metadataFilter match. Supported values are:
+                                          - MATCH_ANY: At least one of the filterLabels must have a matching label in the
+                                        provided metadata.
+                                          - MATCH_ALL: All filterLabels must have matching labels in
+                                        the provided metadata.
+                                      type: string
+                                  required:
+                                  - filterLabels
+                                  - filterMatchCriteria
+                                  type: object
+                                type: array
+                              prefixMatch:
+                                description: |-
+                                  For satifying the matchRule condition, the request's path must begin with the
+                                  specified prefixMatch. prefixMatch must begin with a /. The value must be
+                                  between 1 and 1024 characters. Only one of prefixMatch, fullPathMatch or
+                                  regexMatch must be specified.
+                                type: string
+                              queryParameterMatches:
+                                description: |-
+                                  Specifies a list of query parameter match criteria, all of which must match
+                                  corresponding query parameters in the request.
+                                items:
+                                  properties:
+                                    exactMatch:
+                                      description: |-
+                                        The queryParameterMatch matches if the value of the parameter exactly matches
+                                        the contents of exactMatch. Only one of presentMatch, exactMatch and regexMatch
+                                        must be set.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        The name of the query parameter to match. The query parameter must exist in the
+                                        request, in the absence of which the request match fails.
+                                      type: string
+                                    presentMatch:
+                                      description: |-
+                                        Specifies that the queryParameterMatch matches if the request contains the query
+                                        parameter, irrespective of whether the parameter has a value or not. Only one of
+                                        presentMatch, exactMatch and regexMatch must be set.
+                                      type: boolean
+                                    regexMatch:
+                                      description: |-
+                                        The queryParameterMatch matches if the value of the parameter matches the
+                                        regular expression specified by regexMatch. For the regular expression grammar,
+                                        please see en.cppreference.com/w/cpp/regex/ecmascript  Only one of presentMatch,
+                                        exactMatch and regexMatch must be set.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              regexMatch:
+                                description: |-
+                                  For satifying the matchRule condition, the path of the request must satisfy the
+                                  regular expression specified in regexMatch after removing any query parameters
+                                  and anchor supplied with the original URL. For regular expression grammar please
+                                  see en.cppreference.com/w/cpp/regex/ecmascript  Only one of prefixMatch,
+                                  fullPathMatch or regexMatch must be specified.
+                                type: string
+                            type: object
+                          type: array
+                        priority:
+                          description: |-
+                            For routeRules within a given pathMatcher, priority determines the order
+                            in which load balancer will interpret routeRules. RouteRules are evaluated
+                            in order of priority, from the lowest to highest number. The priority of
+                            a rule decreases as its number increases (1, 2, 3, N+1). The first rule
+                            that matches the request is applied.
+
+                            You cannot configure two or more routeRules with the same priority.
+                            Priority for each rule must be set to a number between 0 and
+                            2147483647 inclusive.
+
+                            Priority numbers can have gaps, which enable you to add or remove rules
+                            in the future without affecting the rest of the rules. For example,
+                            1, 2, 3, 4, 5, 9, 12, 16 is a valid series of priority numbers to which
+                            you could add rules numbered from 6 to 8, 10 to 11, and 13 to 15 in the
+                            future without any impact on existing rules.
+                          type: integer
+                        routeAction:
+                          description: |-
+                            In response to a matching matchRule, the load balancer performs advanced routing
+                            actions like URL rewrites, header transformations, etc. prior to forwarding the
+                            request to the selected backend. If  routeAction specifies any
+                            weightedBackendServices, service must not be set. Conversely if service is set,
+                            routeAction cannot contain any  weightedBackendServices. Only one of routeAction
+                            or urlRedirect must be set.
+                          properties:
+                            corsPolicy:
+                              description: |-
+                                The specification for allowing client side cross-origin requests. Please see W3C
+                                Recommendation for Cross Origin Resource Sharing
+                              properties:
+                                allowCredentials:
+                                  description: |-
+                                    In response to a preflight request, setting this to true indicates that the
+                                    actual request can include user credentials. This translates to the Access-
+                                    Control-Allow-Credentials header. Defaults to false.
+                                  type: boolean
+                                allowHeaders:
+                                  description: Specifies the content for the Access-Control-Allow-Headers
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowMethods:
+                                  description: Specifies the content for the Access-Control-Allow-Methods
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowOriginRegexes:
+                                  description: |-
+                                    Specifies the regualar expression patterns that match allowed origins. For
+                                    regular expression grammar please see en.cppreference.com/w/cpp/regex/ecmascript
+                                    An origin is allowed if it matches either allow_origins or allow_origin_regex.
+                                  items:
+                                    type: string
+                                  type: array
+                                allowOrigins:
+                                  description: |-
+                                    Specifies the list of origins that will be allowed to do CORS requests. An
+                                    origin is allowed if it matches either allow_origins or allow_origin_regex.
+                                  items:
+                                    type: string
+                                  type: array
+                                disabled:
+                                  description: |-
+                                    If true, specifies the CORS policy is disabled.
+                                    which indicates that the CORS policy is in effect. Defaults to false.
+                                  type: boolean
+                                exposeHeaders:
+                                  description: Specifies the content for the Access-Control-Expose-Headers
+                                    header.
+                                  items:
+                                    type: string
+                                  type: array
+                                maxAge:
+                                  description: |-
+                                    Specifies how long the results of a preflight request can be cached. This
+                                    translates to the content for the Access-Control-Max-Age header.
+                                  type: integer
+                              type: object
+                            faultInjectionPolicy:
+                              description: |-
+                                The specification for fault injection introduced into traffic to test the
+                                resiliency of clients to backend service failure. As part of fault injection,
+                                when clients send requests to a backend service, delays can be introduced by
+                                Loadbalancer on a percentage of requests before sending those request to the
+                                backend service. Similarly requests from clients can be aborted by the
+                                Loadbalancer for a percentage of requests. timeout and retry_policy will be
+                                ignored by clients that are configured with a fault_injection_policy.
+                              properties:
+                                abort:
+                                  description: |-
+                                    The specification for how client requests are aborted as part of fault
+                                    injection.
+                                  properties:
+                                    httpStatus:
+                                      description: |-
+                                        The HTTP status code used to abort the request. The value must be between 200
+                                        and 599 inclusive.
+                                      type: integer
+                                    percentage:
+                                      description: |-
+                                        The percentage of traffic (connections/operations/requests) which will be
+                                        aborted as part of fault injection. The value must be between 0.0 and 100.0
+                                        inclusive.
+                                      type: number
+                                  type: object
+                                delay:
+                                  description: |-
+                                    The specification for how client requests are delayed as part of fault
+                                    injection, before being sent to a backend service.
+                                  properties:
+                                    fixedDelay:
+                                      description: Specifies the value of the fixed
+                                        delay interval.
+                                      properties:
+                                        nanos:
+                                          description: |-
+                                            Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                            less than one second are represented with a 0 'seconds' field and a positive
+                                            'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                          type: integer
+                                        seconds:
+                                          description: |-
+                                            Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                            inclusive.
+                                          type: string
+                                      required:
+                                      - seconds
+                                      type: object
+                                    percentage:
+                                      description: |-
+                                        The percentage of traffic (connections/operations/requests) on which delay will
+                                        be introduced as part of fault injection. The value must be between 0.0 and
+                                        100.0 inclusive.
+                                      type: number
+                                  type: object
+                              type: object
+                            requestMirrorPolicy:
+                              description: |-
+                                Specifies the policy on how requests intended for the route's backends are
+                                shadowed to a separate mirrored backend service. Loadbalancer does not wait for
+                                responses from the shadow service. Prior to sending traffic to the shadow
+                                service, the host / authority header is suffixed with -shadow.
+                              properties:
+                                backendService:
+                                  description: The BackendService resource being mirrored
+                                    to.
+                                  type: string
+                              required:
+                              - backendService
+                              type: object
+                            retryPolicy:
+                              description: Specifies the retry policy associated with
+                                this route.
+                              properties:
+                                numRetries:
+                                  description: Specifies the allowed number retries.
+                                    This number must be > 0.
+                                  type: integer
+                                perTryTimeout:
+                                  description: |-
+                                    Specifies a non-zero timeout per retry attempt.
+                                    If not specified, will use the timeout set in HttpRouteAction. If timeout in HttpRouteAction
+                                    is not set, will use the largest timeout among all backend services associated with the route.
+                                  properties:
+                                    nanos:
+                                      description: |-
+                                        Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                        less than one second are represented with a 0 'seconds' field and a positive
+                                        'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                      type: integer
+                                    seconds:
+                                      description: |-
+                                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                        inclusive.
+                                      type: string
+                                  required:
+                                  - seconds
+                                  type: object
+                                retryConditions:
+                                  description: |-
+                                    Specfies one or more conditions when this retry rule applies. Valid values are:
+                                    - 5xx: Loadbalancer will attempt a retry if the backend service responds with
+                                      any 5xx response code, or if the backend service does not respond at all,
+                                      example: disconnects, reset, read timeout, connection failure, and refused
+                                      streams.
+                                    - gateway-error: Similar to 5xx, but only applies to response codes
+                                      502, 503 or 504.
+                                    - connect-failure: Loadbalancer will retry on failures
+                                      connecting to backend services, for example due to connection timeouts.
+                                    - retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                                      Currently the only retriable error supported is 409.
+                                    - refused-stream: Loadbalancer will retry if the backend service resets the stream with a
+                                      REFUSED_STREAM error code. This reset type indicates that it is safe to retry.
+                                    - cancelled: Loadbalancer will retry if the gRPC status code in the response
+                                      header is set to cancelled
+                                    - deadline-exceeded: Loadbalancer will retry if the
+                                      gRPC status code in the response header is set to deadline-exceeded
+                                    - resource-exhausted: Loadbalancer will retry if the gRPC status code in the response
+                                      header is set to resource-exhausted
+                                    - unavailable: Loadbalancer will retry if the gRPC status code in
+                                      the response header is set to unavailable
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - numRetries
+                              type: object
+                            timeout:
+                              description: |-
+                                Specifies the timeout for the selected route. Timeout is computed from the time
+                                the request is has been fully processed (i.e. end-of-stream) up until the
+                                response has been completely processed. Timeout includes all retries. If not
+                                specified, the default value is 15 seconds.
+                              properties:
+                                nanos:
+                                  description: |-
+                                    Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                    less than one second are represented with a 0 'seconds' field and a positive
+                                    'nanos' field. Must be from 0 to 999,999,999 inclusive.
+                                  type: integer
+                                seconds:
+                                  description: |-
+                                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                    inclusive.
+                                  type: string
+                              required:
+                              - seconds
+                              type: object
+                            urlRewrite:
+                              description: |-
+                                The spec to modify the URL of the request, prior to forwarding the request to
+                                the matched service
+                              properties:
+                                hostRewrite:
+                                  description: |-
+                                    Prior to forwarding the request to the selected service, the request's host
+                                    header is replaced with contents of hostRewrite. The value must be between 1 and
+                                    255 characters.
+                                  type: string
+                                pathPrefixRewrite:
+                                  description: |-
+                                    Prior to forwarding the request to the selected backend service, the matching
+                                    portion of the request's path is replaced by pathPrefixRewrite. The value must
+                                    be between 1 and 1024 characters.
+                                  type: string
+                              type: object
+                            weightedBackendServices:
+                              description: |-
+                                A list of weighted backend services to send traffic to when a route match
+                                occurs. The weights determine the fraction of traffic that flows to their
+                                corresponding backend service. If all traffic needs to go to a single backend
+                                service, there must be one  weightedBackendService with weight set to a non 0
+                                number. Once a backendService is identified and before forwarding the request to
+                                the backend service, advanced routing actions like Url rewrites and header
+                                transformations are applied depending on additional settings specified in this
+                                HttpRouteAction.
+                              items:
+                                properties:
+                                  backendServiceRef:
+                                    oneOf:
+                                    - not:
+                                        required:
+                                        - external
+                                      required:
+                                      - name
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - name
+                                        - required:
+                                          - namespace
+                                      required:
+                                      - external
+                                    properties:
+                                      external:
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      namespace:
+                                        description: 'Namespace of the referent. More
+                                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                        type: string
+                                    type: object
+                                  headerAction:
+                                    description: |-
+                                      Specifies changes to request and response headers that need to take effect for
+                                      the selected backendService. headerAction specified here take effect before
+                                      headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+                                    properties:
+                                      requestHeadersToAdd:
+                                        description: |-
+                                          Headers to add to a matching request prior to forwarding the request to the
+                                          backendService.
+                                        items:
+                                          properties:
+                                            headerName:
+                                              description: The name of the header.
+                                              type: string
+                                            headerValue:
+                                              description: The value of the header
+                                                to add.
+                                              type: string
+                                            replace:
+                                              description: |-
+                                                If false, headerValue is appended to any values that already exist for the
+                                                header. If true, headerValue is set for the header, discarding any values that
+                                                were set for that header.
+                                              type: boolean
+                                          required:
+                                          - headerName
+                                          - headerValue
+                                          - replace
+                                          type: object
+                                        type: array
+                                      requestHeadersToRemove:
+                                        description: |-
+                                          A list of header names for headers that need to be removed from the request
+                                          prior to forwarding the request to the backendService.
+                                        items:
+                                          type: string
+                                        type: array
+                                      responseHeadersToAdd:
+                                        description: Headers to add the response prior
+                                          to sending the response back to the client.
+                                        items:
+                                          properties:
+                                            headerName:
+                                              description: The name of the header.
+                                              type: string
+                                            headerValue:
+                                              description: The value of the header
+                                                to add.
+                                              type: string
+                                            replace:
+                                              description: |-
+                                                If false, headerValue is appended to any values that already exist for the
+                                                header. If true, headerValue is set for the header, discarding any values that
+                                                were set for that header.
+                                              type: boolean
+                                          required:
+                                          - headerName
+                                          - headerValue
+                                          - replace
+                                          type: object
+                                        type: array
+                                      responseHeadersToRemove:
+                                        description: |-
+                                          A list of header names for headers that need to be removed from the response
+                                          prior to sending the response back to the client.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      Specifies the fraction of traffic sent to backendService, computed as weight /
+                                      (sum of all weightedBackendService weights in routeAction) . The selection of a
+                                      backend service is determined only for new traffic. Once a user's request has
+                                      been directed to a backendService, subsequent requests will be sent to the same
+                                      backendService as determined by the BackendService's session affinity policy.
+                                      The value must be between 0 and 1000
+                                    type: integer
+                                required:
+                                - backendServiceRef
+                                - weight
+                                type: object
+                              type: array
+                          type: object
+                        service:
+                          description: |-
+                            The backend service resource to which traffic is
+                            directed if this rule is matched. If routeAction is additionally specified,
+                            advanced routing actions like URL Rewrites, etc. take effect prior to sending
+                            the request to the backend. However, if service is specified, routeAction cannot
+                            contain any weightedBackendService s. Conversely, if routeAction specifies any
+                            weightedBackendServices, service must not be specified. Only one of urlRedirect,
+                            service or routeAction.weightedBackendService must be set.
+                          type: string
+                        urlRedirect:
+                          description: |-
+                            When this rule is matched, the request is redirected to a URL specified by
+                            urlRedirect. If urlRedirect is specified, service or routeAction must not be
+                            set.
+                          properties:
+                            hostRedirect:
+                              description: |-
+                                The host that will be used in the redirect response instead of the one that was
+                                supplied in the request. The value must be between 1 and 255 characters.
+                              type: string
+                            httpsRedirect:
+                              description: |-
+                                If set to true, the URL scheme in the redirected request is set to https. If set
+                                to false, the URL scheme of the redirected request will remain the same as that
+                                of the request. This must only be set for UrlMaps used in TargetHttpProxys.
+                                Setting this true for TargetHttpsProxy is not permitted. Defaults to false.
+                              type: boolean
+                            pathRedirect:
+                              description: |-
+                                The path that will be used in the redirect response instead of the one that was
+                                supplied in the request. Only one of pathRedirect or prefixRedirect must be
+                                specified. The value must be between 1 and 1024 characters.
+                              type: string
+                            prefixRedirect:
+                              description: |-
+                                The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
+                                retaining the remaining portion of the URL before redirecting the request.
+                              type: string
+                            redirectResponseCode:
+                              description: |-
+                                The HTTP Status code to use for this RedirectAction. Supported values are:   -
+                                MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.  -
+                                FOUND, which corresponds to 302.  - SEE_OTHER which corresponds to 303.  -
+                                TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                                will be retained.  - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                                the request method will be retained.
+                              type: string
+                            stripQuery:
+                              description: |-
+                                If set to true, any accompanying query portion of the original URL is removed
+                                prior to redirecting the request. If set to false, the query portion of the
+                                original URL is retained. Defaults to false.
+                              type: boolean
+                          type: object
+                      required:
+                      - priority
+                      type: object
+                    type: array
+                required:
+                - name
+                type: object
+              type: array
+            test:
+              description: |-
+                The list of expected URL mapping tests. Request to update this UrlMap will
+                succeed only if all of the test cases pass. You can specify a maximum of 100
+                tests per UrlMap.
+              items:
+                properties:
+                  description:
+                    description: Description of this test case.
+                    type: string
+                  host:
+                    description: Host portion of the URL.
+                    type: string
+                  path:
+                    description: Path portion of the URL.
+                    type: string
+                  service:
+                    properties:
+                      backendBucketRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                      backendServiceRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - host
+                - path
+                - service
+                type: object
+              type: array
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            fingerprint:
+              description: |-
+                Fingerprint of this resource. A hash of the contents stored in this object. This
+                field is used in optimistic locking.
+              type: string
+            mapId:
+              description: The unique identifier for the resource.
+              type: integer
+            selfLink:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computevpngateways.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeVPNGateway
+    plural: computevpngateways
+    shortNames:
+    - gcpcomputevpngateway
+    - gcpcomputevpngateways
+    singular: computevpngateway
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            region:
+              description: The region this gateway should sit in.
+              type: string
+          required:
+          - networkRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+            vpnInterfaces:
+              description: A list of interfaces on this VPN gateway.
+              items:
+                properties:
+                  id:
+                    description: The numeric ID of this VPN gateway interface.
+                    type: integer
+                  ipAddress:
+                    description: The external IP address for this VPN gateway interface.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: computevpntunnels.compute.cnrm.cloud.google.com
+spec:
+  group: compute.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ComputeVPNTunnel
+    plural: computevpntunnels
+    shortNames:
+    - gcpcomputevpntunnel
+    - gcpcomputevpntunnels
+    singular: computevpntunnel
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              description: An optional description of this resource.
+              type: string
+            ikeVersion:
+              description: |-
+                IKE protocol version to use when establishing the VPN tunnel with
+                peer VPN gateway.
+                Acceptable IKE versions are 1 or 2. Default version is 2.
+              type: integer
+            localTrafficSelector:
+              description: |-
+                Local traffic selector to use when establishing the VPN tunnel with
+                peer VPN gateway. The value should be a CIDR formatted string,
+                for example '192.168.0.0/16'. The ranges should be disjoint.
+                Only IPv4 is supported.
+              items:
+                type: string
+              type: array
+            peerExternalGatewayInterface:
+              description: The interface ID of the external VPN gateway to which this
+                VPN tunnel is connected.
+              type: integer
+            peerExternalGatewayRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            peerGCPGatewayRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            peerIp:
+              description: IP address of the peer VPN gateway. Only IPv4 is supported.
+              type: string
+            region:
+              description: The region where the tunnel is located. If unset, is set
+                to the region of 'target_vpn_gateway'.
+              type: string
+            remoteTrafficSelector:
+              description: |-
+                Remote traffic selector to use when establishing the VPN tunnel with
+                peer VPN gateway. The value should be a CIDR formatted string,
+                for example '192.168.0.0/16'. The ranges should be disjoint.
+                Only IPv4 is supported.
+              items:
+                type: string
+              type: array
+            routerRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            sharedSecret:
+              description: |-
+                Shared secret used to set the secure session between the Cloud VPN
+                gateway and the peer VPN gateway.
+              oneOf:
+              - not:
+                  required:
+                  - valueFrom
+                required:
+                - value
+              - not:
+                  required:
+                  - value
+                required:
+                - valueFrom
+              properties:
+                value:
+                  description: Value of the field. Cannot be used if 'valueFrom' is
+                    specified.
+                  type: string
+                valueFrom:
+                  description: Source for the field's value. Cannot be used if 'value'
+                    is specified.
+                  properties:
+                    secretKeyRef:
+                      description: Reference to a value with the given key in the
+                        given Secret in the resource's namespace.
+                      properties:
+                        key:
+                          description: Key that identifies the value to be extracted.
+                          type: string
+                        name:
+                          description: Name of the Secret to extract a value from.
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+              type: object
+            targetVPNGatewayRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            vpnGatewayInterface:
+              description: The interface ID of the VPN gateway with which this VPN
+                tunnel is associated.
+              type: integer
+            vpnGatewayRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - sharedSecret
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            creationTimestamp:
+              description: Creation timestamp in RFC3339 text format.
+              type: string
+            detailedStatus:
+              description: Detailed status message for the VPN tunnel.
+              type: string
+            labelFingerprint:
+              description: |-
+                The fingerprint used for optimistic locking of this resource.  Used
+                internally during updates.
+              type: string
+            selfLink:
+              type: string
+            sharedSecretHash:
+              description: Hash of the shared secret.
+              type: string
+            tunnelId:
+              description: The unique identifier for the resource. This identifier
+                is defined by the server.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: containerclusters.container.cnrm.cloud.google.com
+spec:
+  group: container.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ContainerCluster
+    plural: containerclusters
+    shortNames:
+    - gcpcontainercluster
+    - gcpcontainerclusters
+    singular: containercluster
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            addonsConfig:
+              properties:
+                cloudrunConfig:
+                  properties:
+                    disabled:
+                      type: boolean
+                  required:
+                  - disabled
+                  type: object
+                horizontalPodAutoscaling:
+                  properties:
+                    disabled:
+                      type: boolean
+                  required:
+                  - disabled
+                  type: object
+                httpLoadBalancing:
+                  properties:
+                    disabled:
+                      type: boolean
+                  required:
+                  - disabled
+                  type: object
+                istioConfig:
+                  properties:
+                    auth:
+                      type: string
+                    disabled:
+                      type: boolean
+                  required:
+                  - disabled
+                  type: object
+                networkPolicyConfig:
+                  properties:
+                    disabled:
+                      type: boolean
+                  required:
+                  - disabled
+                  type: object
+              type: object
+            authenticatorGroupsConfig:
+              properties:
+                securityGroup:
+                  type: string
+              required:
+              - securityGroup
+              type: object
+            clusterAutoscaling:
+              properties:
+                autoProvisioningDefaults:
+                  properties:
+                    oauthScopes:
+                      items:
+                        type: string
+                      type: array
+                    serviceAccountRef:
+                      oneOf:
+                      - not:
+                          required:
+                          - external
+                        required:
+                        - name
+                      - not:
+                          anyOf:
+                          - required:
+                            - name
+                          - required:
+                            - namespace
+                        required:
+                        - external
+                      properties:
+                        external:
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                      type: object
+                  type: object
+                enabled:
+                  type: boolean
+                resourceLimits:
+                  items:
+                    properties:
+                      maximum:
+                        type: integer
+                      minimum:
+                        type: integer
+                      resourceType:
+                        type: string
+                    required:
+                    - resourceType
+                    type: object
+                  type: array
+              required:
+              - enabled
+              type: object
+            clusterIpv4Cidr:
+              type: string
+            databaseEncryption:
+              properties:
+                keyName:
+                  type: string
+                state:
+                  type: string
+              required:
+              - state
+              type: object
+            defaultMaxPodsPerNode:
+              type: integer
+            description:
+              type: string
+            enableBinaryAuthorization:
+              type: boolean
+            enableIntranodeVisibility:
+              type: boolean
+            enableKubernetesAlpha:
+              type: boolean
+            enableLegacyAbac:
+              type: boolean
+            enableShieldedNodes:
+              type: boolean
+            enableTpu:
+              type: boolean
+            initialNodeCount:
+              type: integer
+            ipAllocationPolicy:
+              properties:
+                clusterIpv4CidrBlock:
+                  type: string
+                clusterSecondaryRangeName:
+                  type: string
+                servicesIpv4CidrBlock:
+                  type: string
+                servicesSecondaryRangeName:
+                  type: string
+              type: object
+            location:
+              type: string
+            loggingService:
+              type: string
+            maintenancePolicy:
+              properties:
+                dailyMaintenanceWindow:
+                  properties:
+                    duration:
+                      type: string
+                    startTime:
+                      type: string
+                  required:
+                  - startTime
+                  type: object
+                recurringWindow:
+                  properties:
+                    endTime:
+                      type: string
+                    recurrence:
+                      type: string
+                    startTime:
+                      type: string
+                  required:
+                  - endTime
+                  - recurrence
+                  - startTime
+                  type: object
+              type: object
+            masterAuth:
+              properties:
+                clientCertificate:
+                  type: string
+                clientCertificateConfig:
+                  properties:
+                    issueClientCertificate:
+                      type: boolean
+                  required:
+                  - issueClientCertificate
+                  type: object
+                clientKey:
+                  type: string
+                clusterCaCertificate:
+                  type: string
+                password:
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                username:
+                  type: string
+              type: object
+            masterAuthorizedNetworksConfig:
+              properties:
+                cidrBlocks:
+                  items:
+                    properties:
+                      cidrBlock:
+                        type: string
+                      displayName:
+                        type: string
+                    required:
+                    - cidrBlock
+                    type: object
+                  type: array
+              type: object
+            minMasterVersion:
+              type: string
+            monitoringService:
+              type: string
+            networkPolicy:
+              properties:
+                enabled:
+                  type: boolean
+                provider:
+                  type: string
+              required:
+              - enabled
+              type: object
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            nodeConfig:
+              properties:
+                diskSizeGb:
+                  type: integer
+                diskType:
+                  type: string
+                guestAccelerator:
+                  items:
+                    properties:
+                      count:
+                        type: integer
+                      type:
+                        type: string
+                    required:
+                    - count
+                    - type
+                    type: object
+                  type: array
+                imageType:
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                localSsdCount:
+                  type: integer
+                machineType:
+                  type: string
+                metadata:
+                  additionalProperties:
+                    type: string
+                  type: object
+                minCpuPlatform:
+                  type: string
+                oauthScopes:
+                  items:
+                    type: string
+                  type: array
+                preemptible:
+                  type: boolean
+                sandboxConfig:
+                  properties:
+                    sandboxType:
+                      type: string
+                  required:
+                  - sandboxType
+                  type: object
+                serviceAccountRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                shieldedInstanceConfig:
+                  properties:
+                    enableIntegrityMonitoring:
+                      type: boolean
+                    enableSecureBoot:
+                      type: boolean
+                  type: object
+                tags:
+                  items:
+                    type: string
+                  type: array
+                taint:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - effect
+                    - key
+                    - value
+                    type: object
+                  type: array
+                workloadMetadataConfig:
+                  properties:
+                    nodeMetadata:
+                      type: string
+                  required:
+                  - nodeMetadata
+                  type: object
+              type: object
+            nodeLocations:
+              items:
+                type: string
+              type: array
+            nodeVersion:
+              type: string
+            podSecurityPolicyConfig:
+              properties:
+                enabled:
+                  type: boolean
+              required:
+              - enabled
+              type: object
+            privateClusterConfig:
+              properties:
+                enablePrivateEndpoint:
+                  type: boolean
+                enablePrivateNodes:
+                  type: boolean
+                masterIpv4CidrBlock:
+                  type: string
+                peeringName:
+                  type: string
+                privateEndpoint:
+                  type: string
+                publicEndpoint:
+                  type: string
+              required:
+              - enablePrivateEndpoint
+              type: object
+            releaseChannel:
+              properties:
+                channel:
+                  type: string
+              required:
+              - channel
+              type: object
+            resourceUsageExportConfig:
+              properties:
+                bigqueryDestination:
+                  properties:
+                    datasetId:
+                      type: string
+                  required:
+                  - datasetId
+                  type: object
+                enableNetworkEgressMetering:
+                  type: boolean
+              required:
+              - bigqueryDestination
+              type: object
+            subnetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            verticalPodAutoscaling:
+              properties:
+                enabled:
+                  type: boolean
+              required:
+              - enabled
+              type: object
+            workloadIdentityConfig:
+              properties:
+                identityNamespace:
+                  type: string
+              required:
+              - identityNamespace
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            endpoint:
+              type: string
+            instanceGroupUrls:
+              items:
+                type: string
+              type: array
+            labelFingerprint:
+              type: string
+            masterVersion:
+              type: string
+            operation:
+              type: string
+            servicesIpv4Cidr:
+              type: string
+            tpuIpv4CidrBlock:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: containernodepools.container.cnrm.cloud.google.com
+spec:
+  group: container.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ContainerNodePool
+    plural: containernodepools
+    shortNames:
+    - gcpcontainernodepool
+    - gcpcontainernodepools
+    singular: containernodepool
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            autoscaling:
+              properties:
+                maxNodeCount:
+                  type: integer
+                minNodeCount:
+                  type: integer
+              required:
+              - maxNodeCount
+              - minNodeCount
+              type: object
+            clusterRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            initialNodeCount:
+              type: integer
+            location:
+              type: string
+            management:
+              properties:
+                autoRepair:
+                  type: boolean
+                autoUpgrade:
+                  type: boolean
+              type: object
+            maxPodsPerNode:
+              type: integer
+            namePrefix:
+              type: string
+            nodeConfig:
+              properties:
+                diskSizeGb:
+                  type: integer
+                diskType:
+                  type: string
+                guestAccelerator:
+                  items:
+                    properties:
+                      count:
+                        type: integer
+                      type:
+                        type: string
+                    required:
+                    - count
+                    - type
+                    type: object
+                  type: array
+                imageType:
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                localSsdCount:
+                  type: integer
+                machineType:
+                  type: string
+                metadata:
+                  additionalProperties:
+                    type: string
+                  type: object
+                minCpuPlatform:
+                  type: string
+                oauthScopes:
+                  items:
+                    type: string
+                  type: array
+                preemptible:
+                  type: boolean
+                sandboxConfig:
+                  properties:
+                    sandboxType:
+                      type: string
+                  required:
+                  - sandboxType
+                  type: object
+                serviceAccountRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+                shieldedInstanceConfig:
+                  properties:
+                    enableIntegrityMonitoring:
+                      type: boolean
+                    enableSecureBoot:
+                      type: boolean
+                  type: object
+                tags:
+                  items:
+                    type: string
+                  type: array
+                taint:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - effect
+                    - key
+                    - value
+                    type: object
+                  type: array
+                workloadMetadataConfig:
+                  properties:
+                    nodeMetadata:
+                      type: string
+                  required:
+                  - nodeMetadata
+                  type: object
+              type: object
+            nodeCount:
+              type: integer
+            nodeLocations:
+              items:
+                type: string
+              type: array
+            upgradeSettings:
+              properties:
+                maxSurge:
+                  type: integer
+                maxUnavailable:
+                  type: integer
+              required:
+              - maxSurge
+              - maxUnavailable
+              type: object
+            version:
+              type: string
+          required:
+          - clusterRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            instanceGroupUrls:
+              items:
+                type: string
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: dataflowjobs.dataflow.cnrm.cloud.google.com
+spec:
+  group: dataflow.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: DataflowJob
+    plural: dataflowjobs
+    shortNames:
+    - gcpdataflowjob
+    - gcpdataflowjobs
+    singular: dataflowjob
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            ipConfiguration:
+              type: string
+            machineType:
+              type: string
+            maxWorkers:
+              type: integer
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            parameters:
+              type: object
+            region:
+              type: string
+            serviceAccountRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            subnetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            tempGcsLocation:
+              type: string
+            templateGcsPath:
+              type: string
+            zone:
+              type: string
+          required:
+          - tempGcsLocation
+          - templateGcsPath
+          - zone
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            jobId:
+              type: string
+            state:
+              type: string
+            type:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: dnsmanagedzones.dns.cnrm.cloud.google.com
+spec:
+  group: dns.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: DNSManagedZone
+    plural: dnsmanagedzones
+    shortNames:
+    - gcpdnsmanagedzone
+    - gcpdnsmanagedzones
+    singular: dnsmanagedzone
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            dnsName:
+              description: The DNS name of this managed zone, for instance "example.com.".
+              type: string
+            dnssecConfig:
+              description: DNSSEC configuration
+              properties:
+                defaultKeySpecs:
+                  description: |-
+                    Specifies parameters that will be used for generating initial DnsKeys
+                    for this ManagedZone. If you provide a spec for keySigning or zoneSigning,
+                    you must also provide one for the other.
+                  items:
+                    properties:
+                      algorithm:
+                        description: String mnemonic specifying the DNSSEC algorithm
+                          of this key
+                        type: string
+                      keyLength:
+                        description: Length of the keys in bits
+                        type: integer
+                      keyType:
+                        description: |-
+                          Specifies whether this is a key signing key (KSK) or a zone
+                          signing key (ZSK). Key signing keys have the Secure Entry
+                          Point flag set and, when active, will only be used to sign
+                          resource record sets of type DNSKEY. Zone signing keys do
+                          not have the Secure Entry Point flag set and will be used
+                          to sign all other types of resource record sets.
+                        type: string
+                      kind:
+                        description: Identifies what kind of resource this is
+                        type: string
+                    type: object
+                  type: array
+                kind:
+                  description: Identifies what kind of resource this is
+                  type: string
+                nonExistence:
+                  description: Specifies the mechanism used to provide authenticated
+                    denial-of-existence responses.
+                  type: string
+                state:
+                  description: Specifies whether DNSSEC is enabled, and what mode
+                    it is in
+                  type: string
+              type: object
+            forwardingConfig:
+              description: |-
+                The presence for this field indicates that outbound forwarding is enabled
+                for this zone. The value of this field contains the set of destinations
+                to forward to.
+              properties:
+                targetNameServers:
+                  description: |-
+                    List of target name servers to forward to. Cloud DNS will
+                    select the best available name server if more than
+                    one target is given.
+                  items:
+                    properties:
+                      ipv4Address:
+                        description: IPv4 address of a target name server.
+                        type: string
+                    required:
+                    - ipv4Address
+                    type: object
+                  type: array
+              required:
+              - targetNameServers
+              type: object
+            peeringConfig:
+              description: |-
+                The presence of this field indicates that DNS Peering is enabled for this
+                zone. The value of this field contains the network to peer with.
+              properties:
+                targetNetwork:
+                  description: The network with which to peer.
+                  properties:
+                    networkRef:
+                      oneOf:
+                      - not:
+                          required:
+                          - external
+                        required:
+                        - name
+                      - not:
+                          anyOf:
+                          - required:
+                            - name
+                          - required:
+                            - namespace
+                        required:
+                        - external
+                      properties:
+                        external:
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                      type: object
+                  required:
+                  - networkRef
+                  type: object
+              required:
+              - targetNetwork
+              type: object
+            privateVisibilityConfig:
+              description: |-
+                For privately visible zones, the set of Virtual Private Cloud
+                resources that the zone is visible from.
+              properties:
+                networks:
+                  items:
+                    properties:
+                      networkRef:
+                        oneOf:
+                        - not:
+                            required:
+                            - external
+                          required:
+                          - name
+                        - not:
+                            anyOf:
+                            - required:
+                              - name
+                            - required:
+                              - namespace
+                          required:
+                          - external
+                        properties:
+                          external:
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        type: object
+                    required:
+                    - networkRef
+                    type: object
+                  type: array
+              required:
+              - networks
+              type: object
+            visibility:
+              description: |-
+                The zone's visibility: public zones are exposed to the Internet,
+                while private zones are visible only to Virtual Private Cloud resources.
+                Must be one of: 'public', 'private'.
+              type: string
+          required:
+          - dnsName
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            nameServers:
+              description: |-
+                Delegate your managed_zone to these virtual name servers;
+                defined by the server
+              items:
+                type: string
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: dnspolicies.dns.cnrm.cloud.google.com
+spec:
+  group: dns.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: DNSPolicy
+    plural: dnspolicies
+    shortNames:
+    - gcpdnspolicy
+    - gcpdnspolicies
+    singular: dnspolicy
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            alternativeNameServerConfig:
+              description: |-
+                Sets an alternative name server for the associated networks.
+                When specified, all DNS queries are forwarded to a name server that you choose.
+                Names such as .internal are not available when an alternative name server is specified.
+              properties:
+                targetNameServers:
+                  description: |-
+                    Sets an alternative name server for the associated networks. When specified,
+                    all DNS queries are forwarded to a name server that you choose. Names such as .internal
+                    are not available when an alternative name server is specified.
+                  items:
+                    properties:
+                      ipv4Address:
+                        description: IPv4 address to forward to.
+                        type: string
+                    required:
+                    - ipv4Address
+                    type: object
+                  type: array
+              required:
+              - targetNameServers
+              type: object
+            description:
+              type: string
+            enableInboundForwarding:
+              description: |-
+                Allows networks bound to this policy to receive DNS queries sent
+                by VMs or applications over VPN connections. When enabled, a
+                virtual IP address will be allocated from each of the sub-networks
+                that are bound to this policy.
+              type: boolean
+            enableLogging:
+              description: |-
+                Controls whether logging is enabled for the networks bound to this policy.
+                Defaults to no logging if not set.
+              type: boolean
+            networks:
+              description: List of network names specifying networks to which this
+                policy is applied.
+              items:
+                properties:
+                  networkRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                required:
+                - networkRef
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: dnsrecordsets.dns.cnrm.cloud.google.com
+spec:
+  group: dns.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: DNSRecordSet
+    plural: dnsrecordsets
+    shortNames:
+    - gcpdnsrecordset
+    - gcpdnsrecordsets
+    singular: dnsrecordset
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            managedZoneRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            name:
+              type: string
+            rrdatas:
+              items:
+                type: string
+              type: array
+            ttl:
+              type: integer
+            type:
+              type: string
+          required:
+          - managedZoneRef
+          - name
+          - rrdatas
+          - ttl
+          - type
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: firestoreindexes.firestore.cnrm.cloud.google.com
+spec:
+  group: firestore.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: FirestoreIndex
+    plural: firestoreindexes
+    shortNames:
+    - gcpfirestoreindex
+    - gcpfirestoreindexes
+    singular: firestoreindex
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            collection:
+              description: The collection being indexed.
+              type: string
+            database:
+              description: The Firestore database id. Defaults to '"(default)"'.
+              type: string
+            fields:
+              description: |-
+                The fields supported by this index. The last field entry is always for
+                the field path '__name__'. If, on creation, '__name__' was not
+                specified as the last field, it will be added automatically with the
+                same direction as that of the last field defined. If the final field
+                in a composite index is not directional, the '__name__' will be
+                ordered '"ASCENDING"' (unless explicitly specified otherwise).
+              items:
+                properties:
+                  arrayConfig:
+                    description: |-
+                      Indicates that this field supports operations on arrayValues. Only one of 'order' and 'arrayConfig' can
+                      be specified.
+                    type: string
+                  fieldPath:
+                    description: Name of the field.
+                    type: string
+                  order:
+                    description: |-
+                      Indicates that this field supports ordering by the specified order or comparing using =, <, <=, >, >=.
+                      Only one of 'order' and 'arrayConfig' can be specified.
+                    type: string
+                type: object
+              type: array
+            queryScope:
+              description: |-
+                The scope at which a query is run. One of '"COLLECTION"' or
+                '"COLLECTION_GROUP"'. Defaults to '"COLLECTION"'.
+              type: string
+          required:
+          - collection
+          - fields
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            name:
+              description: |-
+                A server defined name for this index. Format:
+                'projects/{{project}}/databases/{{database}}/collectionGroups/{{collection}}/indexes/{{server_generated_id}}'
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: folders.resourcemanager.cnrm.cloud.google.com
+spec:
+  group: resourcemanager.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: Folder
+    plural: folders
+    shortNames:
+    - gcpfolder
+    - gcpfolders
+    singular: folder
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            displayName:
+              type: string
+          required:
+          - displayName
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            createTime:
+              type: string
+            lifecycleState:
+              type: string
+            name:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: iamcustomroles.iam.cnrm.cloud.google.com
+spec:
+  group: iam.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: IAMCustomRole
+    plural: iamcustomroles
+    shortNames:
+    - gcpiamcustomrole
+    - gcpiamcustomroles
+    singular: iamcustomrole
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            permissions:
+              items:
+                type: string
+              type: array
+            stage:
+              type: string
+            title:
+              type: string
+          required:
+          - permissions
+          - title
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            deleted:
+              type: boolean
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    controller-tools.k8s.io: "1.0"
+  name: iampolicies.iam.cnrm.cloud.google.com
+spec:
+  group: iam.cnrm.cloud.google.com
+  names:
+    kind: IAMPolicy
+    plural: iampolicies
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bindings:
+              description: Optional. The list of IAM bindings.
+              items:
+                properties:
+                  condition:
+                    description: Optional. The condition under which the binding applies.
+                    properties:
+                      description:
+                        type: string
+                      expression:
+                        type: string
+                      title:
+                        type: string
+                    required:
+                    - title
+                    - expression
+                    type: object
+                  members:
+                    description: Optional. The list of IAM users to be bound to the
+                      role.
+                    items:
+                      pattern: ^(user|serviceAccount|group|domain):.+|allUsers|allAuthenticatedUsers$
+                      type: string
+                    pattern: ^(user|serviceAccount|group|domain):.+|allUsers|allAuthenticatedUsers$
+                    type: array
+                  role:
+                    description: Required. The role to bind the users to.
+                    pattern: ^roles/[\w\.]+$
+                    type: string
+                required:
+                - role
+                type: object
+              type: array
+            resourceRef:
+              description: Required. The GCP resource to set the IAM policy on.
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                  - required:
+                    - apiVersion
+                  - required:
+                    - external
+              properties:
+                apiVersion:
+                  type: string
+                external:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - kind
+              type: object
+          required:
+          - resourceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observations
+                of the IAM policy's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    controller-tools.k8s.io: "1.0"
+  name: iampolicymembers.iam.cnrm.cloud.google.com
+spec:
+  group: iam.cnrm.cloud.google.com
+  names:
+    kind: IAMPolicyMember
+    plural: iampolicymembers
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            condition:
+              description: Optional. The condition under which the binding applies.
+              properties:
+                description:
+                  type: string
+                expression:
+                  type: string
+                title:
+                  type: string
+              required:
+              - title
+              - expression
+              type: object
+            member:
+              description: Required. The list of IAM identities to be bound to the
+                role
+              pattern: ^(user|serviceAccount|group|domain):.+|allUsers|allAuthenticatedUsers$
+              type: string
+            resourceRef:
+              description: Required. The GCP resource to set the IAM policy on.
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                  - required:
+                    - apiVersion
+                  - required:
+                    - external
+              properties:
+                apiVersion:
+                  type: string
+                external:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - kind
+              type: object
+            role:
+              description: Required. The role for which the Member will be bound.
+              pattern: ^roles/[\w\.]+$
+              type: string
+          required:
+          - resourceRef
+          - member
+          - role
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observations
+                of the IAM policy's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: iamserviceaccountkeys.iam.cnrm.cloud.google.com
+spec:
+  group: iam.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: IAMServiceAccountKey
+    plural: iamserviceaccountkeys
+    shortNames:
+    - gcpiamserviceaccountkey
+    - gcpiamserviceaccountkeys
+    singular: iamserviceaccountkey
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            keyAlgorithm:
+              type: string
+            privateKeyType:
+              type: string
+            publicKeyType:
+              type: string
+            serviceAccountRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - serviceAccountRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            name:
+              type: string
+            privateKey:
+              type: string
+            publicKey:
+              type: string
+            validAfter:
+              type: string
+            validBefore:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: iamserviceaccounts.iam.cnrm.cloud.google.com
+spec:
+  group: iam.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: IAMServiceAccount
+    plural: iamserviceaccounts
+    shortNames:
+    - gcpiamserviceaccount
+    - gcpiamserviceaccounts
+    singular: iamserviceaccount
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            displayName:
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            email:
+              type: string
+            name:
+              type: string
+            uniqueId:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: kmscryptokeys.kms.cnrm.cloud.google.com
+spec:
+  group: kms.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: KMSCryptoKey
+    plural: kmscryptokeys
+    shortNames:
+    - gcpkmscryptokey
+    - gcpkmscryptokeys
+    singular: kmscryptokey
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            keyRingRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            purpose:
+              description: |-
+                The immutable purpose of this CryptoKey. See the
+                [purpose reference](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys#CryptoKeyPurpose)
+                for possible inputs.
+              type: string
+            rotationPeriod:
+              description: |-
+                Every time this period passes, generate a new CryptoKeyVersion and set it as the primary.
+                The first rotation will take place after the specified period. The rotation period has
+                the format of a decimal number with up to 9 fractional digits, followed by the
+                letter 's' (seconds). It must be greater than a day (ie, 86400).
+              type: string
+            versionTemplate:
+              description: A template describing settings for new crypto key versions.
+              properties:
+                algorithm:
+                  description: |-
+                    The algorithm to use when creating a version based on this template.
+                    See the [algorithm reference](https://cloud.google.com/kms/docs/reference/rest/v1/CryptoKeyVersionAlgorithm) for possible inputs.
+                  type: string
+                protectionLevel:
+                  description: The protection level to use when creating a version
+                    based on this template.
+                  type: string
+              required:
+              - algorithm
+              type: object
+          required:
+          - keyRingRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: kmskeyrings.kms.cnrm.cloud.google.com
+spec:
+  group: kms.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: KMSKeyRing
+    plural: kmskeyrings
+    shortNames:
+    - gcpkmskeyring
+    - gcpkmskeyrings
+    singular: kmskeyring
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            location:
+              description: |-
+                The location for the KeyRing.
+                A full list of valid locations can be found by running 'gcloud kms locations list'.
+              type: string
+          required:
+          - location
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: projects.resourcemanager.cnrm.cloud.google.com
+spec:
+  group: resourcemanager.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: Project
+    plural: projects
+    shortNames:
+    - gcpproject
+    - gcpprojects
+    singular: project
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            billingAccountRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            name:
+              type: string
+          required:
+          - name
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            number:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: pubsubsubscriptions.pubsub.cnrm.cloud.google.com
+spec:
+  group: pubsub.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: PubSubSubscription
+    plural: pubsubsubscriptions
+    shortNames:
+    - gcppubsubsubscription
+    - gcppubsubsubscriptions
+    singular: pubsubsubscription
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            ackDeadlineSeconds:
+              description: |-
+                This value is the maximum time after a subscriber receives a message
+                before the subscriber should acknowledge the message. After message
+                delivery but before the ack deadline expires and before the message is
+                acknowledged, it is an outstanding message and will not be delivered
+                again during that time (on a best-effort basis).
+
+                For pull subscriptions, this value is used as the initial value for
+                the ack deadline. To override this value for a given message, call
+                subscriptions.modifyAckDeadline with the corresponding ackId if using
+                pull. The minimum custom deadline you can specify is 10 seconds. The
+                maximum custom deadline you can specify is 600 seconds (10 minutes).
+                If this parameter is 0, a default value of 10 seconds is used.
+
+                For push delivery, this value is also used to set the request timeout
+                for the call to the push endpoint.
+
+                If the subscriber never acknowledges the message, the Pub/Sub system
+                will eventually redeliver the message.
+              type: integer
+            expirationPolicy:
+              description: |-
+                A policy that specifies the conditions for this subscription's expiration.
+                A subscription is considered active as long as any connected subscriber
+                is successfully consuming messages from the subscription or is issuing
+                operations on the subscription. If expirationPolicy is not set, a default
+                policy with ttl of 31 days will be used.  If it is set but ttl is "", the
+                resource never expires.  The minimum allowed value for expirationPolicy.ttl
+                is 1 day.
+              properties:
+                ttl:
+                  description: |-
+                    Specifies the "time-to-live" duration for an associated resource. The
+                    resource expires if it is not active for a period of ttl.
+                    If ttl is not set, the associated resource never expires.
+                    A duration in seconds with up to nine fractional digits, terminated by 's'.
+                    Example - "3.5s".
+                  type: string
+              required:
+              - ttl
+              type: object
+            messageRetentionDuration:
+              description: |-
+                How long to retain unacknowledged messages in the subscription's
+                backlog, from the moment a message is published. If
+                retainAckedMessages is true, then this also configures the retention
+                of acknowledged messages, and thus configures how far back in time a
+                subscriptions.seek can be done. Defaults to 7 days. Cannot be more
+                than 7 days ('"604800s"') or less than 10 minutes ('"600s"').
+
+                A duration in seconds with up to nine fractional digits, terminated
+                by 's'. Example: '"600.5s"'.
+              type: string
+            pushConfig:
+              description: |-
+                If push delivery is used with this subscription, this field is used to
+                configure it. An empty pushConfig signifies that the subscriber will
+                pull and ack messages using API methods.
+              properties:
+                attributes:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Endpoint configuration attributes.
+
+                    Every endpoint has a set of API supported attributes that can
+                    be used to control different aspects of the message delivery.
+
+                    The currently supported attribute is x-goog-version, which you
+                    can use to change the format of the pushed message. This
+                    attribute indicates the version of the data expected by
+                    the endpoint. This controls the shape of the pushed message
+                    (i.e., its fields and metadata). The endpoint version is
+                    based on the version of the Pub/Sub API.
+
+                    If not present during the subscriptions.create call,
+                    it will default to the version of the API used to make
+                    such call. If not present during a subscriptions.modifyPushConfig
+                    call, its value will not be changed. subscriptions.get
+                    calls will always return a valid version, even if the
+                    subscription was created without this attribute.
+
+                    The possible values for this attribute are:
+
+                    - v1beta1: uses the push format defined in the v1beta1 Pub/Sub API.
+                    - v1 or v1beta2: uses the push format defined in the v1 Pub/Sub API.
+                  type: object
+                oidcToken:
+                  description: |-
+                    If specified, Pub/Sub will generate and attach an OIDC JWT token as
+                    an Authorization header in the HTTP request for every pushed message.
+                  properties:
+                    audience:
+                      description: |-
+                        Audience to be used when generating OIDC token. The audience claim
+                        identifies the recipients that the JWT is intended for. The audience
+                        value is a single case-sensitive string. Having multiple values (array)
+                        for the audience field is not supported. More info about the OIDC JWT
+                        token audience here: https://tools.ietf.org/html/rfc7519#section-4.1.3
+                        Note: if not specified, the Push endpoint URL will be used.
+                      type: string
+                    serviceAccountEmail:
+                      description: |-
+                        Service account email to be used for generating the OIDC token.
+                        The caller (for subscriptions.create, subscriptions.patch, and
+                        subscriptions.modifyPushConfig RPCs) must have the
+                        iam.serviceAccounts.actAs permission for the service account.
+                      type: string
+                  required:
+                  - serviceAccountEmail
+                  type: object
+                pushEndpoint:
+                  description: |-
+                    A URL locating the endpoint to which messages should be pushed.
+                    For example, a Webhook endpoint might use
+                    "https://example.com/push".
+                  type: string
+              required:
+              - pushEndpoint
+              type: object
+            retainAckedMessages:
+              description: |-
+                Indicates whether to retain acknowledged messages. If 'true', then
+                messages are not expunged from the subscription's backlog, even if
+                they are acknowledged, until they fall out of the
+                messageRetentionDuration window.
+              type: boolean
+            topicRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - topicRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            path:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: pubsubtopics.pubsub.cnrm.cloud.google.com
+spec:
+  group: pubsub.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: PubSubTopic
+    plural: pubsubtopics
+    shortNames:
+    - gcppubsubtopic
+    - gcppubsubtopics
+    singular: pubsubtopic
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            kmsKeyRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            messageStoragePolicy:
+              description: |-
+                Policy constraining the set of Google Cloud Platform regions where
+                messages published to the topic may be stored. If not present, then no
+                constraints are in effect.
+              properties:
+                allowedPersistenceRegions:
+                  description: |-
+                    A list of IDs of GCP regions where messages that are published to
+                    the topic may be persisted in storage. Messages published by
+                    publishers running in non-allowed GCP regions (or running outside
+                    of GCP altogether) will be routed for storage in one of the
+                    allowed regions. An empty list means that no regions are allowed,
+                    and is not a valid configuration.
+                  items:
+                    type: string
+                  type: array
+              required:
+              - allowedPersistenceRegions
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: redisinstances.redis.cnrm.cloud.google.com
+spec:
+  group: redis.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: RedisInstance
+    plural: redisinstances
+    shortNames:
+    - gcpredisinstance
+    - gcpredisinstances
+    singular: redisinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            alternativeLocationId:
+              description: |-
+                Only applicable to STANDARD_HA tier which protects the instance
+                against zonal failures by provisioning it across two zones.
+                If provided, it must be a different zone from the one provided in
+                [locationId].
+              type: string
+            authorizedNetworkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            displayName:
+              description: An arbitrary and optional user-provided name for the instance.
+              type: string
+            locationId:
+              description: |-
+                The zone where the instance will be provisioned. If not provided,
+                the service will choose a zone for the instance. For STANDARD_HA tier,
+                instances will be created across two zones for protection against
+                zonal failures. If [alternativeLocationId] is also provided, it must
+                be different from [locationId].
+              type: string
+            memorySizeGb:
+              description: Redis memory size in GiB.
+              type: integer
+            redisConfigs:
+              additionalProperties:
+                type: string
+              description: |-
+                Redis configuration parameters, according to http://redis.io/topics/config.
+                Please check Memorystore documentation for the list of supported parameters:
+                https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs
+              type: object
+            redisVersion:
+              description: |-
+                The version of Redis software. If not provided, latest supported
+                version will be used. Currently, the supported values are:
+
+                - REDIS_4_0 for Redis 4.0 compatibility
+                - REDIS_3_2 for Redis 3.2 compatibility
+              type: string
+            region:
+              description: The name of the Redis region of the instance.
+              type: string
+            reservedIpRange:
+              description: |-
+                The CIDR range of internal addresses that are reserved for this
+                instance. If not provided, the service will choose an unused /29
+                block, for example, 10.0.0.0/29 or 192.168.0.0/29. Ranges must be
+                unique and non-overlapping with existing subnets in an authorized
+                network.
+              type: string
+            tier:
+              description: |-
+                The service tier of the instance. Must be one of these values:
+
+                - BASIC: standalone instance
+                - STANDARD_HA: highly available primary/replica instances
+              type: string
+          required:
+          - memorySizeGb
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            createTime:
+              description: |-
+                The time the instance was created in RFC3339 UTC "Zulu" format,
+                accurate to nanoseconds.
+              type: string
+            currentLocationId:
+              description: |-
+                The current zone where the Redis endpoint is placed.
+                For Basic Tier instances, this will always be the same as the
+                [locationId] provided by the user at creation time. For Standard Tier
+                instances, this can be either [locationId] or [alternativeLocationId]
+                and can change after a failover event.
+              type: string
+            host:
+              description: |-
+                Hostname or IP address of the exposed Redis endpoint used by clients
+                to connect to the service.
+              type: string
+            port:
+              description: The port number of the exposed Redis endpoint.
+              type: integer
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    controller-tools.k8s.io: "1.0"
+  name: servicemappings.core.cnrm.cloud.google.com
+spec:
+  group: core.cnrm.cloud.google.com
+  names:
+    kind: ServiceMapping
+    plural: servicemappings
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ServiceMappingSpec defines the aspects common to all resources
+            of a particular service being mapped from the Terraform provider to Kubernetes
+            Resource Model (KRM).
+          properties:
+            name:
+              description: Name is the name of the service being mapped (e.g. Spanner,
+                PubSub). This is used for the construction of the generated CRDs'
+                API group and kind.
+              type: string
+            resources:
+              description: Resources is a list of configurations specifying how to
+                map a specific resource from the Terraform provider to KRM.
+              items:
+                properties:
+                  containers:
+                    description: Containers describes all the container mappings this
+                      resource understands. Config Connector maps Kubernetes namespaces
+                      to the abstract GCP container objects they are scoped by via
+                      namespaces. For most resource types, this is a project, but
+                      certain resources live outside the scope of a project, like
+                      folders or projects themselves. Containers are expressed as
+                      annotations on a given Namespace, though users may provide resource-level
+                      overrides.
+                    items:
+                      properties:
+                        tfField:
+                          description: TFField is the path to the field in the underlying
+                            Terraform provider that represents the implicit reference
+                            to the container object. Use periods to delimit the fields
+                            in the path. For example, if the field is "bar" nested
+                            inside "foo" ("foo" being either an object or a list of
+                            objects), the associated TFField should be "foo.bar")
+                          type: string
+                        type:
+                          description: Type is the type of container this represents.
+                          type: string
+                        valueTemplate:
+                          description: ValueTemplate is a template by which the value
+                            of the container annotation should be interpreted before
+                            being passed to the Terraform provider. {{value}} is used
+                            in place of this sourced value.  e.g. If the value sourced
+                            from the container annotation is "123456789", a valueTemplate
+                            of "folders/{{value}}" would mean the final value passed
+                            to the provider is "folders/123456789"
+                          type: string
+                      required:
+                      - type
+                      - tfField
+                      type: object
+                    type: array
+                  directives:
+                    description: Directives is a list of Terraform fields that perform
+                      unique behaviors on top of the resource which are not part of
+                      a GET response. If the KCC annotation's key contains a directive
+                      from this list (e.g. `cnrm.cloud.google.com/force-destroy`),
+                      the value from the annotation is stored/overwritten in the TF
+                      config (e.g. force_destroy -> true)
+                    items:
+                      type: string
+                    type: array
+                  iamConfig:
+                    description: IAMConfig contains the mappings from a given resource
+                      onto its associated terraform IAM resources (policies, bindings,
+                      and members)
+                    properties:
+                      policyMemberName:
+                        description: PolicyMemberName is the terraform name of the
+                          associated IAM Policy Member resource (e.g. google_spanner_instance_iam_member)
+                        type: string
+                      policyName:
+                        description: PolicyName is the terraform name of the associated
+                          IAM Policy resource (e.g. google_spanner_instance_iam_policy)
+                        type: string
+                      referenceField:
+                        description: A description of the manner in which the IAM
+                          Policy references its resource.
+                        properties:
+                          name:
+                            description: The name of the field in the policy or binding
+                              which references the resource. For 'google_spanner_instance_iam_policy'
+                              this value is 'instance'.
+                            type: string
+                          type:
+                            description: The type of value that should be used in
+                              this field. It can be one of { name, id }. For 'google_spanner_instance_iam_policy'
+                              it would be 'name' for 'google_kms_key_ring_iam_policy'
+                              it would be 'id'.
+                            type: string
+                        required:
+                        - name
+                        - type
+                        type: object
+                      supportsConditions:
+                        description: SupportsConditions indicates whether or not the
+                          resource supports IAM Conditions.
+                        type: boolean
+                    required:
+                    - policyName
+                    - policyMemberName
+                    - supportsConditions
+                    type: object
+                  idTemplate:
+                    description: IDTemplate defines the format in which the ID fed
+                      into the TF resource's importer should look. Fields may be sourced
+                      from the TF resource by using the `{{foo}}` syntax. (e.g. {{project}}/{{location}}/{{name}}.
+                      If SkipImport is true, this must be specified, and its expanded
+                      form will be directly used as the TF resource's `id` field.
+                    type: string
+                  ignoredFields:
+                    description: IgnoredFields is a list of fields that should be
+                      dropped from the underlying Terraform resource.
+                    items:
+                      type: string
+                    type: array
+                  kind:
+                    description: Kind is the Kubernetes kind you wish the resource
+                      to have.
+                    type: string
+                  locationality:
+                    description: 'Locationality categorizes the GCP resources as global,
+                      regional, or zonal. It''s only applicable to the effort of unifying
+                      multiple locational TF resources into one, e.g. KCC could have
+                      a single ComputeAddress CRD to represent two TF/GCE resources
+                      - compute address and global compute address. The location field
+                      in ComputeAddress CRD is used to specify whether it is a global
+                      address or regional address. If unset, it''s assumed that there
+                      is no multiple TF locational resources mapping to the same compute
+                      resource schema. Currently, this supports the following values:
+                      global, regional, zonal.'
+                    type: string
+                  metadataMapping:
+                    description: MetadataMapping determines how to map Kubernetes
+                      metadata fields to the Terraform resource's configuration.
+                    properties:
+                      labels:
+                        description: Labels is a JSONPath to the field in the TF resource
+                          where the KRM "metadata.labels" field will be mapped to.
+                          By default, this is mapped to the "labels" field, if that
+                          field is found in the TF resource schema.
+                        type: string
+                      name:
+                        description: Name is a JSONPath to the field in the TF resource
+                          where the KRM "metadata.name" field will be mapped to. By
+                          default, this is mapped to the "name" field, if that field
+                          is found in the TF resource schema.
+                        type: string
+                      nameValueTemplate:
+                        description: NameValueTemplate is a template by which the
+                          value of the metadata.name value should be interpreted before
+                          being passed to the Terraform provider. {{value}} is used
+                          in place of this sourced value.  e.g. If the value sourced
+                          from metadata.name is "foo_bar", a nameValueTemplate of
+                          "resource/{{value}}" would mean the final value passed to
+                          the provider is "resource/foo_bar"
+                        type: string
+                    type: object
+                  name:
+                    description: Name is the Terraform name of the resource (e.g.
+                      google_spanner_instance)
+                    type: string
+                  resourceReferences:
+                    description: ResourceReferences configures the mapping of fields
+                      in the Terraform resource that implicitly define references
+                      to other GCP resources into explicit Kubernetes-style references.
+                    items:
+                      properties:
+                        group:
+                          description: Group is the Kubernetes group of the resource
+                            being referenced. If not is set, it is implied that the
+                            kind specified is unique across all groups.
+                          type: string
+                        jsonSchemaType:
+                          description: JSONSchemaType specifies the type as understood
+                            by JSON schema validation of this reference field. Should
+                            never be specified for a TypeConfig inlined in the ReferenceConfig.  This
+                            field is mutually exclusive with Kind and TargetField.
+                          type: string
+                        key:
+                          description: 'Key is the field name that will be exposed
+                            through the KRM resource''s spec. It should follow the
+                            Kubernetes reference naming semantics:   `fooRef`, where
+                            foo is some describer of what is being referenced (e.g.   instanceRef,
+                            healthCheckRef) Complex references (those with a "Types"
+                            list defined) or lists of references should not specify
+                            a key.'
+                          type: string
+                        kind:
+                          description: Kind is the Kubernetes kind of the resource
+                            being referenced. The API group and version are assumed
+                            to match the referencing resource's.  This field is mutually
+                            exclusive with JSONSchemaType.
+                          type: string
+                        parent:
+                          description: Parent specifies whether the referenced resource
+                            is a parent. If the parent is successfully deleted, this
+                            resource may be deleted without any call to the underlying
+                            API. Only one parent may be present. A parent reference's
+                            TFField must not be a nested path.
+                          type: boolean
+                        targetField:
+                          description: TargetField is the referenced resource's Terraform
+                            field that will be extracted and set as the value of the
+                            TFField. For example, a ComputeSubnetwork can reference
+                            a ComputeNetwork's self link by setting TargetField to
+                            "self_link", a field defined on the google_compute_network
+                            resource.
+                          type: string
+                        tfField:
+                          description: TFField is the path to the field in the underlying
+                            Terraform provider that is the implicit reference. Use
+                            periods to delimit the fields in the path. For example,
+                            if the reference field is "bar" nested inside "foo" ("foo"
+                            being either an object or a list of objects), the associated
+                            TFField should be "foo.bar")
+                          type: string
+                        types:
+                          description: Types is the supported types this resource
+                            reference supports. Must not be specified if the inlined
+                            TypeConfig is filled out.  If the value for the reference
+                            is not specified in the KRM spec, it is possible that
+                            a default value may be set by GCP. This default reference
+                            value will be populated in the KRM resource's spec. In
+                            cases where a resource reference has multiple types, the
+                            first type in this list will become the default TypeConfig
+                            for that value.
+                          items:
+                            properties:
+                              group:
+                                description: Group is the Kubernetes group of the
+                                  resource being referenced. If not is set, it is
+                                  implied that the kind specified is unique across
+                                  all groups.
+                                type: string
+                              jsonSchemaType:
+                                description: JSONSchemaType specifies the type as
+                                  understood by JSON schema validation of this reference
+                                  field. Should never be specified for a TypeConfig
+                                  inlined in the ReferenceConfig.  This field is mutually
+                                  exclusive with Kind and TargetField.
+                                type: string
+                              key:
+                                description: 'Key is the field name that will be exposed
+                                  through the KRM resource''s spec. It should follow
+                                  the Kubernetes reference naming semantics:   `fooRef`,
+                                  where foo is some describer of what is being referenced
+                                  (e.g.   instanceRef, healthCheckRef) Complex references
+                                  (those with a "Types" list defined) or lists of
+                                  references should not specify a key.'
+                                type: string
+                              kind:
+                                description: Kind is the Kubernetes kind of the resource
+                                  being referenced. The API group and version are
+                                  assumed to match the referencing resource's.  This
+                                  field is mutually exclusive with JSONSchemaType.
+                                type: string
+                              parent:
+                                description: Parent specifies whether the referenced
+                                  resource is a parent. If the parent is successfully
+                                  deleted, this resource may be deleted without any
+                                  call to the underlying API. Only one parent may
+                                  be present. A parent reference's TFField must not
+                                  be a nested path.
+                                type: boolean
+                              targetField:
+                                description: TargetField is the referenced resource's
+                                  Terraform field that will be extracted and set as
+                                  the value of the TFField. For example, a ComputeSubnetwork
+                                  can reference a ComputeNetwork's self link by setting
+                                  TargetField to "self_link", a field defined on the
+                                  google_compute_network resource.
+                                type: string
+                              valueTemplate:
+                                description: ValueTemplate is a template by which
+                                  the value sourced from the reference should be interpreted
+                                  before being passed to the Terraform provider. {{value}}
+                                  is used in place of this sourced value.  e.g. If
+                                  the value sourced from the reference is "foo@domain.com",
+                                  a valueTemplate of "serviceAccount:{{value}}" would
+                                  mean the final value passed to the provider is "serviceAccount:foo@domain.com"
+                                type: string
+                            type: object
+                          type: array
+                        valueTemplate:
+                          description: ValueTemplate is a template by which the value
+                            sourced from the reference should be interpreted before
+                            being passed to the Terraform provider. {{value}} is used
+                            in place of this sourced value.  e.g. If the value sourced
+                            from the reference is "foo@domain.com", a valueTemplate
+                            of "serviceAccount:{{value}}" would mean the final value
+                            passed to the provider is "serviceAccount:foo@domain.com"
+                          type: string
+                      required:
+                      - tfField
+                      type: object
+                    type: array
+                  serverGeneratedIDField:
+                    description: ServerGeneratedIDField is the field in the resource's
+                      status that corresponds to the server-generated resource ID.
+                      If unset, it's assumed the resource ID is specified by the user.
+                      Resources with this set do not support acquisition.
+                    type: string
+                  skipImport:
+                    description: SkipImport skips the import step when fetching the
+                      live state of the underlying resource. If specified, IDTemplate
+                      must also be specified, and its expanded form will be used as
+                      the TF resource's `id` field.
+                    type: boolean
+                required:
+                - name
+                - kind
+                type: object
+              type: array
+            version:
+              description: Version is the API version for all the resource CRDs being
+                generated.
+              type: string
+          required:
+          - name
+          - version
+          - resources
+          type: object
+      type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: servicenetworkingconnections.servicenetworking.cnrm.cloud.google.com
+spec:
+  group: servicenetworking.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: ServiceNetworkingConnection
+    plural: servicenetworkingconnections
+    shortNames:
+    - gcpservicenetworkingconnection
+    - gcpservicenetworkingconnections
+    singular: servicenetworkingconnection
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            networkRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            reservedPeeringRanges:
+              items:
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              type: array
+            service:
+              type: string
+          required:
+          - networkRef
+          - reservedPeeringRanges
+          - service
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            peering:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: services.serviceusage.cnrm.cloud.google.com
+spec:
+  group: serviceusage.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: Service
+    plural: services
+    shortNames:
+    - gcpservice
+    - gcpservices
+    singular: service
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: sourcereporepositories.sourcerepo.cnrm.cloud.google.com
+spec:
+  group: sourcerepo.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SourceRepoRepository
+    plural: sourcereporepositories
+    shortNames:
+    - gcpsourcereporepository
+    - gcpsourcereporepositories
+    singular: sourcereporepository
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            pubsubConfigs:
+              description: |-
+                How this repository publishes a change in the repository through Cloud Pub/Sub.
+                Keyed by the topic names.
+              items:
+                properties:
+                  messageFormat:
+                    description: |-
+                      The format of the Cloud Pub/Sub messages.
+                      - PROTOBUF: The message payload is a serialized protocol buffer of SourceRepoEvent.
+                      - JSON: The message payload is a JSON string of SourceRepoEvent.
+                    type: string
+                  serviceAccountRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                  topicRef:
+                    oneOf:
+                    - not:
+                        required:
+                        - external
+                      required:
+                      - name
+                    - not:
+                        anyOf:
+                        - required:
+                          - name
+                        - required:
+                          - namespace
+                      required:
+                      - external
+                    properties:
+                      external:
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    type: object
+                required:
+                - messageFormat
+                - topicRef
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            size:
+              description: The disk usage of the repo, in bytes.
+              type: integer
+            url:
+              description: URL to clone the repository from Google Cloud Source Repositories.
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: spannerdatabases.spanner.cnrm.cloud.google.com
+spec:
+  group: spanner.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SpannerDatabase
+    plural: spannerdatabases
+    shortNames:
+    - gcpspannerdatabase
+    - gcpspannerdatabases
+    singular: spannerdatabase
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            ddl:
+              description: |-
+                An optional list of DDL statements to run inside the newly created
+                database. Statements can create tables, indexes, etc. These statements
+                execute atomically with the creation of the database: if there is an
+                error in any statement, the database is not created.
+              items:
+                type: string
+              type: array
+            instanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - instanceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            state:
+              description: An explanation of the status of the database.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: spannerinstances.spanner.cnrm.cloud.google.com
+spec:
+  group: spanner.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SpannerInstance
+    plural: spannerinstances
+    shortNames:
+    - gcpspannerinstance
+    - gcpspannerinstances
+    singular: spannerinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            config:
+              description: |-
+                The name of the instance's configuration (similar but not
+                quite the same as a region) which defines defines the geographic placement and
+                replication of your databases in this instance. It determines where your data
+                is stored. Values are typically of the form 'regional-europe-west1' , 'us-central' etc.
+                In order to obtain a valid list please consult the
+                [Configuration section of the docs](https://cloud.google.com/spanner/docs/instances).
+              type: string
+            displayName:
+              description: |-
+                The descriptive name for this instance as it appears in UIs. Must be
+                unique per project and between 4 and 30 characters in length.
+              type: string
+            numNodes:
+              description: The number of nodes allocated to this instance.
+              type: integer
+          required:
+          - config
+          - displayName
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            state:
+              description: 'Instance status: ''CREATING'' or ''READY''.'
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: sqldatabases.sql.cnrm.cloud.google.com
+spec:
+  group: sql.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SQLDatabase
+    plural: sqldatabases
+    shortNames:
+    - gcpsqldatabase
+    - gcpsqldatabases
+    singular: sqldatabase
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            charset:
+              description: |-
+                The charset value. See MySQL's
+                [Supported Character Sets and Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html)
+                and Postgres' [Character Set Support](https://www.postgresql.org/docs/9.6/static/multibyte.html)
+                for more details and supported values. Postgres databases only support
+                a value of 'UTF8' at creation time.
+              type: string
+            collation:
+              description: |-
+                The collation value. See MySQL's
+                [Supported Character Sets and Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html)
+                and Postgres' [Collation Support](https://www.postgresql.org/docs/9.6/static/collation.html)
+                for more details and supported values. Postgres databases only support
+                a value of 'en_US.UTF8' at creation time.
+              type: string
+            instanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - instanceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: sqlinstances.sql.cnrm.cloud.google.com
+spec:
+  group: sql.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SQLInstance
+    plural: sqlinstances
+    shortNames:
+    - gcpsqlinstance
+    - gcpsqlinstances
+    singular: sqlinstance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            databaseVersion:
+              type: string
+            masterInstanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            region:
+              type: string
+            replicaConfiguration:
+              properties:
+                caCertificate:
+                  type: string
+                clientCertificate:
+                  type: string
+                clientKey:
+                  type: string
+                connectRetryInterval:
+                  type: integer
+                dumpFilePath:
+                  type: string
+                failoverTarget:
+                  type: boolean
+                masterHeartbeatPeriod:
+                  type: integer
+                password:
+                  oneOf:
+                  - not:
+                      required:
+                      - valueFrom
+                    required:
+                    - value
+                  - not:
+                      required:
+                      - value
+                    required:
+                    - valueFrom
+                  properties:
+                    value:
+                      description: Value of the field. Cannot be used if 'valueFrom'
+                        is specified.
+                      type: string
+                    valueFrom:
+                      description: Source for the field's value. Cannot be used if
+                        'value' is specified.
+                      properties:
+                        secretKeyRef:
+                          description: Reference to a value with the given key in
+                            the given Secret in the resource's namespace.
+                          properties:
+                            key:
+                              description: Key that identifies the value to be extracted.
+                              type: string
+                            name:
+                              description: Name of the Secret to extract a value from.
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      type: object
+                  type: object
+                sslCipher:
+                  type: string
+                username:
+                  type: string
+                verifyServerCertificate:
+                  type: boolean
+              type: object
+            rootPassword:
+              oneOf:
+              - not:
+                  required:
+                  - valueFrom
+                required:
+                - value
+              - not:
+                  required:
+                  - value
+                required:
+                - valueFrom
+              properties:
+                value:
+                  description: Value of the field. Cannot be used if 'valueFrom' is
+                    specified.
+                  type: string
+                valueFrom:
+                  description: Source for the field's value. Cannot be used if 'value'
+                    is specified.
+                  properties:
+                    secretKeyRef:
+                      description: Reference to a value with the given key in the
+                        given Secret in the resource's namespace.
+                      properties:
+                        key:
+                          description: Key that identifies the value to be extracted.
+                          type: string
+                        name:
+                          description: Name of the Secret to extract a value from.
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+              type: object
+            settings:
+              properties:
+                activationPolicy:
+                  type: string
+                authorizedGaeApplications:
+                  items:
+                    type: string
+                  type: array
+                availabilityType:
+                  type: string
+                backupConfiguration:
+                  properties:
+                    binaryLogEnabled:
+                      type: boolean
+                    enabled:
+                      type: boolean
+                    location:
+                      type: string
+                    startTime:
+                      type: string
+                  type: object
+                crashSafeReplication:
+                  type: boolean
+                databaseFlags:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                diskAutoresize:
+                  type: boolean
+                diskSize:
+                  type: integer
+                diskType:
+                  type: string
+                ipConfiguration:
+                  properties:
+                    authorizedNetworks:
+                      items:
+                        properties:
+                          expirationTime:
+                            type: string
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - value
+                        type: object
+                      type: array
+                    ipv4Enabled:
+                      type: boolean
+                    privateNetworkRef:
+                      oneOf:
+                      - not:
+                          required:
+                          - external
+                        required:
+                        - name
+                      - not:
+                          anyOf:
+                          - required:
+                            - name
+                          - required:
+                            - namespace
+                        required:
+                        - external
+                      properties:
+                        external:
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                      type: object
+                    requireSsl:
+                      type: boolean
+                  type: object
+                locationPreference:
+                  properties:
+                    followGaeApplication:
+                      type: string
+                    zone:
+                      type: string
+                  type: object
+                maintenanceWindow:
+                  properties:
+                    day:
+                      type: integer
+                    hour:
+                      type: integer
+                    updateTrack:
+                      type: string
+                  type: object
+                pricingPlan:
+                  type: string
+                replicationType:
+                  type: string
+                tier:
+                  type: string
+              required:
+              - tier
+              type: object
+          required:
+          - settings
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            connectionName:
+              type: string
+            firstIpAddress:
+              type: string
+            ipAddress:
+              items:
+                properties:
+                  ipAddress:
+                    type: string
+                  timeToRetire:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+            privateIpAddress:
+              type: string
+            publicIpAddress:
+              type: string
+            selfLink:
+              type: string
+            serverCaCert:
+              properties:
+                cert:
+                  type: string
+                commonName:
+                  type: string
+                createTime:
+                  type: string
+                expirationTime:
+                  type: string
+                sha1Fingerprint:
+                  type: string
+              type: object
+            serviceAccountEmailAddress:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: sqlusers.sql.cnrm.cloud.google.com
+spec:
+  group: sql.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: SQLUser
+    plural: sqlusers
+    shortNames:
+    - gcpsqluser
+    - gcpsqlusers
+    singular: sqluser
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            host:
+              type: string
+            instanceRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            password:
+              oneOf:
+              - not:
+                  required:
+                  - valueFrom
+                required:
+                - value
+              - not:
+                  required:
+                  - value
+                required:
+                - valueFrom
+              properties:
+                value:
+                  description: Value of the field. Cannot be used if 'valueFrom' is
+                    specified.
+                  type: string
+                valueFrom:
+                  description: Source for the field's value. Cannot be used if 'value'
+                    is specified.
+                  properties:
+                    secretKeyRef:
+                      description: Reference to a value with the given key in the
+                        given Secret in the resource's namespace.
+                      properties:
+                        key:
+                          description: Key that identifies the value to be extracted.
+                          type: string
+                        name:
+                          description: Name of the Secret to extract a value from.
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+              type: object
+          required:
+          - instanceRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: storagebucketaccesscontrols.storage.cnrm.cloud.google.com
+spec:
+  group: storage.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: StorageBucketAccessControl
+    plural: storagebucketaccesscontrols
+    shortNames:
+    - gcpstoragebucketaccesscontrol
+    - gcpstoragebucketaccesscontrols
+    singular: storagebucketaccesscontrol
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bucketRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            entity:
+              description: |-
+                The entity holding the permission, in one of the following forms:
+                  user-userId
+                  user-email
+                  group-groupId
+                  group-email
+                  domain-domain
+                  project-team-projectId
+                  allUsers
+                  allAuthenticatedUsers
+                Examples:
+                  The user liz@example.com would be user-liz@example.com.
+                  The group example@googlegroups.com would be
+                  group-example@googlegroups.com.
+                  To refer to all members of the Google Apps for Business domain
+                  example.com, the entity would be domain-example.com.
+              type: string
+            role:
+              description: The access permission for the entity.
+              type: string
+          required:
+          - bucketRef
+          - entity
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            domain:
+              description: The domain associated with the entity.
+              type: string
+            email:
+              description: The email address associated with the entity.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: storagebuckets.storage.cnrm.cloud.google.com
+spec:
+  group: storage.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: StorageBucket
+    plural: storagebuckets
+    shortNames:
+    - gcpstoragebucket
+    - gcpstoragebuckets
+    singular: storagebucket
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bucketPolicyOnly:
+              type: boolean
+            cors:
+              items:
+                properties:
+                  maxAgeSeconds:
+                    type: integer
+                  method:
+                    items:
+                      type: string
+                    type: array
+                  origin:
+                    items:
+                      type: string
+                    type: array
+                  responseHeader:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            encryption:
+              properties:
+                kmsKeyRef:
+                  oneOf:
+                  - not:
+                      required:
+                      - external
+                    required:
+                    - name
+                  - not:
+                      anyOf:
+                      - required:
+                        - name
+                      - required:
+                        - namespace
+                    required:
+                    - external
+                  properties:
+                    external:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                  type: object
+              required:
+              - kmsKeyRef
+              type: object
+            lifecycleRule:
+              items:
+                properties:
+                  action:
+                    properties:
+                      storageClass:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  condition:
+                    properties:
+                      age:
+                        type: integer
+                      createdBefore:
+                        type: string
+                      matchesStorageClass:
+                        items:
+                          type: string
+                        type: array
+                      numNewerVersions:
+                        type: integer
+                      withState:
+                        type: string
+                    type: object
+                required:
+                - action
+                - condition
+                type: object
+              type: array
+            location:
+              type: string
+            logging:
+              properties:
+                logBucket:
+                  type: string
+                logObjectPrefix:
+                  type: string
+              required:
+              - logBucket
+              type: object
+            requesterPays:
+              type: boolean
+            retentionPolicy:
+              properties:
+                isLocked:
+                  type: boolean
+                retentionPeriod:
+                  type: integer
+              required:
+              - retentionPeriod
+              type: object
+            storageClass:
+              type: string
+            versioning:
+              properties:
+                enabled:
+                  type: boolean
+              required:
+              - enabled
+              type: object
+            website:
+              properties:
+                mainPageSuffix:
+                  type: string
+                notFoundPage:
+                  type: string
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            selfLink:
+              type: string
+            url:
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: storagedefaultobjectaccesscontrols.storage.cnrm.cloud.google.com
+spec:
+  group: storage.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: StorageDefaultObjectAccessControl
+    plural: storagedefaultobjectaccesscontrols
+    shortNames:
+    - gcpstoragedefaultobjectaccesscontrol
+    - gcpstoragedefaultobjectaccesscontrols
+    singular: storagedefaultobjectaccesscontrol
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bucketRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            entity:
+              description: |-
+                The entity holding the permission, in one of the following forms:
+                  * user-{{userId}}
+                  * user-{{email}} (such as "user-liz@example.com")
+                  * group-{{groupId}}
+                  * group-{{email}} (such as "group-example@googlegroups.com")
+                  * domain-{{domain}} (such as "domain-example.com")
+                  * project-team-{{projectId}}
+                  * allUsers
+                  * allAuthenticatedUsers
+              type: string
+            object:
+              description: The name of the object, if applied to an object.
+              type: string
+            role:
+              description: The access permission for the entity.
+              type: string
+          required:
+          - bucketRef
+          - entity
+          - role
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            domain:
+              description: The domain associated with the entity.
+              type: string
+            email:
+              description: The email address associated with the entity.
+              type: string
+            entityId:
+              description: The ID for the entity
+              type: string
+            generation:
+              description: The content generation of the object, if applied to an
+                object.
+              type: integer
+            projectTeam:
+              description: The project team associated with the entity
+              properties:
+                projectNumber:
+                  description: The project team associated with the entity
+                  type: string
+                team:
+                  description: The team.
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: storagenotifications.storage.cnrm.cloud.google.com
+spec:
+  group: storage.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: StorageNotification
+    plural: storagenotifications
+    shortNames:
+    - gcpstoragenotification
+    - gcpstoragenotifications
+    singular: storagenotification
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'apiVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bucketRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+            customAttributes:
+              additionalProperties:
+                type: string
+              type: object
+            eventTypes:
+              items:
+                type: string
+              type: array
+            objectNamePrefix:
+              type: string
+            payloadFormat:
+              type: string
+            topicRef:
+              oneOf:
+              - not:
+                  required:
+                  - external
+                required:
+                - name
+              - not:
+                  anyOf:
+                  - required:
+                    - name
+                  - required:
+                    - namespace
+                required:
+                - external
+              properties:
+                external:
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+              type: object
+          required:
+          - bucketRef
+          - payloadFormat
+          - topicRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest available observation
+                of the resource's current state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                type: object
+              type: array
+            notificationId:
+              type: string
+            selfLink:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test-infra/management/upstream/management/cnrm-install/install-system/kustomization.yaml
+++ b/test-infra/management/upstream/management/cnrm-install/install-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- 0-cnrm-system.yaml
+- crds.yaml


### PR DESCRIPTION
* Management cluster is a cluster running Cloud Config connector which
  can be used to create GCP resources.

* This PR checks in the config for cluster kf-ci-management.
  We also setup a namespace to administer resources in project
  kubeflow-ci-deployment

Fix #644