### PR TITLE
Create a task and pipeline to check IAP endpoint and KF app deployements

### DIFF
--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_pipeline_gcp-kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_pipeline_gcp-kf-ready.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: gcp-kf-ready
+  namespace: auto-deploy
+spec:
+  params:
+  - description: Cluster pattern to select the KF cluster to run on Default to be
+      from master branch.
+    name: testing-cluster-pattern
+    type: string
+  - description: Location to search for test clusters e.g. us-central1 or us-central1-f
+    name: testing-cluster-location
+    type: string
+  - description: GCS bucket and directory artifacts will be uploaded to. Should be
+      in the form of 'gs://'
+    name: artifacts-gcs
+    type: string
+  resources:
+  - name: kfctl-repo
+    type: git
+  tasks:
+  - name: kf-ready
+    params:
+    - name: testing-cluster-location
+      value: $(params.testing-cluster-location)
+    - name: testing-cluster-pattern
+      value: $(params.testing-cluster-pattern)
+    - name: artifacts-gcs
+      value: $(params.artifacts-gcs)/artifacts/junit_kf-ready
+    resources:
+      inputs:
+      - name: kfctl-repo
+        resource: kfctl-repo
+    taskRef:
+      name: kf-ready
+  - name: iap-ready
+    params:
+    - name: testing-cluster-location
+      value: $(params.testing-cluster-location)
+    - name: testing-cluster-pattern
+      value: $(params.testing-cluster-pattern)
+    - name: artifacts-gcs
+      value: $(params.artifacts-gcs)/artifacts/junit_iap-ready
+    resources:
+      inputs:
+      - name: kfctl-repo
+        resource: kfctl-repo
+    taskRef:
+      name: iap-ready

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_golang-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_golang-test.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3@sha256:2213a6469f83b0a9d3c6a2175b7b64d7c7a16b89dd409b66eef8120f92d00b7e
+    - default: gcr.io/kubeflow-ci/test-worker-py3@sha256:83c6a930354c05261f75aff12cdc3ddadd452a5eaa4727ea065ae6737877be1d
       description: The docker image to run the tests in
       name: test-image
       type: string
@@ -52,9 +52,9 @@ spec:
   - args:
     - -m
     - kubeflow.testing.tekton_client
