### PR TITLE
Fix auto-deployments reconciler.

### DIFF
--- a/py/kubeflow/testing/auto_deploy/reconciler.py
+++ b/py/kubeflow/testing/auto_deploy/reconciler.py
@@ -282,13 +282,20 @@ class Reconciler: # pylint: disable=too-many-instance-attributes
       version_name = labels.get(auto_deploy_util.AUTO_NAME_LABEL, "unknown")
 
       if not "manifest" in d:
-        logging.error(f"Skipping deployment {d['name']} it doesn't "
-                       "have a manifest")
-        continue
+        # Since we don't know the manifest we can't get the zone.
+        # It looks like the manfiest might also be stored in the operation.
+        # However, it looks like the reason the manifest isn't there
+        # is because the deployment failed. So we can just set zone to the
+        # empty string. I think zone only matters for getting cluster
+        # credentials but since the deployment failed that shouldn't matter.
+        logging.error(f"Deployment {d['name']} doesn't "
+                       "have a manifest. This typically indicates the "
+                       "deployment failed")
+        zone = ""
+      else:
+        dm_manifest_name = d["manifest"].split("/")[-1]
 
-      dm_manifest_name = d["manifest"].split("/")[-1]
-
-      zone = self._get_deployment_zone(d["name"], dm_manifest_name)
+        zone = self._get_deployment_zone(d["name"], dm_manifest_name)
 
       context = {
         "deployment_name" : d['name'],

--- a/py/kubeflow/testing/delete_kf_instance.py
+++ b/py/kubeflow/testing/delete_kf_instance.py
@@ -11,7 +11,8 @@ from oauth2client.client import GoogleCredentials
 
 from kubeflow.testing import util
 
-@retrying.retry(stop_max_delay=10*60*1000)
+@retrying.retry(stop_max_delay=10*60*1000, wait_exponential_max=60*1000,
+                wait_exponential_multiplier=1000)
 def delete_deployment(dm, project, name):
   deployments_client = dm.deployments()
   try:


### PR DESCRIPTION
* The reconciler is running amok because in #657 we changed the code
  to skip over deployments with no manifest field because we couldn't get
  the zone. It turns out the lack of the manifest is an indication that
  the deployment failed. By not matching these deployments we end
  up retrying the auto-deployment. This is causing a cascading failure
  because we end up using up all our DM quota which in turn causes auto
  deployments to fail which in turn causes us to try again and eat up
  more deployments.

* This PR fixes that by matching deployments even if the manifest field
  is missing. This should prevent us from repeatedly retrying.

* Add exponential backoff to delete deployments. Because of the above
  error we are bumping to write quota limits per day which is impacting
  our ability to GC deployments.

Related to #660 