### PR TITLE
Use ACM to deploy auto-deploy; fixes to support blueprint testing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ TEKTON_INSTALLS=./tekton/templates/installs
 # Hydrate ACM repos
 .PHONY: hydrate
 hydrate:
-	rm $(REPO_DIRS)/kf-ci-v1/namespaces/auto-deploy/tekton*
-	rm $(REPO_DIRS)/kf-ci-v1/namespaces/tektoncd/tekton*
+	rm -f $(REPO_DIRS)/kf-ci-v1/namespaces/auto-deploy/tekton*	
+	rm -f $(REPO_DIRS)/kf-ci-v1/namespaces/tektoncd/tekton*
+	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/auto-deploy/auto-deploy.yaml test-infra/auto-deploy/manifest
 	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/auto-deploy $(TEKTON_INSTALLS)/auto-deploy
 	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/tektoncd $(TEKTON_INSTALLS)/tektoncd
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,4 @@
-# TODO(jlewi): We should probably have OWNERs files in subdirectories that
-# list approvers for individual components (e.g. Seldon folks for Seldon component)
 approvers:
-  - gabrielwen
-  - jlewi
-  - kunmingg
-  - lluunn
-  - richardsliu
-  - zhenghuiwang
+- bobgy
+- jlewi
+- rmgogogo

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/auto-deploy.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/auto-deploy.yaml
@@ -1,0 +1,319 @@
+apiVersion: v1
+data:
+  deploy-kubeflow.yaml: |
+    # This version of the script has been updated to use unique names
+    # See https://github.com/kubeflow/testing/issues/444
+    # Its also using an init container to check out the code.
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      generateName: deploy-master-
+      labels:
+        job: deploy-master-oneoff
+        version: master
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          annotations:
+            # side cars can cause jobs to get stuck.
+            sidecar.istio.io/inject: "false"
+          labels:
+            job: deploy-master-oneoff
+            version: master
+        spec:
+          initContainers:
+          - command:
+            - /usr/local/bin/checkout_repos.sh
+            # TOODO(jlewi): We should really switch to tekton and use resources.
+            # TODO(https://github.com/kubeflow/testing/pull/641): Switch to  kubeflow/testing@HEAD
+            # after 641 is merged
+            - --depth=all
+            - --repos=kubeflow/kfctl@HEAD,jlewi/testing@playbook
+            - --src_dir=/src
+            - --links
+            env:
+            - name: PYTHONPATH
+              value: /src/kubeflow/testing/py
+            image: gcr.io/kubeflow-ci/test-worker@sha256:dd559f89b3cbd926ec563559995f25025eecc6290b3146f17f82d2f084d07ee2
+            imagePullPolicy: IfNotPresent
+            name: checkout
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /src
+              name: src
+          containers:
+          - name: deploy
+            image: gcr.io/kubeflow-ci/test-worker@sha256:dd559f89b3cbd926ec563559995f25025eecc6290b3146f17f82d2f084d07ee2
+            env:
+            # TODO(jlewi): Get rid of /src/jlewi once we change repos to checkout kubeflow/testing
+            - name: PYTHONPATH
+              value: /src/kubeflow/testing/py:/src/jlewi/testing/py
+            # We need to explicitly set the KUBECONFIG variable because that's what our python client uses to determine
+            # whether its an in cluster config or not.
+            - name: KUBECONFIG
+              value: /etc/.kube
+            # Note command is completely overwritten by reconciler
+            command:
+            - python
+            - -m
+            - kubeflow.testing.create_unique_kf_instance
+            - --apps_dir=/src/apps
+            - --kubeflow_repo=/src/kubeflow/kfctl
+            - --name=kf-vmaster-{uid}
+            - --project=kubeflow-ci-deployment
+            - --zone=us-central1-a
+            - --kfctl_config=https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml
+            - --no-use_self-cert
+            volumeMounts:
+            - mountPath: /src
+              name: src
+          # Rely on workload identity.
+          serviceAccount: default-editor
+          restartPolicy: Never
+          volumes:
+          - name: src
+            emptyDir: {}
+  deployments.yaml: |
+    # This is a configuration file that configures
+    # the list of branches that we want to continusouly deploy from.
+    # The project where things should be deployed
+    #
+    #
+    # TODO(jlewi): This is deprecated. Instead you should add YAML files containing Tekton PipelineRun YAMLs
+    # Each PipelineRun should deploy a different sequence of pipelines.
+    #
+    # TODO(jlewi): Project and zone in which to deploy.
+    # Should we define this in the kustomize package because it will be different
+    # for different environments and we will want to easily override it?
+    project: kubeflow-ci-deployment
+    zone: us-east1-c
+    # Each version specifies a different combination of versions of KF to deploy.
+    versions:
+      - name: master
+        kfDefUrl: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml
+        kfctlUrl: https://github.com/kubeflow/kfctl/releases/download/v1.0/kfctl_v1.0-0-g94c35cf_linux.tar.gz
+      - name: v1
+        # TODO(jlewi): Change to the version on the v1.0 branch once it exists; otherwise we won't redeploy on changes
+        # to the manifests
+        kfDefUrl: https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_gcp_iap.v1.0.0.yaml
+        kfctlUrl: https://github.com/kubeflow/kfctl/releases/download/v1.0/kfctl_v1.0-0-g94c35cf_linux.tar.gz
+      - name: stacks
+        # TODO(jlewi): We can get rid of this autodeployment once the stacks manifest is incorporated into a versioned
+        # manifest. We may need to update the kfctl link as additional fixes to work with kfctl
+        kfDefUrl: https://raw.githubusercontent.com/kubeflow/manifests/master/stacks/examples/kfctl_gcp_stacks.experimental.yaml
+        kfctlUrl: https://storage.googleapis.com/kubeflow-ci_builds/kfctl/20200413_0845/linux/kfctl
+  pipeline-run-deploy-blueprint-master.yaml: "# A Tekton PipelineRune to deploy Kubeflow
+    using a blueprint.\n#\n# Several pieces of information in the spec are used to
+    configure autodeployments.\n# 1. labels:\n#    auto-deploy-group - Used to group
+    auto deployments. Only so many instances will be kept\n#        each pipeline
+    run should use a unique value \n#    auto-deploy-base-name: This will be changed
+    to name-{uid} to generate a unique name for the deployment\napiVersion: tekton.dev/v1alpha1\nkind:
+    PipelineRun\nmetadata:      \n  generateName: deploy-kf-master-\n  namespace:
+    auto-deploy\n  labels:\n    auto-deploy-group: gcp-blueprint-master\n    auto-deploy-base-name:
+    kf-vbp\nspec:    \n  resources:  \n  - name: blueprint-repo\n    resourceSpec:\n
+    \     type: git\n      params:\n        - name: revision\n          value: master\n
+    \       - name: url\n          value: https://github.com/kubeflow/gcp-blueprints.git\n
+    \ - name: testing-repo\n    resourceSpec:\n      type: git\n      params:\n        #
+    TODO(jlewi): Switch to master once \n        # https://github.com/kubeflow/testing/pull/676
+    is submitted\n        - name: revision\n          value: gcp_blueprints\n        -
+    name: url\n          value: https://github.com/jlewi/testing.git\n  # Need to
+    use a KSA with appropriate GSA\n  serviceAccountName: default-editor\n  pipelineRef:\n
+    \   name: deploy-gcp-blueprint"
+kind: ConfigMap
+metadata:
+  labels:
+    service: auto-deploy
+  name: auto-deploy-config-2bffg2b5h5
+  namespace: auto-deploy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: auto-deploy
+  name: auto-deploy-server
+  namespace: auto-deploy
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: auto-deploy
+    service: auto-deploy
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    service: auto-deploy
+  name: auto-deploy-server
+  namespace: auto-deploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: auto-deploy
+      service: auto-deploy
+  template:
+    metadata:
+      labels:
+        app: auto-deploy
+        service: auto-deploy
+    spec:
+      containers:
+      - command:
+        - python
+        - -m
+        - kubeflow.testing.auto_deploy.server
+        - serve
+        - --template-folder=/app/templates
+        - --deployments-dir=/cache/deployments
+        - --port=80
+        env:
+        - name: FLASK_DEBUG
+          value: "true"
+        image: gcr.io/kubeflow-ci/auto_deploy@sha256:7b30a7ad4aabcfede8dc9130b99265e213481037ab6a408178319328ba5d37a2
+        name: server
+        resources:
+          requests:
+            cpu: 2
+            memory: 8Gi
+        volumeMounts:
+        - mountPath: /app/config
+          name: config
+        - mountPath: /cache
+          name: cache
+        workingDir: /app
+      - command:
+        - python
+        - -m
+        - kubeflow.testing.auto_deploy.reconciler
+        - run
+        - --config-path=/app/config/deployments.yaml
+        - --job-template-path=/app/config/deploy-kubeflow.yaml
+        - --local-dir=/cache/auto_deploy_src
+        - --deployments-dir=/cache/deployments
+        env:
+        - name: JOB_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/kubeflow-ci/auto_deploy@sha256:7b30a7ad4aabcfede8dc9130b99265e213481037ab6a408178319328ba5d37a2
+        name: reconciler
+        resources:
+          requests:
+            cpu: 2
+            memory: 8Gi
+        volumeMounts:
+        - mountPath: /app/config
+          name: config
+        - mountPath: /cache
+          name: cache
+        workingDir: /app
+      - command:
+        - python
+        - -m
+        - kubeflow.testing.auto_deploy.blueprint_reconciler
+        - run
+        - --pipelines-dir=/app/config/
+        - --local-dir=/cache/blueprints_auto_deploy_src
+        - --deployments-dir=/cache/deployments
+        - --management-context=kf-ci-deployment-management
+        - --tekton-context=kf-auto-deploy
+        env:
+        - name: JOB_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBECONFIG
+          value: /cache/kubeconfig
+        image: gcr.io/kubeflow-ci/auto_deploy@sha256:7b30a7ad4aabcfede8dc9130b99265e213481037ab6a408178319328ba5d37a2
+        name: blueprints-reconciler
+        resources:
+          requests:
+            cpu: 2
+            memory: 8Gi
+        volumeMounts:
+        - mountPath: /app/config
+          name: config
+        - mountPath: /cache
+          name: cache
+        workingDir: /app
+      initContainers:
+      - command:
+        - python
+        - -m
+        - kubeflow.testing.create_context
+        - create
+        - --project=kubeflow-ci
+        - --cluster=kf-ci-management
+        - --location=us-central1
+        - --namespace=kubeflow-ci-management
+        - --name=kf-ci-deployment-management
+        env:
+        - name: KUBECONFIG
+          value: /cache/kubeconfig
+        image: gcr.io/kubeflow-ci/auto_deploy@sha256:7b30a7ad4aabcfede8dc9130b99265e213481037ab6a408178319328ba5d37a2
+        name: management-context
+        volumeMounts:
+        - mountPath: /cache
+          name: cache
+      - command:
+        - python
+        - -m
+        - kubeflow.testing.create_context
+        - create
+        - --project=kubeflow-ci
+        - --cluster=kf-ci-v1
+        - --location=us-east1-d
+        - --namespace=auto-deploy
+        - --name=kf-auto-deploy
+        env:
+        - name: KUBECONFIG
+          value: /cache/kubeconfig
+        image: gcr.io/kubeflow-ci/auto_deploy@sha256:7b30a7ad4aabcfede8dc9130b99265e213481037ab6a408178319328ba5d37a2
+        name: tekton-context
+        volumeMounts:
+        - mountPath: /cache
+          name: cache
+      serviceAccount: default-editor
+      volumes:
+      - configMap:
+          name: auto-deploy-config-2bffg2b5h5
+        name: config
+      - emptyDir: {}
+        name: cache
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    service: auto-deploy
+  name: auto-deploy-server
+  namespace: auto-deploy
+spec:
+  gateways:
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        add:
+          x-forwarded-prefix: /auto_deploy
+    match:
+    - uri:
+        prefix: /auto_deploy/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: auto-deploy-server.auto-deploy.svc.cluster.local
+        port:
+          number: 80

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -33,6 +33,10 @@ spec:
     - description: Directory to write outputs to in local FS.
       name: output-workspace
       type: string