-    - junit_parse_and_upload
-    - --artifacts_dir=/workspace/artifacts
-    - --output_gcs=$(inputs.params.artifacts-gcs)
+    - junit-parse-and-upload
+    - --artifacts-dir=/workspace/artifacts
+    - --output-gcs=$(inputs.params.artifacts-gcs)
     command:
     - python
     env:

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_iap-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_iap-ready.yaml
@@ -1,0 +1,77 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  annotations:
+    sidecar.istio.io/inject: "false"
+  name: iap-ready
+  namespace: auto-deploy
+spec:
+  inputs:
+    params:
+    - description: Cluster pattern to select the KF cluster to run on Default to be
+        from master branch.
+      name: testing-cluster-pattern
+      type: string
+    - description: Location to search for test clusters e.g. us-central1 or us-central1-f
+      name: testing-cluster-location
+      type: string
+    - default: gcp-iap-ready
+      description: Name to give the test results file.
+      name: test-name
+      type: string
+    - description: GCS bucket and directory artifacts will be uploaded to. Should
+        be in the form of 'gs://'
+      name: artifacts-gcs
+      type: string
+    - default: gcr.io/kubeflow-ci/test-worker-py3:4b85d9b-dirty@sha256:8d71b7db1830f6578af90c7c9b409e3248f8d3a4a8d938017ebe2ae5e5e2747b
+      description: The docker image to run the tests in
+      name: test-image
+      type: string
+    resources:
+    - name: kfctl-repo
+      type: git
+  steps:
+  - args:
+    - -m
+    - kubeflow.testing.get_kf_testing_cluster
+    - --base=$(inputs.params.testing-cluster-pattern)
+    - --location=$(inputs.params.testing-cluster-location)
+    - get-credentials
+    command:
+    - python
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: get-credential
+  - env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: endpoint-ready
+    script: |
+      #!/usr/bin/env bash
+      set -x
+      # Test suite name needs to be unique based on parameters
+      pytest endpoint_ready_test.py \
+        -s \
+        --log-cli-level=info \
+        --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
+        --junitxml=/workspace/artifacts/junit_endpoint-is-ready.xml \
+        --timeout=180 \
+        -o junit_suite_name=test_endpoint_is_ready_blueprint
+      echo test finished.
+    workingDir: /workspace/$(inputs.resources.kfctl-repo.name)/py/kubeflow/kfctl/testing/pytests
+  - args:
+    - -m
+    - kubeflow.testing.tekton_client
+    - junit-parse-and-upload
+    - --artifacts_dir=/workspace/artifacts
+    - --output_gcs=$(inputs.params.artifacts-gcs)
+    command:
+    - python
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: copy-artifacts

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_kf-ready.yaml
@@ -1,0 +1,80 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  annotations:
+    sidecar.istio.io/inject: "false"
+  name: kf-ready
+  namespace: auto-deploy
+spec:
+  inputs:
+    params:
+    - description: Cluster pattern to select the KF cluster to run on Default to be
+        from master branch.
+      name: testing-cluster-pattern
+      type: string
+    - description: Location to search for test clusters e.g. us-central1 or us-central1-f
+      name: testing-cluster-location
+      type: string
+    - default: kf-ready
+      description: Name to give the test results file.
+      name: test-name
+      type: string
+    - description: GCS bucket and directory artifacts will be uploaded to. Should
+        be in the form of 'gs://'
+      name: artifacts-gcs
+      type: string
+    - default: gcr.io/kubeflow-ci/test-worker-py3:4b85d9b-dirty@sha256:8d71b7db1830f6578af90c7c9b409e3248f8d3a4a8d938017ebe2ae5e5e2747b
+      description: The docker image to run the tests in. Should contain a version
+        of kubeflow/testing/py in /srcCache that we want to use.
+      name: test-image
+      type: string
+    resources:
+    - name: kfctl-repo
+      type: git
+  steps:
+  - args:
+    - -m
+    - kubeflow.testing.get_kf_testing_cluster
+    - --base=$(inputs.params.testing-cluster-pattern)
+    - --location=$(inputs.params.testing-cluster-location)
+    - get-credentials
+    command:
+    - python
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: get-credential
+  - env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: kf-ready
+    script: |
+      #!/usr/bin/env bash
+      set -x
+      # I think -s mean stdout/stderr will print out to aid in debugging.
+      # Failures still appear to be captured and stored in the junit file.
+      # Test suite name needs to be unique based on parameters
+      pytest kf_is_ready_test.py \
+        -s \
+        --log-cli-level=info \
+        --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
+        --junitxml=/workspace/artifacts/junit_kf-ready.xml \
+        --timeout=180 \
+        -o junit_suite_name=test_kf_ready_blueprint
+      echo test finished.
+    workingDir: /workspace/$(inputs.resources.kfctl-repo.name)/py/kubeflow/kfctl/testing/pytests
+  - args:
+    - -m
+    - kubeflow.testing.tekton_client
+    - junit-parse-and-upload
+    - --artifacts_dir=/workspace/artifacts
+    - --output_gcs=$(inputs.params.artifacts-gcs)
+    command:
+    - python
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: copy-artifacts

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_pipeline_gcp-kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_pipeline_gcp-kf-ready.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: gcp-kf-ready
+  namespace: kf-ci
+spec:
+  params:
+  - description: Cluster pattern to select the KF cluster to run on Default to be
+      from master branch.
+    name: testing-cluster-pattern
+    type: string
+  - description: Location to search for test clusters e.g. us-central1 or us-central1-f
+    name: testing-cluster-location
+    type: string
+  - description: GCS bucket and directory artifacts will be uploaded to. Should be
+      in the form of 'gs://'
+    name: artifacts-gcs
+    type: string
+  resources:
+  - name: kfctl-repo
+    type: git
+  tasks:
+  - name: kf-ready
+    params:
+    - name: testing-cluster-location
+      value: $(params.testing-cluster-location)
+    - name: testing-cluster-pattern
+      value: $(params.testing-cluster-pattern)
+    - name: artifacts-gcs
+      value: $(params.artifacts-gcs)/artifacts/junit_kf-ready
+    resources:
+      inputs:
+      - name: kfctl-repo
+        resource: kfctl-repo
+    taskRef:
+      name: kf-ready
+  - name: iap-ready
+    params:
+    - name: testing-cluster-location
+      value: $(params.testing-cluster-location)
+    - name: testing-cluster-pattern
+      value: $(params.testing-cluster-pattern)
+    - name: artifacts-gcs
+      value: $(params.artifacts-gcs)/artifacts/junit_iap-ready
+    resources:
+      inputs:
+      - name: kfctl-repo
+        resource: kfctl-repo
+    taskRef:
+      name: iap-ready

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_golang-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_golang-test.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3@sha256:2213a6469f83b0a9d3c6a2175b7b64d7c7a16b89dd409b66eef8120f92d00b7e
+    - default: gcr.io/kubeflow-ci/test-worker-py3@sha256:83c6a930354c05261f75aff12cdc3ddadd452a5eaa4727ea065ae6737877be1d
       description: The docker image to run the tests in
       name: test-image
       type: string
