### PR TITLE
Fix periodic runs of tekton workflows.

### DIFF
--- a/apps-cd/README.md
+++ b/apps-cd/README.md
@@ -169,7 +169,6 @@ This is a Kubeflow cluster (v0.6.2) and we rely on that to configure certain thi
 
    ```
    kustomize build pipelines/overlays/prod | kubectl --context=kf-releasing apply -f -
-
    ```
 ## Developer Guide
 


### PR DESCRIPTION
* Periodic runs aren't associated with a repository/commit; so we shouldn't
  try to substitute into the pipelineruns.

* Add exception handling so we keep going if a workflow has an exception.

* Fix: #696