### PR TITLE
Fix cluster get-credentials  command in playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ The logs should be in StackDriver but to get them we need to identify the pod.
      - This requires appropriate K8s RBAC permissions
      - You'll need to be added to the Google group **ci-team@kubeflow.org**
      - Create a PR adding yourself to [ci-team](https://github.com/kubeflow/internal-acls/blob/master/ci-team.members.txt)
-     - Add credentials to your $HOME/.kube/config: `gcloud container clusters get-credentials  kubeflow-testing --project kubeflow-ci --zone us-east1-d`
+     - Add credentials to your $HOME/.kube/config: `gcloud --project kubeflow-ci container clusters get-credentials kubeflow-testing --zone us-east1-d`
 
    - Get the workflow YAML from Prow artifacts
      - Find your Prow job from <https://prow.k8s.io/?repo=kubeflow%2Ftesting>.

--- a/playbook/playbook.md
+++ b/playbook/playbook.md
@@ -27,7 +27,7 @@ This is a playbook for build cops to help deal with problems with the CI infrast
 1. To access to k8s resources make sure to get credentials and set the default namespace to `kubeflow-test-infra`:
 
 ```
-gcloud container clusters get-credentials kubeflow-testing --zone $ZONE --project kubelow-ci
+gcloud --project kubelow-ci container clusters get-credentials kubeflow-testing --zone $ZONE
 kubectl config set-context $(kubectl config current-context) --namespace=kubeflow-test-infra
 ```
 


### PR DESCRIPTION
Seems we need to put --project at the beginning to make the command work

```
gcloud container clusters get-credentials kubeflow-testing --zone us-east1-d --project kubelow-ci
Fetching cluster endpoint and auth data.
ERROR: (gcloud.container.clusters.get-credentials) ResponseError: code=403, message=Project lookup error: permission denied on resource 'projects/kubelow-ci' (or it may not exist).


 gcloud --project=kubeflow-ci container clusters get-credentials kubeflow-testing --zone us-east1-d
Fetching cluster endpoint and auth data.
kubeconfig entry generated for kubeflow-testing.

```

Just in case someone experience same issue