+    - default: default-profile
+      description: The namespace to run the notebook in
+      name: nb-namespace
+      type: string
     resources:
     - name: examples-repo
       targetPath: src/kubeflow/examples
@@ -77,6 +81,7 @@ spec:
         --notebook_path=$(inputs.params.notebook-path) \
         --test-target-name=$(inputs.params.test-target-name) \
         --artifacts-gcs=$(inputs.params.artifacts-gcs) \
+        --namespace=$(inputs.params.nb-namespace)
       || echo test finished.
     volumeMounts:
     - mountPath: /secret/gcp-credentials

--- a/acm-repos/kf-ci-v1/namespaces/tektoncd/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/tektoncd/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -33,6 +33,10 @@ spec:
     - description: Directory to write outputs to in local FS.
       name: output-workspace
       type: string
+    - default: default-profile
+      description: The namespace to run the notebook in
+      name: nb-namespace
+      type: string
     resources:
     - name: examples-repo
       targetPath: src/kubeflow/examples
@@ -77,6 +81,7 @@ spec:
         --notebook_path=$(inputs.params.notebook-path) \
         --test-target-name=$(inputs.params.test-target-name) \
         --artifacts-gcs=$(inputs.params.artifacts-gcs) \
+        --namespace=$(inputs.params.nb-namespace)
       || echo test finished.
     volumeMounts:
     - mountPath: /secret/gcp-credentials