@@ -52,9 +52,9 @@ spec:
   - args:
     - -m
     - kubeflow.testing.tekton_client
-    - junit_parse_and_upload
-    - --artifacts_dir=/workspace/artifacts
-    - --output_gcs=$(inputs.params.artifacts-gcs)
+    - junit-parse-and-upload
+    - --artifacts-dir=/workspace/artifacts
+    - --output-gcs=$(inputs.params.artifacts-gcs)
     command:
     - python
     env:

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_iap-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_iap-ready.yaml
@@ -1,0 +1,77 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  annotations:
+    sidecar.istio.io/inject: "false"
+  name: iap-ready
+  namespace: kf-ci
+spec:
+  inputs:
+    params:
+    - description: Cluster pattern to select the KF cluster to run on Default to be
+        from master branch.
+      name: testing-cluster-pattern
+      type: string
+    - description: Location to search for test clusters e.g. us-central1 or us-central1-f
+      name: testing-cluster-location
+      type: string
+    - default: gcp-iap-ready
+      description: Name to give the test results file.
+      name: test-name
+      type: string
+    - description: GCS bucket and directory artifacts will be uploaded to. Should
+        be in the form of 'gs://'
+      name: artifacts-gcs
+      type: string
+    - default: gcr.io/kubeflow-ci/test-worker-py3:4b85d9b-dirty@sha256:8d71b7db1830f6578af90c7c9b409e3248f8d3a4a8d938017ebe2ae5e5e2747b
+      description: The docker image to run the tests in
+      name: test-image
+      type: string
+    resources:
+    - name: kfctl-repo
+      type: git
+  steps:
+  - args:
+    - -m
+    - kubeflow.testing.get_kf_testing_cluster
+    - --base=$(inputs.params.testing-cluster-pattern)
+    - --location=$(inputs.params.testing-cluster-location)
+    - get-credentials
+    command:
+    - python
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: get-credential
+  - env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: endpoint-ready
+    script: |
+      #!/usr/bin/env bash
+      set -x
+      # Test suite name needs to be unique based on parameters
+      pytest endpoint_ready_test.py \
+        -s \
+        --log-cli-level=info \
+        --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
+        --junitxml=/workspace/artifacts/junit_endpoint-is-ready.xml \
+        --timeout=180 \
+        -o junit_suite_name=test_endpoint_is_ready_blueprint
+      echo test finished.
+    workingDir: /workspace/$(inputs.resources.kfctl-repo.name)/py/kubeflow/kfctl/testing/pytests
+  - args:
+    - -m
+    - kubeflow.testing.tekton_client
+    - junit-parse-and-upload
+    - --artifacts_dir=/workspace/artifacts
+    - --output_gcs=$(inputs.params.artifacts-gcs)
+    command:
+    - python
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: copy-artifacts

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_kf-ready.yaml
@@ -1,0 +1,80 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  annotations:
+    sidecar.istio.io/inject: "false"
+  name: kf-ready
+  namespace: kf-ci
+spec:
+  inputs:
+    params:
+    - description: Cluster pattern to select the KF cluster to run on Default to be
+        from master branch.
+      name: testing-cluster-pattern
+      type: string
+    - description: Location to search for test clusters e.g. us-central1 or us-central1-f
+      name: testing-cluster-location
+      type: string
+    - default: kf-ready
+      description: Name to give the test results file.
+      name: test-name
+      type: string
+    - description: GCS bucket and directory artifacts will be uploaded to. Should
+        be in the form of 'gs://'
+      name: artifacts-gcs
+      type: string
+    - default: gcr.io/kubeflow-ci/test-worker-py3:4b85d9b-dirty@sha256:8d71b7db1830f6578af90c7c9b409e3248f8d3a4a8d938017ebe2ae5e5e2747b
+      description: The docker image to run the tests in. Should contain a version
+        of kubeflow/testing/py in /srcCache that we want to use.
+      name: test-image
+      type: string
+    resources:
+    - name: kfctl-repo
+      type: git
+  steps:
+  - args:
+    - -m
+    - kubeflow.testing.get_kf_testing_cluster
+    - --base=$(inputs.params.testing-cluster-pattern)
+    - --location=$(inputs.params.testing-cluster-location)
+    - get-credentials
+    command:
+    - python
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: get-credential
+  - env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: kf-ready
+    script: |
+      #!/usr/bin/env bash
+      set -x
+      # I think -s mean stdout/stderr will print out to aid in debugging.
+      # Failures still appear to be captured and stored in the junit file.
+      # Test suite name needs to be unique based on parameters
+      pytest kf_is_ready_test.py \
+        -s \
+        --log-cli-level=info \
+        --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
+        --junitxml=/workspace/artifacts/junit_kf-ready.xml \
+        --timeout=180 \
+        -o junit_suite_name=test_kf_ready_blueprint
+      echo test finished.
+    workingDir: /workspace/$(inputs.resources.kfctl-repo.name)/py/kubeflow/kfctl/testing/pytests
+  - args:
+    - -m
+    - kubeflow.testing.tekton_client
+    - junit-parse-and-upload
+    - --artifacts_dir=/workspace/artifacts
+    - --output_gcs=$(inputs.params.artifacts-gcs)
+    command:
+    - python
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: copy-artifacts

