### PR TITLE
Fix apps CD; install jinja2 library

### DIFF
--- a/apps-cd/README.md
+++ b/apps-cd/README.md
@@ -10,6 +10,13 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+
+## Quick Links
+
+* [Tekton Dashboard for CD runs](https://kf-releasing-0-6-2.endpoints.kubeflow-releasing.cloud.goog/tekton/#/pipelineruns)
+* [Stack Driver Logs For Reconciler](https://console.cloud.google.com/logs/viewer?project=kubeflow-releasing&folder&organizationId&minLogLevel=0&expandAll=false&&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fnamespace_name%2Fkf-releasing&advancedFilter=resource.type%3D%22k8s_container%22%0Alabels.%22k8s-pod%2Fapp%22%20%3D%20%22update-kfapps%22%0A)
+
+
 ## Kubeflow CD with tektoncd pipelines
 
 This directory contains Tekton pipelines intended to rebuild Kubeflow docker images 
@@ -142,6 +149,28 @@ This is a Kubeflow cluster (v0.6.2) and we rely on that to configure certain thi
    kustomize build pipelines/base/ | kubectl apply -f -
    ```
 
+## Pushing Production
+
+1. Build a new image
+
+   ```
+   skaffold build -p prod --kube-context=kf-releasing -v info --file-output=latest_image.json
+   ```
+
+1. Set the image to the newly built image which will be in latest_image.json
+
+   ```
+   cd pipelines/base
+   kustomize edit set image gcr.io/kubeflow-releasing/update_kf_apps=<NEW IMAGE>
+
+   ```
+
+1. Deploy it
+
+   ```
+   kustomize build pipelines/overlays/prod | kubectl --context=kf-releasing apply -f -
+
+   ```
 ## Developer Guide
 
 You can use skaffold to build a docker image and auto update the deployment running `update_kf_apps.py`
@@ -154,6 +183,9 @@ You can use skaffold to build a docker image and auto update the deployment runn
     * You can change this to point to your fork of kubeflow/testing to test your changes
 * You can also deploy any changes to tekton resources to that namespace before trying out
   in prod. 
+
+* **Warning** If you don't delete the dev instance the PRs might end up being created by the dev instance and not
+  the prod instance
 
 1. Run skaffold
 

--- a/apps-cd/latest_image.json
+++ b/apps-cd/latest_image.json
@@ -1,0 +1,1 @@
+{"builds":[{"imageName":"gcr.io/kubeflow-releasing/update_kf_apps","tag":"gcr.io/kubeflow-releasing/update_kf_apps:060b1ab@sha256:677d38b9931547e434fb1951ec2b378672747a4a0af28726d8ddd4160d6d175a"}]}

--- a/apps-cd/pipelines/base/config/app-pipeline.template.yaml
+++ b/apps-cd/pipelines/base/config/app-pipeline.template.yaml
@@ -18,7 +18,7 @@ spec:
   - name: "src_image_url"
     value: "gcr.io/kubeflow-images-public/profile-controller"
   - name: "container_image"
-    value: "gcr.io/kubeflow-releasing/update_kf_apps:d4b8243@sha256:656a4ad689b17715a287f09772cc48444a2190c353c5b84828db4fbf4ede4acc"
+    value: "gcr.io/kubeflow-releasing/update_kf_apps:060b1ab@sha256:677d38b9931547e434fb1951ec2b378672747a4a0af28726d8ddd4160d6d175a"
   resources:
   # The git resources that will be used
   - name: app-repo

--- a/apps-cd/pipelines/base/kustomization.yaml
+++ b/apps-cd/pipelines/base/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:3c9360314639724f4b5e1b675673186b9bad726852b2bc1d5bd14951b6ffd26c
+- digest: sha256:677d38b9931547e434fb1951ec2b378672747a4a0af28726d8ddd4160d6d175a
   name: gcr.io/kubeflow-releasing/update_kf_apps
-  newName: gcr.io/kubeflow-releasing/update_kf_apps:043da55-dirty
+  newName: gcr.io/kubeflow-releasing/update_kf_apps:060b1ab
 resources:
 - service-account.yaml
 - deployment.yaml
@@ -13,7 +13,6 @@ resources:
 namespace: kf-releasing
 # Create a configMap containing the template for the pipeline run
 configMapGenerator:
-- name: pipelinerun-template
-  files:
-    # key will be name of the file
-    - ./config/app-pipeline.template.yaml
+- files:
+  - ./config/app-pipeline.template.yaml
+  name: pipelinerun-template

--- a/apps-cd/requirements.txt
+++ b/apps-cd/requirements.txt
@@ -9,6 +9,7 @@ google-auth==1.6.3
 google-auth-httplib2==0.0.3
 google-cloud-core==1.0.3
 google-cloud-storage==1.17.0
+jinja2==2.11.2
 json-log-formatter==0.2.0
 jwcrypto==0.6.0
 kubernetes==9.0.0

--- a/py/kubeflow/testing/cd/update_kf_apps.py
+++ b/py/kubeflow/testing/cd/update_kf_apps.py
@@ -451,7 +451,7 @@ class UpdateKfApps:
           all_pipelines.append(run_file)
           if needs_update:
             pipelines_to_run.append(run_file)
-        except (ValueError, LookupError) as e:
+        except (FileNotFoundError, LookupError, ValueError) as e:
           failures.append(pair)
           extra = {
             "app": app['name'],


### PR DESCRIPTION
Fix apps CD; install jinja2 library

* The scripts to generate the tests now depend on the jinja2 library but
  its not in the container.

* Add some docs for debugging.

* Related to kubeflow/testing#631

* Catch FilenotFoundErrors
  * The problem is that on master the location of some of the kustomize
    manifests changes (e.g. v3 versions) but for the v1.0 branches
    these paths won't exist. So we should just catch these errors
    and continue.

* Update the docker image used by the Tekton pipeline because we need jinja2.

* Example PR where tests passed: kubeflow/manifests#1273