### PR TITLE
Cleanup orphaned backend services and instance groups.

### DIFF
--- a/py/kubeflow/testing/cleanup_ci_test.py
+++ b/py/kubeflow/testing/cleanup_ci_test.py
@@ -139,6 +139,12 @@ def test_trim_unused_bindings():
   actual_bindings = set(policy["bindings"][0]["members"])
   assert actual_bindings == expected
 
+def test_parse_k8s_url_map():
+  expected = cleanup_ci.K8S_URL_MAP_NAME("istio-system-envoy-ingress",
+                                         "848f8392b2ce1c27")
+  assert cleanup_ci._parse_k8s(
+    "k8s-um-istio-system-envoy-ingress--848f8392b2ce1c27") == expected
+
 if __name__ == "__main__":
   logging.basicConfig(
       level=logging.INFO,

--- a/py/kubeflow/testing/gcp_util.py
+++ b/py/kubeflow/testing/gcp_util.py
@@ -48,7 +48,7 @@ def deployments_iterator(project):
   while True:
     deployments = deployments_client.list(project=project,
                                           pageToken=next_page_token,
-                                          maxResults=10).execute()
+                                          maxResults=100).execute()
 
     for d in deployments.get("deployments", []):
       yield d
@@ -57,3 +57,22 @@ def deployments_iterator(project):
       return
 
     next_page_token = deployments.get("nextPageToken")
+
+
+def url_maps_iterator(project):
+
+  credentials = GoogleCredentials.get_application_default()
+  compute = discovery.build('compute', 'v1', credentials=credentials)
+  urlMaps = compute.urlMaps()
+
+  next_page_token = None
+  while True:
+    results = urlMaps.list(project=project,
+                           pageToken=next_page_token,
+                           maxResults=100).execute()
+    for u in results.get("items", []):
+      yield u
+
+    if not "nextPageToken" in results:
+      return
+    next_page_token = results["nextPageToken"]


### PR DESCRIPTION
* To cleanup orphaned backend services associated with K8s ingresses
  we need to match the backend service to a URL map. If the URL map
  doesn't exist then its orphaned and we can delete it.

* Similarly for instance groups associated with K8s ingresses
  we need to map them to URL maps and delete them if the URL
  map doesn't exist.

Related to 
kubeflow/testing#660
kubeflow/testing#664