--- a/images/Dockerfile.py3
+++ b/images/Dockerfile.py3
@@ -15,10 +15,14 @@ RUN python3.8 -m pip install \
     google-cloud \
     google-cloud-storage \
     junit-xml \
-    kubernetes \
+    # See https://github.com/kubeflow/gcp-blueprints/issues/52#issuecomment-645446088
+    # our libs seem to break with 11.0.0
+    kubernetes==9.0.0 \
     lint \
     oauth2client \
-    pytest \
+    pytest==5.4 \
+    pytest-timeout==1.4 \
+    python-dateutil \
     retrying \
     watchdog
 

--- a/images/README.md
+++ b/images/README.md
@@ -7,7 +7,8 @@ that we use to run a bunch of our test and release scripts.
 ## To build a release image
 
 ```
-skaffold build -v info -p kf-releasing 
+skaffold build -v info -p kf-releasing --file-output=latest_images.release.json
+
 ```
 
 * This will only work if you have access to the release project

--- a/images/latest_images.json
+++ b/images/latest_images.json
@@ -1,0 +1,1 @@
+{"builds":[{"imageName":"gcr.io/kubeflow-ci/test-worker-py3","tag":"gcr.io/kubeflow-ci/test-worker-py3:4b85d9b-dirty@sha256:8d71b7db1830f6578af90c7c9b409e3248f8d3a4a8d938017ebe2ae5e5e2747b"}]}

--- a/tekton/templates/pipelines/gcp-kf-ready.yaml
+++ b/tekton/templates/pipelines/gcp-kf-ready.yaml
@@ -1,0 +1,55 @@
+# This is intended to be a reusable pipeline for verifying that KF is
+# correctly deployed.
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: gcp-kf-ready
+spec:
+  params:
+  - name: testing-cluster-pattern
+    type: string
+    description:
+      Cluster pattern to select the KF cluster to run on
+      Default to be from master branch.
+  - name: testing-cluster-location
+    type: string
+    description:
+      Location to search for test clusters e.g. us-central1 or us-central1-f
+
+  - name: artifacts-gcs
+    type: string
+    description:
+      GCS bucket and directory artifacts will be uploaded to.
+      Should be in the form of 'gs://'
+  resources:
+  - name: kfctl-repo
+    type: git
+  tasks:
+  - name: kf-ready
+    taskRef:
+      name: kf-ready
+    params:
+    - name: testing-cluster-location
+      value: $(params.testing-cluster-location)
+    - name: testing-cluster-pattern
+      value: $(params.testing-cluster-pattern)
+    - name: artifacts-gcs
+      value: $(params.artifacts-gcs)/artifacts/junit_kf-ready
+    resources:
+      inputs:
+      - name: kfctl-repo
+        resource: kfctl-repo
+  - name: iap-ready
+    taskRef:
+      name: iap-ready
+    params:
+    - name: testing-cluster-location
+      value: $(params.testing-cluster-location)
+    - name: testing-cluster-pattern
+      value: $(params.testing-cluster-pattern)
+    - name: artifacts-gcs
+      value: $(params.artifacts-gcs)/artifacts/junit_iap-ready
+    resources:
+      inputs:
+      - name: kfctl-repo
+        resource: kfctl-repo