--- a/py/kubeflow/testing/auto_deploy/blueprint_reconciler.py
+++ b/py/kubeflow/testing/auto_deploy/blueprint_reconciler.py
@@ -19,7 +19,6 @@ import uuid
 import yaml
 
 from kubeflow.testing import cnrm_clients
-from kubeflow.testing.auto_deploy import util as auto_deploy_util
 from kubeflow.testing import cleanup_blueprints
 from kubeflow.testing import delete_kf_instance
 from kubeflow.testing import gcp_util
@@ -188,7 +187,7 @@ class PipelineRunWrapper:
 
 def labels_to_selector(labels):
   pairs = []
-  for k,v in labels.items():
+  for k, v in labels.items():
     pairs.append(f"{k}=v")
   return ",".join(pairs)
 
@@ -286,23 +285,31 @@ class BlueprintReconciler: # pylint: disable=too-many-instance-attributes
       **kwargs: Additional constructor arguments see __init__.
     """
 
+    logging.info(f"Reading pipelines from directory {pipelines_dir}")
     pipeline_runs = []
-    for root, _, files in os.walk(pipelines_dir, topdown=False):
-      for f in files:
-        full_path = os.path.join(root, f)
-        if not f.endswith(".yaml"):
-          logging.info(f"Skipping file {full_path}")
-          continue
+    loaded = []
+    # We don't recursively walk the directory because if we do
+    # we end counting files twice when mounting the config map because
+    # of sym-links. If we need to support recursively finding all files
+    # then we will need to find a better solution. os.walk seemed to be
+    # following links even when follow_links wasn't explicitly set.
+    for f in os.listdir(pipelines_dir):
+      full_path = os.path.join(pipelines_dir, f)
+      if not f.endswith(".yaml"):
+        logging.info(f"Skipping file {full_path}")
+        continue
 
-        try:
-          pipeline_runs.append(PipelineRunWrapper.from_file(full_path))
-        except NotAPipeline:
-          logging.info(f"Skipping file {full_path}; does not contain a "
-                       f"PipelineRun")
+      try:
+        pipeline_runs.append(PipelineRunWrapper.from_file(full_path))
+        loaded.append(full_path)
+      except NotAPipeline:
+        logging.info(f"Skipping file {full_path}; does not contain a "
+                     f"PipelineRun")
 
     if not pipeline_runs:
       raise ValueError(f"No pipelineruns loaded from directory {pipelines_dir}")
 
+    logging.info("Loaded pipelineruns:\n%s", "\n".join(loaded))
     reconciler = BlueprintReconciler(pipeline_runs=pipeline_runs,
                                      management_context=management_context,
                                      tekton_context=tekton_context,
@@ -600,11 +607,11 @@ class BlueprintReconciler: # pylint: disable=too-many-instance-attributes
       active_deployments += len(i)
 
 
-    for run in self._pipeline_runs:
+    for i, run in enumerate(self._pipeline_runs):
       self._log_context = {
         GROUP_LABEL: run.group,
       }
-      logging.info(f"Reconciling pipeline group: {run.group}",
+      logging.info(f"Reconciling pipeline {i} group: {run.group}",
                    extra=self._log_context)
 
       branch = run.get_resource_param(BLUEPRINTS_REPO, "revision")

--- a/tekton/templates/tasks/notebook-test-task.yaml
+++ b/tekton/templates/tasks/notebook-test-task.yaml
@@ -46,6 +46,12 @@ spec:
       type: string
       description:
         Directory to write outputs to in local FS.
+    - name: nb-namespace
+      type: string
+      description:
+        The namespace to run the notebook in
+      # The default corresponds to the name of the default profile created by blueprints
+      default: default-profile
     # TODO(jlewi): Lets not use targetPath. Instead lets rely on Tekton checking repos
     # out to /workspace/$(resource.name)
     resources:
@@ -89,6 +95,7 @@ spec:
           --notebook_path=$(inputs.params.notebook-path) \
           --test-target-name=$(inputs.params.test-target-name) \
           --artifacts-gcs=$(inputs.params.artifacts-gcs) \
+          --namespace=$(inputs.params.nb-namespace)
         || echo test finished.
     workingDir: /workspace/src/kubeflow/examples/py/kubeflow/examples/notebook_tests
     env:

--- a/test-infra/auto-deploy/README.md
+++ b/test-infra/auto-deploy/README.md
@@ -84,10 +84,27 @@ The reconciler is currently running in
 * **cluster**: kf-ci-v1
 * **namespace**: auto-deploy
 
-The auto-deployer can be updated using skaffold
+To update it
 
-```
-skaffold run -v info 
-```
+1. Build a new image with skaffold
 
-* You must select the appropriate skaffold profile; e.g. by setting your context to match the context listed in skaffold.yaml
+   ```
+   skaffold build
+   ```
+
+1. Update the kustomization to use the new image
+
+1. Hydrate the ACM repo with the hypdated manifests
+
+   ```
+   make hydrate
+   ```
+
+   * The Makefile is at the root of the repository
+
+1. Push the changes
+
+
+TODO(jlewi): We don't have a good story for testing a development version. Right now the solution would be
+
+1. Update the ACM config to point to a branch which you can push to deploy your changes

--- a/test-infra/auto-deploy/manifest/config/pipeline-run-deploy-blueprint-master.yaml
+++ b/test-infra/auto-deploy/manifest/config/pipeline-run-deploy-blueprint-master.yaml
@@ -8,7 +8,7 @@
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineRun
 metadata:      
-  generateName: deploy-kf-master
+  generateName: deploy-kf-master-
   namespace: auto-deploy
   labels:
     auto-deploy-group: gcp-blueprint-master
@@ -19,7 +19,6 @@ spec:
     resourceSpec:
       type: git
       params:
-        # TODO(jlewi): Switch to master on kubeflow/gcp-blueprints
         - name: revision
           value: master
         - name: url
@@ -28,9 +27,10 @@ spec:
     resourceSpec:
       type: git
       params:
-        # TODO(jlewi): Switch to master on kubeflow/gcp-blueprints
+        # TODO(jlewi): Switch to master once 
+        # https://github.com/kubeflow/testing/pull/676 is submitted
         - name: revision
-          value: gcp_blueprint
+          value: gcp_blueprints
         - name: url
           value: https://github.com/jlewi/testing.git
   # Need to use a KSA with appropriate GSA

--- a/test-infra/auto-deploy/manifest/kustomization.yaml
+++ b/test-infra/auto-deploy/manifest/kustomization.yaml
@@ -5,7 +5,8 @@ namespace: auto-deploy
 commonLabels:
   service: auto-deploy
 images:
-- name: gcr.io/kubeflow-ci/auto_deploy  
+- name: gcr.io/kubeflow-ci/auto_deploy
+  digest: sha256:7b30a7ad4aabcfede8dc9130b99265e213481037ab6a408178319328ba5d37a2
 resources:
 - deployment.yaml
 - service.yaml


### PR DESCRIPTION
* Use ACM to deploy the auto-deploy infrastructure

  * Previously we were using ACM to manage Tekton resources but not
    the auto-deploy server and reconciler

  * Move the Makefile with the hydration rules to the root of the repository

Fix double deployments of blueprints kubeflow/testing#666
  * We were reading pipelineruns twice because of symbolic links

* Related to kubeflow/gcp-blueprints#42 CI for blueprint deployments

* Update OWNERs file.
  * Add Reming and Yuan; remove folks no longer actively working on Kubeflow