--- a/tekton/templates/pipelines/kustomization.yaml
+++ b/tekton/templates/pipelines/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deploy-gcp-blueprint-pipeline.yaml
+- gcp-kf-ready.yaml
 - go-test-pipeline.yaml
 - notebook-test-pipeline.yaml

--- a/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
+++ b/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
@@ -1,0 +1,99 @@
+# Verify that the IAP endpoint is accessible.
+
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: iap-ready  
+  annotations:
+    sidecar.istio.io/inject: "false"
+spec:
+  inputs:
+    params:    
+    - name: testing-cluster-pattern
+      type: string
+      description:
+        Cluster pattern to select the KF cluster to run on
+        Default to be from master branch.
+    - name: testing-cluster-location
+      type: string
+      description:
+        Location to search for test clusters e.g. us-central1 or us-central1-f
+
+    #**********************************************************
+    # Kubeflow test parameters
+    #**********************************************************
+    - name: test-name
+      type: string
+      default: gcp-iap-ready
+      description:
+        Name to give the test results file.
+    - name: artifacts-gcs
+      type: string
+      description:
+        GCS bucket and directory artifacts will be uploaded to.
+        Should be in the form of 'gs://'
+
+    - name: test-image
+      type: string
+      default: gcr.io/kubeflow-ci/test-worker-py3:4b85d9b-dirty@sha256:8d71b7db1830f6578af90c7c9b409e3248f8d3a4a8d938017ebe2ae5e5e2747b
+      description: The docker image to run the tests in
+    
+    # TODO(jlewi): Lets not use targetPath. Instead lets rely on Tekton checking repos
+    # out to /workspace/$(resource.name)
+    resources:     
+    - name: kfctl-repo  
+      type: git
+  steps:
+  - name: get-credential
+    image: $(inputs.params.test-image)
+    command:
+    - python
+    args:
+    - -m
+    - kubeflow.testing.get_kf_testing_cluster
+    - --base=$(inputs.params.testing-cluster-pattern)
+    - --location=$(inputs.params.testing-cluster-location)
+    - get-credentials
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+  - name: endpoint-ready
+    image: $(inputs.params.test-image)
+    # Need to use script as workaround not to error out in tests.
+    # If any of the steps returns non-zero codes, subsequent steps will not be run.
+    #
+    # N.B: beware trailing whitespace after "\" it will mess up pytest
+    # N.B: Timeout is based on assumption that we are running against auto-deployments
+    # and things should already be ready
+    script: |
+        #!/usr/bin/env bash
+        set -x
+        # Test suite name needs to be unique based on parameters
+        pytest endpoint_ready_test.py \
+          -s \
+          --log-cli-level=info \
+          --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
+          --junitxml=/workspace/artifacts/junit_endpoint-is-ready.xml \
+          --timeout=180 \
+          -o junit_suite_name=test_endpoint_is_ready_blueprint
+        echo test finished.
+    workingDir: /workspace/$(inputs.resources.kfctl-repo.name)/py/kubeflow/kfctl/testing/pytests
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+  # This step is designed to be generic: given the output directory, it will try to
+  # parse all the XML files with prefix of junit and error out if failures been found.
+  - name: copy-artifacts
+    image: $(inputs.params.test-image)
+    command:
+    - python
+    args:
+    - -m
+    - kubeflow.testing.tekton_client
+    - junit-parse-and-upload
+    - --artifacts_dir=/workspace/artifacts
+    - --output_gcs=$(inputs.params.artifacts-gcs)
+    env:
+    # N.B. This uses the version of kubeflow/testing cached in the docker image.
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py

--- a/tekton/templates/tasks/go-tests.yaml
+++ b/tekton/templates/tasks/go-tests.yaml
@@ -33,7 +33,7 @@ spec:
 
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker-py3@sha256:2213a6469f83b0a9d3c6a2175b7b64d7c7a16b89dd409b66eef8120f92d00b7e
+      default: gcr.io/kubeflow-ci/test-worker-py3@sha256:83c6a930354c05261f75aff12cdc3ddadd452a5eaa4727ea065ae6737877be1d
       description: The docker image to run the tests in
 
     resources:
@@ -73,5 +73,6 @@ spec:
     - --artifacts-dir=/workspace/artifacts
     - --output-gcs=$(inputs.params.artifacts-gcs)
     env:
-    - name: PYTHONPATH
+    # N.B. This uses the version cached in the docker image.
+    - name: PYTHONPATH      
       value: /srcCache/kubeflow/testing/py

--- a/tekton/templates/tasks/kf-ready-task.yaml
+++ b/tekton/templates/tasks/kf-ready-task.yaml
@@ -1,0 +1,99 @@
+# Run a test that verifies a lot of applications
+# were correctly deployed.
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: kf-ready  
+  annotations:
+    sidecar.istio.io/inject: "false"
+spec:
+  inputs:
+    params:    
+    - name: testing-cluster-pattern
+      type: string
+      description:
+        Cluster pattern to select the KF cluster to run on
+        Default to be from master branch.
+    - name: testing-cluster-location
+      type: string
+      description:
+        Location to search for test clusters e.g. us-central1 or us-central1-f
+
+    #**********************************************************
+    # Kubeflow test parameters
+    #**********************************************************
+    - name: test-name
+      type: string
+      default: kf-ready
+      description:
+        Name to give the test results file.
+    - name: artifacts-gcs
+      type: string
+      description:
+        GCS bucket and directory artifacts will be uploaded to.
+        Should be in the form of 'gs://'
+
+    - name: test-image
+      type: string
+      default: gcr.io/kubeflow-ci/test-worker-py3:4b85d9b-dirty@sha256:8d71b7db1830f6578af90c7c9b409e3248f8d3a4a8d938017ebe2ae5e5e2747b
+      description: The docker image to run the tests in. Should contain a version of kubeflow/testing/py in /srcCache
+         that we want to use.
+    resources:
+    - name: kfctl-repo  
+      type: git
+  steps:
+  - name: get-credential
+    image: $(inputs.params.test-image)
+    command:
+    - python
+    args:
+    - -m
+    - kubeflow.testing.get_kf_testing_cluster
+    - --base=$(inputs.params.testing-cluster-pattern)
+    - --location=$(inputs.params.testing-cluster-location)
+    - get-credentials
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+  - name: kf-ready
+    image: $(inputs.params.test-image)
+    # Need to use script as workaround not to error out in tests.
+    # If any of the steps returns non-zero codes, subsequent steps will not be run.
+    #
+    # N.B: beware trailing whitespace after "\" it will mess up pytest
+    #
+    # N.B: Timeout is based on assumption that we are running against auto-deployments
+    # and things should already be ready
+    script: |
+        #!/usr/bin/env bash
+        set -x
+        # I think -s mean stdout/stderr will print out to aid in debugging.
+        # Failures still appear to be captured and stored in the junit file.
+        # Test suite name needs to be unique based on parameters
+        pytest kf_is_ready_test.py \
+          -s \
+          --log-cli-level=info \
+          --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
+          --junitxml=/workspace/artifacts/junit_kf-ready.xml \
+          --timeout=180 \
+          -o junit_suite_name=test_kf_ready_blueprint
+        echo test finished.
+    workingDir: /workspace/$(inputs.resources.kfctl-repo.name)/py/kubeflow/kfctl/testing/pytests
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
+  # This step is designed to be generic: given the output directory, it will try to
+  # parse all the XML files with prefix of junit and error out if failures been found.
+  - name: copy-artifacts
+    image: $(inputs.params.test-image)
+    command:
+    - python
+    args:
+    - -m
+    - kubeflow.testing.tekton_client
+    - junit-parse-and-upload
+    - --artifacts_dir=/workspace/artifacts
+    - --output_gcs=$(inputs.params.artifacts-gcs)
+    env:
+    - name: PYTHONPATH
+      value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py

--- a/tekton/templates/tasks/kustomization.yaml
+++ b/tekton/templates/tasks/kustomization.yaml
@@ -6,5 +6,7 @@ kind: Kustomization
 resources:
 - cleanup-kubeflow-ci.yaml
 - deploy-gcp-blueprint.yaml
-- notebook-test-task.yaml
+- gcp-iap-endpoint-ready-task.yaml
 - go-tests.yaml
+- kf-ready-task.yaml
+- notebook-test-task.yaml


### PR DESCRIPTION
* Related to kubeflow/gcp-deployments#51; to test KF deployments are
  ready we want to create a Tekton pipeline to run the tests
  to verify if KF is ready.

* Add some dependencies to the test worker image

  * Install dateutil
  * install pytest-timeout in the worker image so we can set the --timeout

* Add a Tekton task to check if KF is ready.

  * This runs our existing test to verify that various KF applications
    are ready.

* Tasks should use the version of the kubeflow/testing/py cached in the docker image rather than checking out the testing repo.

* Related to kubeflow/gcp-deployments#52 run a test to check that
  KF applications are deployed.