### PR TITLE
Revamp how Tekton pipelines to run notebooks work.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,29 @@ hydrate:
 	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/auto-deploy $(TEKTON_INSTALLS)/auto-deploy
 	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/kf-ci $(TEKTON_INSTALLS)/kf-ci
 
+build-worker-image:
+	cd images && skaffold build -p testing --kube-context=kubeflow-testing -v info --file-output=latest_image.json
+
+set-worker-image:
+	kpt cfg set ./tekton test-image $(shell yq r ./images/latest_image.json builds[0].tag)
+
+update-worker-image: build-worker-image set-worker-image	
+
+# This is a debug rule providing some sugar to hydrate and push the manifests and then wait for the
+# sync
+debug-push-and-run:
+	make hydrate && git add . && git commit -m "Latest" && git push jlewi
+	cd ./go/cmd/nomos-wait && go run .
+	kubectl --context=kf-ci-v1 create -f ./tekton/runs/nb-test-run.yaml 
+
+# This is a debug rule providing some sugar for fast iteration during development
+# It might need to be customized for your usage.
+# make-update-worker-image builds and sets a new worker image.
+# make hydrate ... rehydrates and pushes the Tekton resources
+# nomos-wait waits for the latest nomos changes to be sync'd
+# and then we submit a run of the pipeline.
+debug-rebuild-and-run:
+	make update-worker-image
+	make hydrate && git add . && git commit -m "Latest" && git push jlewi
+	cd ./go/cmd/nomos-wait && go run .
+	kubectl --context=kf-ci-v1 create -f ./tekton/runs/nb-test-run.yaml 

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_pipeline_notebook-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_pipeline_notebook-test.yaml
@@ -9,6 +9,16 @@ spec:
     description: Test targe name, used to group test results in JUNIT.
     name: test-target-name
     type: string
+  - description: This should be the bucket that the rendered notebook will be written
+      to. This should be a GCS path that is accessible from the KF cluster where the
+      notebook runs. It will be copied to artifacts-gcs
+    name: notebook-output
+    type: string
+  - description: Path to the notebook to run. This should be the relative path relative
+      to the root of the repository where the notebook lives. Do not include a leading
+      "/"
+    name: notebook-path
+    type: string
   - description: GCS bucket and directory artifacts will be uploaded to. Should be
       in the form of 'gs://'
     name: artifacts-gcs
@@ -24,36 +34,41 @@ spec:
   - description: Location to search for test clusters.
     name: testing-cluster-location
     type: string
-  - description: Directory to write outputs to in local FS.
-    name: output-workspace
-    type: string
   resources:
-  - name: examples-repo
+  - name: notebook-repo
     type: git
   - name: testing-repo
     type: git
+  - name: image
+    type: image
   tasks:
-  - name: mnist-gcp
+  - name: build-image
+    params:
+    - name: artifacts-gcs
+      value: $(params.artifacts-gcs)
+    resources:
+      inputs:
+      - name: notebook-repo
+        resource: notebook-repo
+      - name: image
+        resource: image
+    taskRef:
+      name: notebook-test-builder
+  - name: run-notebook
     params:
     - name: notebook-path
-      value: kubeflow/examples/mnist/mnist_gcp.ipynb
-    - name: junit-path
-      value: $(params.output-workspace)/$(params.junit-path)/junit_mnist-gcp.xml
+      value: $(params.notebook-path)
     - name: test-target-name
       value: $(params.test-target-name)
-    - name: output-workspace
-      value: $(params.output-workspace)
+    - name: notebook-output
+      value: $(params.notebook-output)
     - name: artifacts-gcs
       value: $(params.artifacts-gcs)
     - name: testing-cluster-pattern
       value: $(params.testing-cluster-pattern)
     - name: testing-cluster-location
       value: $(params.testing-cluster-location)
-    resources:
-      inputs:
-      - name: examples-repo
-        resource: examples-repo
-      - name: kf-testing-repo
-        resource: testing-repo
+    runAfter:
+    - build-image
     taskRef:
       name: nb-tests

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_cleanup-kubeflow-ci.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_cleanup-kubeflow-ci.yaml
@@ -48,7 +48,7 @@ spec:
       value: /workspace/kubeconfig
     - name: PYTHONPATH
       value: /workspace/$(inputs.resources.testing-repo.name)/py
-    image: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb
+    image: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
     name: create-context
   - command:
     - python

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_deploy-gcp-blueprint.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_deploy-gcp-blueprint.yaml
@@ -39,7 +39,7 @@ spec:
     env:
     - name: KUBECONFIG
       value: /workspace/kubeconfig
-    image: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb
+    image: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
   steps:
   - command:
     - /workspace/$(inputs.resources.blueprint-repo.name)/kubeflow/hack/create_context.sh

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_golang-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_golang-test.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb
+    - default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_iap-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_iap-ready.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb
+    - default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_kf-ready.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb
+    - default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
       description: The docker image to run the tests in. Should contain a version
         of kubeflow/testing/py in /srcCache that we want to use.
       name: test-image

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   inputs:
     params:
-    - description: Testing notebook location. Should be in the form of {REPO_OWNER}/{REPO}/path/to/notebook.ipynb
+    - description: Path to the notebook to run. This should be the relative path relative
+        to the root of the repository where the notebook lives.
       name: notebook-path
       type: string
     - description: Cluster pattern to run the notebook test. Default to be from master
@@ -18,32 +19,27 @@ spec:
     - description: Location to search for test clusters e.g. us-central1 or us-central1-f
       name: testing-cluster-location
       type: string
+    - description: This should be the bucket that the rendered notebook will be written
+        to. This should be a GCS path that is accessible from the KF cluster where
+        the notebook runs. It will be copied to artifacts-gcs
+      name: notebook-output
+      type: string
     - description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
       name: artifacts-gcs
-      type: string
-    - description: Relative path to the GCS artifacts will be uploaded to. Base path
-        is artifacts-gcs so the actual GCS blob will be artifacts-gcs/junit-path
-      name: junit-path
       type: string
     - default: manual-testing
       description: Test targe name, used to group test results in JUNIT.
       name: test-target-name
       type: string
-    - description: Directory to write outputs to in local FS.
-      name: output-workspace
-      type: string
     - default: default-profile
       description: The namespace to run the notebook in
       name: nb-namespace
       type: string
-    resources:
-    - name: examples-repo
-      targetPath: src/kubeflow/examples
-      type: git
-    - name: kf-testing-repo
-      targetPath: src/kubeflow/testing
-      type: git
+    - default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
+      description: The docker image to run the tests in
+      name: test-image
+      type: string
   steps:
   - args:
     - -m
@@ -52,62 +48,49 @@ spec:
     - --location=$(inputs.params.testing-cluster-location)
     - get-credentials
     command:
-    - python3
+    - python
     env:
     - name: PYTHONPATH
-      value: /workspace/src/kubeflow/examples/py:/workspace/src/kubeflow/testing/py
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /secret/gcp-credentials/key.json
-    image: gcr.io/kubeflow-ci/test-worker:latest
+      value: /srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
     name: get-credential
-    volumeMounts:
-    - mountPath: /secret/gcp-credentials
-      name: gcp-credentials
-      readOnly: true
   - env:
     - name: PYTHONPATH
-      value: /workspace/src/kubeflow/examples/py:/workspace/src/kubeflow/testing/py
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /secret/gcp-credentials/key.json
-    image: gcr.io/kubeflow-ci/test-worker:latest
+      value: /srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
     name: run-notebook
     script: |
       #!/usr/bin/env bash
+      set -x
+      mkdir -p /workspace/artifacts
       pytest run_notebook_test.py \
         --log-cli-level=info \
         --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
         --timeout=1800 \
-        --junitxml=$(inputs.params.junit-path) \
-        --notebook_path=$(inputs.params.notebook-path) \
+        --junitxml=/workspace/artifacts/junit_notebook.xml \
+        --notebook_path=/src/notebook-repo/$(inputs.params.notebook-path) \
         --test-target-name=$(inputs.params.test-target-name) \
-        --artifacts-gcs=$(inputs.params.artifacts-gcs) \
+        --artifacts-gcs=$(inputs.params.notebook-output) \
+        --image_file=$(inputs.params.artifacts-gcs)/image.yaml
         --namespace=$(inputs.params.nb-namespace)
-      || echo test finished.
-    volumeMounts:
-    - mountPath: /secret/gcp-credentials
-      name: gcp-credentials
-      readOnly: true
-    workingDir: /workspace/src/kubeflow/examples/py/kubeflow/examples/notebook_tests
+      echo test finished
+    workingDir: /srcCache/kubeflow/testing/py/kubeflow/testing/notebook_tests
+  - image: $(inputs.params.test-image)
+    name: copy-buckets
+    script: |
+      #!/usr/bin/env bash
+      set -x
+      gsutil cp -r $(inputs.params.output)/ $(inputs.params.artifacts-gcs)
   - args:
     - -m
     - kubeflow.testing.tekton_client
     - junit_parse_and_upload
-    - --artifacts_dir=$(inputs.params.output-workspace)
+    - --artifacts_dir=/workspace/artifacts
     - --output_gcs=$(inputs.params.artifacts-gcs)
     command:
     - python
     env:
     - name: PYTHONPATH
-      value: /workspace/src/kubeflow/examples/py:/workspace/src/kubeflow/testing/py
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /secret/gcp-credentials/key.json
-    image: gcr.io/kubeflow-ci/test-worker:latest
+      value: /src/kubeflow/testing/py
+    image: $(inputs.params.test-image)
     name: copy-artifacts
-    volumeMounts:
-    - mountPath: /secret/gcp-credentials
-      name: gcp-credentials
-      readOnly: true
-  volumes:
-  - name: gcp-credentials
-    secret:
-      secretName: gcp-credentials

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_notebook-test-builder.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_notebook-test-builder.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  annotations:
+    sidecar.istio.io/inject: "false"
+  name: notebook-test-builder
+  namespace: auto-deploy
+spec:
+  inputs:
+    params:
+    - default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
+      description: The docker image to run the tests in
+      name: test-image
+      type: string
+    - description: GCS bucket and directory artifacts will be uploaded to. Should
+        be in the form of 'gs://'
+      name: artifacts-gcs
+      type: string
+    resources:
+    - name: notebook-repo
+      type: git
+    - name: image
+      type: image
+  steps:
+  - image: $(inputs.params.test-image)
+    name: setup
+    script: |
+      #!/usr/bin/env bash
+      set -x
+      mkdir -p /workspace/build
+      cd /workspace/build
+      # Copy the source code
+      cp -r /workspace/$(inputs.resources.notebook-repo.name) .
+      cp -r /srcCache/kubeflow/testing/notebook_testing/Dockerfile.notebook_runner ./Dockerfile.notebook_runner
+      mkdir -p kubeflow/
+      # Copy over the kubeflow/testing directory because we need it to run the
+      # notebooks; note that the copy is coming from the worker test image.
+      cp -r /srcCache/kubeflow/testing ./kubeflow/testing
+      # Create the artifacts directory
+      mkdir -p /workspace/artifacts
+  - command:
+    - /kaniko/executor
+    - --dockerfile=/workspace/build/Dockerfile.notebook_runner
+    - --destination=$(inputs.resources.image.url)
+    - --context=/workspace/build
+    - --digest-file=/workspace/artifacts/image-digest
+    image: gcr.io/kaniko-project/executor:v0.23.0
+    name: build-push
+    resources:
+      requests:
+        cpu: 7
+        memory: 16Gi
+  - args:
+    - -m
+    - kubeflow.testing.tekton_client
+    - create-image-file
+    - --image-name=$(inputs.resources.image.url)
+    - --digest-file=/workspace/artifacts/image-digest
+    - --output=$(inputs.params.artifacts-gcs)/image.yaml
+    command:
+    - python
+    env:
+    - name: PYTHONPATH
+      value: /srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: create-image-file

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_pipeline_notebook-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_pipeline_notebook-test.yaml
@@ -9,6 +9,16 @@ spec:
     description: Test targe name, used to group test results in JUNIT.
     name: test-target-name
     type: string
+  - description: This should be the bucket that the rendered notebook will be written
+      to. This should be a GCS path that is accessible from the KF cluster where the
+      notebook runs. It will be copied to artifacts-gcs
+    name: notebook-output
+    type: string
+  - description: Path to the notebook to run. This should be the relative path relative
+      to the root of the repository where the notebook lives. Do not include a leading
+      "/"
+    name: notebook-path
+    type: string
   - description: GCS bucket and directory artifacts will be uploaded to. Should be
       in the form of 'gs://'
     name: artifacts-gcs
@@ -24,36 +34,41 @@ spec:
   - description: Location to search for test clusters.
     name: testing-cluster-location
     type: string
-  - description: Directory to write outputs to in local FS.
-    name: output-workspace
-    type: string
   resources:
-  - name: examples-repo
+  - name: notebook-repo
     type: git
   - name: testing-repo
     type: git
+  - name: image
+    type: image
   tasks:
-  - name: mnist-gcp
+  - name: build-image
+    params:
+    - name: artifacts-gcs
+      value: $(params.artifacts-gcs)
+    resources:
+      inputs:
+      - name: notebook-repo
+        resource: notebook-repo
+      - name: image
+        resource: image
+    taskRef:
+      name: notebook-test-builder
+  - name: run-notebook
     params:
     - name: notebook-path
-      value: kubeflow/examples/mnist/mnist_gcp.ipynb
-    - name: junit-path
-      value: $(params.output-workspace)/$(params.junit-path)/junit_mnist-gcp.xml
+      value: $(params.notebook-path)
     - name: test-target-name
       value: $(params.test-target-name)
-    - name: output-workspace
-      value: $(params.output-workspace)
+    - name: notebook-output
+      value: $(params.notebook-output)
     - name: artifacts-gcs
       value: $(params.artifacts-gcs)
     - name: testing-cluster-pattern
       value: $(params.testing-cluster-pattern)
     - name: testing-cluster-location
       value: $(params.testing-cluster-location)
-    resources:
-      inputs:
-      - name: examples-repo
-        resource: examples-repo
-      - name: kf-testing-repo
-        resource: testing-repo
+    runAfter:
+    - build-image
     taskRef:
       name: nb-tests

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_cleanup-kubeflow-ci.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_cleanup-kubeflow-ci.yaml
@@ -48,7 +48,7 @@ spec:
       value: /workspace/kubeconfig
     - name: PYTHONPATH
       value: /workspace/$(inputs.resources.testing-repo.name)/py
-    image: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb
+    image: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
     name: create-context
   - command:
     - python

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_deploy-gcp-blueprint.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_deploy-gcp-blueprint.yaml
@@ -39,7 +39,7 @@ spec:
     env:
     - name: KUBECONFIG
       value: /workspace/kubeconfig
-    image: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb
+    image: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
   steps:
   - command:
     - /workspace/$(inputs.resources.blueprint-repo.name)/kubeflow/hack/create_context.sh

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_golang-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_golang-test.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb
+    - default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_iap-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_iap-ready.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb
+    - default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_kf-ready.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb
+    - default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
       description: The docker image to run the tests in. Should contain a version
         of kubeflow/testing/py in /srcCache that we want to use.
       name: test-image

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   inputs:
     params:
-    - description: Testing notebook location. Should be in the form of {REPO_OWNER}/{REPO}/path/to/notebook.ipynb
+    - description: Path to the notebook to run. This should be the relative path relative
+        to the root of the repository where the notebook lives.
       name: notebook-path
       type: string
     - description: Cluster pattern to run the notebook test. Default to be from master
@@ -18,32 +19,27 @@ spec:
     - description: Location to search for test clusters e.g. us-central1 or us-central1-f
       name: testing-cluster-location
       type: string
+    - description: This should be the bucket that the rendered notebook will be written
+        to. This should be a GCS path that is accessible from the KF cluster where
+        the notebook runs. It will be copied to artifacts-gcs
+      name: notebook-output
+      type: string
     - description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
       name: artifacts-gcs
-      type: string
-    - description: Relative path to the GCS artifacts will be uploaded to. Base path
-        is artifacts-gcs so the actual GCS blob will be artifacts-gcs/junit-path
-      name: junit-path
       type: string
     - default: manual-testing
       description: Test targe name, used to group test results in JUNIT.
       name: test-target-name
       type: string
-    - description: Directory to write outputs to in local FS.
-      name: output-workspace
-      type: string
     - default: default-profile
       description: The namespace to run the notebook in
       name: nb-namespace
       type: string
-    resources:
-    - name: examples-repo
-      targetPath: src/kubeflow/examples
-      type: git
-    - name: kf-testing-repo
-      targetPath: src/kubeflow/testing
-      type: git
+    - default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
+      description: The docker image to run the tests in
+      name: test-image
+      type: string
   steps:
   - args:
     - -m
@@ -52,62 +48,49 @@ spec:
     - --location=$(inputs.params.testing-cluster-location)
     - get-credentials
     command:
-    - python3
+    - python
     env:
     - name: PYTHONPATH
-      value: /workspace/src/kubeflow/examples/py:/workspace/src/kubeflow/testing/py
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /secret/gcp-credentials/key.json
-    image: gcr.io/kubeflow-ci/test-worker:latest
+      value: /srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
     name: get-credential
-    volumeMounts:
-    - mountPath: /secret/gcp-credentials
-      name: gcp-credentials
-      readOnly: true
   - env:
     - name: PYTHONPATH
-      value: /workspace/src/kubeflow/examples/py:/workspace/src/kubeflow/testing/py
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /secret/gcp-credentials/key.json
-    image: gcr.io/kubeflow-ci/test-worker:latest
+      value: /srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
     name: run-notebook
     script: |
       #!/usr/bin/env bash
+      set -x
+      mkdir -p /workspace/artifacts
       pytest run_notebook_test.py \
         --log-cli-level=info \
         --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
         --timeout=1800 \
-        --junitxml=$(inputs.params.junit-path) \
-        --notebook_path=$(inputs.params.notebook-path) \
+        --junitxml=/workspace/artifacts/junit_notebook.xml \
+        --notebook_path=/src/notebook-repo/$(inputs.params.notebook-path) \
         --test-target-name=$(inputs.params.test-target-name) \
-        --artifacts-gcs=$(inputs.params.artifacts-gcs) \
+        --artifacts-gcs=$(inputs.params.notebook-output) \
+        --image_file=$(inputs.params.artifacts-gcs)/image.yaml
         --namespace=$(inputs.params.nb-namespace)
-      || echo test finished.
-    volumeMounts:
-    - mountPath: /secret/gcp-credentials
-      name: gcp-credentials
-      readOnly: true
-    workingDir: /workspace/src/kubeflow/examples/py/kubeflow/examples/notebook_tests
+      echo test finished
+    workingDir: /srcCache/kubeflow/testing/py/kubeflow/testing/notebook_tests
+  - image: $(inputs.params.test-image)
+    name: copy-buckets
+    script: |
+      #!/usr/bin/env bash
+      set -x
+      gsutil cp -r $(inputs.params.output)/ $(inputs.params.artifacts-gcs)
   - args:
     - -m
     - kubeflow.testing.tekton_client
     - junit_parse_and_upload
-    - --artifacts_dir=$(inputs.params.output-workspace)
+    - --artifacts_dir=/workspace/artifacts
     - --output_gcs=$(inputs.params.artifacts-gcs)
     command:
     - python
     env:
     - name: PYTHONPATH
-      value: /workspace/src/kubeflow/examples/py:/workspace/src/kubeflow/testing/py
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /secret/gcp-credentials/key.json
-    image: gcr.io/kubeflow-ci/test-worker:latest
+      value: /src/kubeflow/testing/py
+    image: $(inputs.params.test-image)
     name: copy-artifacts
-    volumeMounts:
-    - mountPath: /secret/gcp-credentials
-      name: gcp-credentials
-      readOnly: true
-  volumes:
-  - name: gcp-credentials
-    secret:
-      secretName: gcp-credentials

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_notebook-test-builder.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_notebook-test-builder.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  annotations:
+    sidecar.istio.io/inject: "false"
+  name: notebook-test-builder
+  namespace: kf-ci
+spec:
+  inputs:
+    params:
+    - default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea
+      description: The docker image to run the tests in
+      name: test-image
+      type: string
+    - description: GCS bucket and directory artifacts will be uploaded to. Should
+        be in the form of 'gs://'
+      name: artifacts-gcs
+      type: string
+    resources:
+    - name: notebook-repo
+      type: git
+    - name: image
+      type: image
+  steps:
+  - image: $(inputs.params.test-image)
+    name: setup
+    script: |
+      #!/usr/bin/env bash
+      set -x
+      mkdir -p /workspace/build
+      cd /workspace/build
+      # Copy the source code
+      cp -r /workspace/$(inputs.resources.notebook-repo.name) .
+      cp -r /srcCache/kubeflow/testing/notebook_testing/Dockerfile.notebook_runner ./Dockerfile.notebook_runner
+      mkdir -p kubeflow/
+      # Copy over the kubeflow/testing directory because we need it to run the
+      # notebooks; note that the copy is coming from the worker test image.
+      cp -r /srcCache/kubeflow/testing ./kubeflow/testing
+      # Create the artifacts directory
+      mkdir -p /workspace/artifacts
+  - command:
+    - /kaniko/executor
+    - --dockerfile=/workspace/build/Dockerfile.notebook_runner
+    - --destination=$(inputs.resources.image.url)
+    - --context=/workspace/build
+    - --digest-file=/workspace/artifacts/image-digest
+    image: gcr.io/kaniko-project/executor:v0.23.0
+    name: build-push
+    resources:
+      requests:
+        cpu: 7
+        memory: 16Gi
+  - args:
+    - -m
+    - kubeflow.testing.tekton_client
+    - create-image-file
+    - --image-name=$(inputs.resources.image.url)
+    - --digest-file=/workspace/artifacts/image-digest
+    - --output=$(inputs.params.artifacts-gcs)/image.yaml
+    command:
+    - python
+    env:
+    - name: PYTHONPATH
+      value: /srcCache/kubeflow/testing/py
+    image: $(inputs.params.test-image)
+    name: create-image-file

--- a/go/cmd/nomos-wait/go.mod
+++ b/go/cmd/nomos-wait/go.mod
@@ -1,0 +1,5 @@
+module github.com/kubeflow/testing/go/cmd/nomos-wait
+
+go 1.13
+
+require github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/go/cmd/nomos-wait/go.sum
+++ b/go/cmd/nomos-wait/go.sum
@@ -1,0 +1,2 @@
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/go/cmd/nomos-wait/main.go
+++ b/go/cmd/nomos-wait/main.go
@@ -1,0 +1,62 @@
+// nomos-wait is a simple tool to wait until nomos has been sync'd to the current commit.
+package main
+
+import (
+	"flag"
+	"fmt"
+	log "github.com/golang/glog"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func parseStatus(result string) (string, string, error) {
+	lines := strings.Split(result,"\n")
+	for _, l := range lines {
+		columns := strings.Fields(l)
+		if len(columns) != 5 || columns[0] != "*" {
+			continue
+		}
+		return columns[2], columns[3], nil
+	}
+
+	return "", "", fmt.Errorf("Failed to parse nomos status from:\n%v", result)
+}
+
+func main() {
+	var context = flag.String("context", "kf-ci-v1", "Kubernetes context for nomos status")
+	flag.Parse()
+
+	gitOut, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+
+	if err != nil {
+		log.Fatalf("Failed to get git commit; %v", err)
+	}
+
+	commit := strings.TrimSpace(string(gitOut))
+
+	fmt.Printf("Current commit: %v\n", commit)
+
+	for ;; {
+		out, err := exec.Command("nomos", "--contexts=" + *context, "status").Output()
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		status, syncCommit, err := parseStatus(string(out))
+
+		if err != nil {
+			log.Fatalf("Could not parse nomos output; %v", out)
+		}
+
+		fmt.Printf("Nomos status: %v; commit: %v \n", status, syncCommit)
+
+		if status == "SYNCED" && strings.HasPrefix(syncCommit, commit) {
+			fmt.Printf("nomos synced to commit %v \n", commit)
+			return
+		}
+		fmt.Printf("Waiting for sync to commit %v \n", commit)
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/go/cmd/nomos-wait/main_test.go
+++ b/go/cmd/nomos-wait/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	testData := `Current   Context    Status           Last Synced Token   Sync Branch
+-------   -------    ------           -----------------   -----------
+*         kf-ci-v1   SYNCED           79629ca7            gcp_blueprints`
+
+	status, commit, err := parseStatus(testData)
+	//#err := parseS(testData)
+
+	if err != nil {
+		t.Errorf("Expected nil; got error %v", err)
+	}
+
+	expected := "79629ca7"
+	if commit != expected {
+		t.Errorf("Got commit: %v; want %v", commit, expected)
+	}
+
+	expectedStatus := "SYNCED"
+	if status != expectedStatus {
+		t.Errorf("Got status: %v; want %v", commit, expectedStatus)
+	}
+}

--- a/images/Dockerfile.py3
+++ b/images/Dockerfile.py3
@@ -108,3 +108,4 @@ RUN go get -u github.com/jstemmer/go-junit-report
 # need to clone the repo just to get access to them
 RUN mkdir -p /srcCache/kubeflow/testing
 COPY py /srcCache/kubeflow/testing/py
+COPY notebook_testing /srcCache/kubeflow/testing/notebook_testing

--- a/images/README.md
+++ b/images/README.md
@@ -5,17 +5,10 @@ that we use to run a bunch of our test and release scripts.
 
 ## To update the test worker images used in the Tekton tasks
 
-1. Build a new image.
-
-   ```
-   skaffold build -p testing --kube-context=kubeflow-testing -v info --file-output=latest_image.json
-   ```
-1. Set the `kpt setter`
-
-   ```
-   kpt cfg set ./tekton test-image ${IMAGE}
-
-   ```
+```
+cd ..
+make update-worker-image
+```
 
 ## To build a release image
 

--- a/images/latest_image.json
+++ b/images/latest_image.json
@@ -1,1 +1,1 @@
-{"builds":[{"imageName":"gcr.io/kubeflow-ci/test-worker-py3","tag":"gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb"}]}
+{"builds":[{"imageName":"gcr.io/kubeflow-ci/test-worker-py3","tag":"gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea"}]}

--- a/notebook_testing/Dockerfile.notebook_runner
+++ b/notebook_testing/Dockerfile.notebook_runner
@@ -1,0 +1,18 @@
+# Dockerfile for building docker images to run notebooks
+# in.
+ARG BASE_IMAGE=gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
+
+FROM $BASE_IMAGE
+
+USER root
+
+RUN pip3 install -Iv papermill==2.0.0 
+RUN pip3 install -U nbconvert 
+RUN pip3 install -U nbformat
+RUN pip3 install -U retrying
+
+USER jovyan
+
+# Copy any source code into /src
+COPY . /src
+

--- a/notebook_testing/README.md
+++ b/notebook_testing/README.md
@@ -1,0 +1,3 @@
+# Notebook testing
+
+This directory contains some resources used for testing notebooks.

--- a/py/kubeflow/testing/notebook_tests/conftest.py
+++ b/py/kubeflow/testing/notebook_tests/conftest.py
@@ -1,0 +1,51 @@
+import pytest
+
+def pytest_addoption(parser):
+  parser.addoption(
+    "--name", help="Name for the job. If not specified one was created "
+    "automatically", type=str, default="")
+  parser.addoption(
+    "--namespace", help=("The namespace to run in. This should correspond to"
+                         "a namespace associated with a Kubeflow namespace."),
+                   type=str,
+    default="default-profile")
+  parser.addoption(
+    "--image_file", help="Yaml file containing the docker image to use. Can be "
+                         "GCS path",
+    type=str,
+    default="")
+  parser.addoption(
+    "--notebook_path", help=("Path to the testing notebook file"),
+    type=str, default="")
+  parser.addoption(
+    "--test-target-name", help=("Test target name, used as junit class name."),
+    type=str, default="notebook-test")
+  parser.addoption(
+    "--artifacts-gcs", help=("GCS to upload artifacts to. This location "
+                             "should be writable from the cluster running "
+                             "the notebook."),
+    type=str, default="")
+
+@pytest.fixture
+def name(request):
+  return request.config.getoption("--name")
+
+@pytest.fixture
+def namespace(request):
+  return request.config.getoption("--namespace")
+
+@pytest.fixture
+def image_file(request):
+  return request.config.getoption("--image_file")
+
+@pytest.fixture
+def notebook_path(request):
+  return request.config.getoption("--notebook_path")
+
+@pytest.fixture
+def test_target_name(request):
+  return request.config.getoption("--test-target-name")
+
+@pytest.fixture
+def artifacts_gcs(request):
+  return request.config.getoption("--artifacts-gcs")

--- a/py/kubeflow/testing/notebook_tests/execute_notebook.py
+++ b/py/kubeflow/testing/notebook_tests/execute_notebook.py
@@ -1,0 +1,93 @@
+import argparse
+import tempfile
+import logging
+import nbformat
+import nbconvert
+import os
+import papermill
+from papermill import exceptions as papermill_exceptions
+
+logger = logging.getLogger(__name__)
+
+from google.cloud import storage
+from kubeflow.testing import gcp_util
+from kubeflow.testing import util
+
+def execute_notebook(notebook_path, parameters=None):
+  temp_dir = tempfile.mkdtemp()
+
+  logging.info("Executing notebook")
+  notebook_output_path = os.path.join(temp_dir, "out.ipynb")
+  try:
+    papermill.execute_notebook(notebook_path, notebook_output_path,
+                               cwd=os.path.dirname(notebook_path),
+                               parameters=parameters,
+                               log_output=True)
+  # Catch exceptions because we don't want to terminate because we still want
+  # to upload output
+  except papermill_exceptions.PapermillExecutionError as e:
+    logging.error(f"Exception occurred while running notebook {notebook_path}")
+    logging.error(f"Exception occurred while running notebook {e}")
+  except Exception as e: # pylint: disable=broad-except
+    logging.error(f"Unexpected exception occurred while running notebook "
+                  f"{notebook_path}")
+    logging.error(f"Unexpected exception occurred while running notebook {e}")
+  logging.info(f"Finished executing notebook; saved to {notebook_output_path}")
+  return notebook_output_path
+
+def _upload_notebook_html(content, target):
+  gcs_client = storage.Client()
+  bucket_name, path = util.split_gcs_uri(target)
+
+  bucket = gcs_client.get_bucket(bucket_name)
+
+  logging.info("Uploading notebook to %s.", target)
+  blob = bucket.blob(path)
+  # Need to set content type so that if we browse in GCS we end up rendering
+  # as html.
+  blob.upload_from_string(content, content_type="text/html")
+
+def run_notebook_test(notebook_path, parameters=None):
+  # Ensure workload identity is ready.
+  # TODO(jlewi): Need to skip this when not running on GCP.
+  gcp_util.get_gcp_credentials()
+  output_path = execute_notebook(notebook_path, parameters=parameters)
+
+  logging.info(f"Reading notebook {output_path}")
+  with open(output_path, "r") as hf:
+    actual_output = hf.read()
+
+  logging.info("Converting notebook to html")
+  nb = nbformat.reads(actual_output, as_version=4)
+  html_exporter = nbconvert.HTMLExporter()
+  (html_output, _) = html_exporter.from_notebook_node(nb)
+  gcs_path = os.getenv("OUTPUT_GCS")
+  logging.info(f"Uploading notebook to {gcs_path}")
+  _upload_notebook_html(html_output, gcs_path)
+
+class NotebookExecutor:
+  @staticmethod
+  def test(notebook_path):
+    """Test a notebook.
+
+    Args:
+      notebook_path: Absolute path of the notebook.
+    """
+    run_notebook_test(notebook_path)
+
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(message)s|%(pathname)s|%(lineno)d|'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+
+  # fire isn't available in the notebook image which is why we aren't
+  # using it.
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+    "--notebook_path", default="", type=str, help=("Path to the notebook"))
+
+  args = parser.parse_args()
+
+  NotebookExecutor.test(args.notebook_path)

--- a/py/kubeflow/testing/notebook_tests/job.yaml
+++ b/py/kubeflow/testing/notebook_tests/job.yaml
@@ -1,0 +1,37 @@
+# A batch job to run a notebook using papermill.
+# The YAML is modified by nb_test_util.py to generate a Job specific
+# to a notebook.
+#
+# TODO(jlewi): We should switch to using Tekton
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nb-test
+  labels:
+    app: nb-test
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      annotations:
+        # TODO(jlewi): Do we really want to disable sidecar injection
+        # in the test? Would it be better to use istio to mimic what happens
+        # in notebooks?
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: nb-test
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 0
+      containers:
+      - env:
+        - name: PYTHONPATH
+          value: /src/kubeflow/testing/py/
+        name: executing-notebooks
+        image: execute-image
+        # Command will get overwritten by nb_test_util.py
+        command: ["python3", "-m",
+                  "kubeflow.testing.notebook_tests.execute_notebook",
+                  "test", "/src/kubeflow/examples/mnist/mnist_gcp.ipynb"]
+      serviceAccount: default-editor

--- a/py/kubeflow/testing/notebook_tests/nb_test_util.py
+++ b/py/kubeflow/testing/notebook_tests/nb_test_util.py
@@ -21,7 +21,7 @@ PROJECT = "kubeflow-ci-deployment"
 def logs_for_job(project, job_name):
   """Get a stack driver link for the job with the specified name."""
   logs_filter = f"""resource.type="k8s_container"
-   labels."k8s-pod/job-name" = "{job_name}"
+labels."k8s-pod/job-name" = "{job_name}"
 """
 
   new_params = {"project": project,

--- a/py/kubeflow/testing/notebook_tests/nb_test_util.py
+++ b/py/kubeflow/testing/notebook_tests/nb_test_util.py
@@ -1,0 +1,112 @@
+"""Some utitilies for running notebook tests."""
+
+import datetime
+import logging
+import os
+from urllib.parse import urlencode
+import uuid
+import yaml
+
+from google.cloud import storage
+from kubernetes import client as k8s_client
+from kubeflow.testing import util
+
+# This is the bucket where the batch jobs will uploaded an HTML version of the
+# notebook will be written to. The K8s job is running in a Kubeflow cluster
+# so it needs to be a bucket that the kubeflow cluster can write to.
+# This is why we don't write directly to the bucket used for prow artifacts
+NB_BUCKET = "kubeflow-ci-deployment"
+PROJECT = "kubeflow-ci-deployment"
+
+def logs_for_job(project, job_name):
+  """Get a stack driver link for the job with the specified name."""
+  logs_filter = f"""resource.type="k8s_container"
+   labels."k8s-pod/job-name" = "{job_name}"
+"""
+
+  new_params = {"project": project,
+                # Logs for last 7 days
+                "interval": 'P7D',
+                "advancedFilter": logs_filter}
+
+  query = urlencode(new_params)
+
+  url = "https://console.cloud.google.com/logs/viewer?" + query
+
+  return url
+
+def run_papermill_job(notebook_path, name, namespace, # pylint: disable=too-many-branches,too-many-statements
+                      image, output=""):
+  """Generate a K8s job to run a notebook using papermill
+
+  Args:
+    notebook_path: Path to the notebook.
+    name: Name for the K8s job
+    namespace: The namespace where the job should run.
+    image: The docker image to run the notebook in.
+    output = Location where artifacts like the rendered notebook
+      should be uploaded. Should generally be an object storage path.
+      Currently only GCS is supported.
+  """
+
+  util.maybe_activate_service_account()
+
+  with open("job.yaml") as hf:
+    job = yaml.load(hf)
+
+  job["spec"]["template"]["spec"]["containers"][0]["image"] = image
+
+  job["spec"]["template"]["spec"]["containers"][0]["command"] = [
+    "python3", "-m",
+    "kubeflow.testing.notebook_tests.execute_notebook",
+    "--notebook_path", notebook_path]
+
+  job["spec"]["template"]["spec"]["containers"][0]["env"] = [
+    {"name": "OUTPUT_GCS", "value": output},
+    {"name": "PYTHONPATH",
+     "value": "/src/kubeflow/testing/py"},
+  ]
+
+  logging.info("Notebook will be written to %s", output)
+  util.load_kube_config(persist_config=False)
+
+  if name:
+    job["metadata"]["name"] = name
+  else:
+    job["metadata"]["name"] = ("notebook-test-" +
+                               datetime.datetime.now().strftime("%H%M%S")
+                               + "-" + uuid.uuid4().hex[0:3])
+  name = job["metadata"]["name"]
+
+  job["metadata"]["namespace"] = namespace
+
+  # Create an API client object to talk to the K8s master.
+  api_client = k8s_client.ApiClient()
+  batch_api = k8s_client.BatchV1Api(api_client)
+
+  logging.info("Creating job:\n%s", yaml.dump(job))
+  actual_job = batch_api.create_namespaced_job(job["metadata"]["namespace"],
+                                               job)
+  logging.info("Created job %s.%s:\n%s", namespace, name,
+               yaml.safe_dump(actual_job.to_dict()))
+
+  logging.info("*********************Job logs************************")
+  logging.info(logs_for_job(PROJECT, name))
+  logging.info("*****************************************************")
+  final_job = util.wait_for_job(api_client, namespace, name,
+                                timeout=datetime.timedelta(minutes=30))
+
+  logging.info("Final job:\n%s", yaml.safe_dump(final_job.to_dict()))
+
+  logging.info("*********************Job logs************************")
+  logging.info(logs_for_job(PROJECT, name))
+  logging.info("*****************************************************")
+
+  if not final_job.status.conditions:
+    raise RuntimeError("Job {0}.{1}; did not complete".format(namespace, name))
+
+  last_condition = final_job.status.conditions[-1]
+
+  if last_condition.type not in ["Complete"]:
+    logging.error("Job didn't complete successfully")
+    raise RuntimeError("Job {0}.{1} failed".format(namespace, name))

--- a/py/kubeflow/testing/notebook_tests/run_notebook_test.py
+++ b/py/kubeflow/testing/notebook_tests/run_notebook_test.py
@@ -1,0 +1,50 @@
+"""Runs notebook ipynb as test."""
+
+import datetime
+import logging
+import os
+import uuid
+import yaml
+
+import pytest
+
+from kubeflow.testing.notebook_tests import nb_test_util
+from kubeflow.testing import util
+
+def test_run_notebook(record_xml_attribute, namespace, # pylint: disable=too-many-branches,too-many-statements
+                      image_file, notebook_path, test_target_name,
+                      artifacts_gcs):
+
+  if not image_file:
+    raise ValueError("image_file must provided")
+
+  notebook_name = os.path.basename(
+      notebook_path).replace(".ipynb", "").replace("_", "-")
+  junit_name = "_".join(["test", notebook_name])
+  util.set_pytest_junit(record_xml_attribute, junit_name, test_target_name)
+
+  name = "-".join([notebook_name,
+                   datetime.datetime.now().strftime("%H%M%S"),
+                   uuid.uuid4().hex[0:3]])
+
+  logging.info(f"Reading file {image_file}")
+  contents = util.read_file(image_file)
+  image_data = yaml.load(contents)
+
+  if not "image" in image_data:
+    raise ValueError(f"File {image_file} is missing field image containing "
+                     f"the URI of the docker image to run the notebook in")
+
+  image = image_data["image"]
+  logging.info(f"Using image {image}")
+  nb_test_util.run_papermill_job(notebook_path, name, namespace, image,
+                                 artifacts_gcs)
+
+if __name__ == '__main__':
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(pathname)s|%(lineno)d| %(message)s'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+  logging.getLogger().setLevel(logging.INFO)
+  pytest.main()

--- a/py/kubeflow/testing/tekton_client.py
+++ b/py/kubeflow/testing/tekton_client.py
@@ -434,7 +434,7 @@ class CLI(object): # pylint: disable=useless-object-inheritance
       digest = hf.read()
     digest = digest.strip()
 
-    full_image = f"{image_name}@{digest}"
+    full_image = "{0}@{1}".format(image_name, digest)
     logging.info(f"Full digest: {full_image}")
 
     contents = {

--- a/py/kubeflow/testing/tekton_client.py
+++ b/py/kubeflow/testing/tekton_client.py
@@ -435,7 +435,7 @@ class CLI(object): # pylint: disable=useless-object-inheritance
     digest = digest.strip()
 
     full_image = "{0}@{1}".format(image_name, digest)
-    logging.info(f"Full digest: {full_image}")
+    logging.info("Full digest: %s", full_image})
 
     contents = {
       "image": full_image
@@ -449,7 +449,7 @@ class CLI(object): # pylint: disable=useless-object-inheritance
     else:
       local_file = output
 
-    logging.info(f"Writing to {local_file}")
+    logging.info("Writing to %s", local_file)
     with open(local_file, "w") as hf:
       yaml.dump(contents, hf)
 

--- a/py/kubeflow/testing/tekton_client.py
+++ b/py/kubeflow/testing/tekton_client.py
@@ -435,7 +435,7 @@ class CLI(object): # pylint: disable=useless-object-inheritance
     digest = digest.strip()
 
     full_image = "{0}@{1}".format(image_name, digest)
-    logging.info("Full digest: %s", full_image})
+    logging.info("Full digest: %s", full_image)
 
     contents = {
       "image": full_image

--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -865,6 +865,29 @@ def upload_file_to_gcs(source, target):
   blob.upload_from_filename(source)
 
 
+def read_file(path):
+  """Read a file.
+
+  Args:
+    path: A local or GCS path.
+
+  Returns:
+    contents: Contents of the file
+  """
+
+  if not path.lower().startswith("gs://"):
+    with open(path) as hf:
+      hf.read()
+
+  bucket_name, path = split_gcs_uri(path)
+
+  gcs_client = storage.Client()
+
+  bucket = gcs_client.get_bucket(bucket_name)
+
+  blob = bucket.blob(path)
+  return blob.download_as_string()
+
 def makedirs(path):
   """
   makedirs creates a directory if it doesn't already exist

--- a/tekton/runs/go-test-run.yaml
+++ b/tekton/runs/go-test-run.yaml
@@ -21,12 +21,9 @@ spec:
     resourceSpec:
       type: git
       params:
-      - # error "Couldn't find repo under test"
-        name: url # The URL must match the repo under test in prow otherwise you well get the
+      - name: url # The URL must match the repo under test in prow otherwise you well get the
         value: https://github.com/kubeflow/testing.git
-      - # by the appropriate GCS location for the test.
-        # So the value here only matters for manual runs.
-        name: revision # When running under prow revision automatically be replaced 
+      - name: revision # When running under prow revision automatically be replaced 
         value: master
   pipelineRef:
     name: go-tests

--- a/tekton/runs/nb-test-run.yaml
+++ b/tekton/runs/nb-test-run.yaml
@@ -4,7 +4,7 @@ apiVersion: tekton.dev/v1alpha1
 kind: PipelineRun
 metadata:
   generateName: mnist-
-  namespace: tektoncd
+  namespace: kf-ci
   labels:
     pipeline: mnist-notebook
 spec:
@@ -15,34 +15,44 @@ spec:
   - name: test-target-name
     value: manual-testinig
   - name: artifacts-gcs
-    value: gs://kubeflow-ci-deployment/gabrielwen-testing-2
+    value: gs://kubeflow-ci_temp/jlewi_mnist_testing/2020-0619
   - name: junit-path
     value: artifacts/junit_manual-testing
   - name: testing-cluster-pattern
     value: 'kf-vbp-.*'
   - name: testing-cluster-location
     value: 'us-central1'
-  - name: output-workspace
-    value: /workspace/outputs
+  - name: notebook-output
+    value: gs://kubeflow-ci-deployment_ci-temp/mnist_test
+  - name: notebook-path
+    value: mnist/mnist_gcp.ipynb
   resources:
   # This pull number has changes blocked on:
   # https://github.com/kubeflow/testing/pull/622
-  - name: examples-repo
+  - name: notebook-repo
     resourceSpec:
       type: git
       params:
       - name: url
         value: https://github.com/kubeflow/examples.git
       - name: revision
-        value: refs/pull/803/head
+        value: master
   - name: testing-repo
     resourceSpec:
       type: git
       params:
       - name: url
-        value: https://github.com/kubeflow/testing.git
+        value: https://github.com/jlewi/testing.git
       - name: revision
-        #value: master
-        value: refs/pull/676/head
+        value: gcp_blueprints
+        #  value: refs/pull/676/head
+  # The image we want to build
+  - name: image
+    resourceSpec:
+      type: image
+      params:
+      - name: url
+        value: gcr.io/kubeflow-ci-deployment/mnist-test
   pipelineRef:
     name: notebook-test
+  serviceAccountName: kf-ci

--- a/tekton/runs/nb-test-run.yaml
+++ b/tekton/runs/nb-test-run.yaml
@@ -27,8 +27,7 @@ spec:
   - name: notebook-path
     value: mnist/mnist_gcp.ipynb
   resources:
-  # This pull number has changes blocked on:
-  # https://github.com/kubeflow/testing/pull/622
+  # The repository containing the notebook to test.
   - name: notebook-repo
     resourceSpec:
       type: git
@@ -36,16 +35,7 @@ spec:
       - name: url
         value: https://github.com/kubeflow/examples.git
       - name: revision
-        value: master
-  - name: testing-repo
-    resourceSpec:
-      type: git
-      params:
-      - name: url
-        value: https://github.com/jlewi/testing.git
-      - name: revision
-        value: gcp_blueprints
-        #  value: refs/pull/676/head
+        value: master  
   # The image we want to build
   - name: image
     resourceSpec:

--- a/tekton/templates/pipelines/notebook-test-pipeline.yaml
+++ b/tekton/templates/pipelines/notebook-test-pipeline.yaml
@@ -37,8 +37,6 @@ spec:
   resources:
   - name: notebook-repo
     type: git
-  - name: testing-repo
-    type: git
   - name: image
     type: image
   tasks:

--- a/tekton/templates/pipelines/notebook-test-pipeline.yaml
+++ b/tekton/templates/pipelines/notebook-test-pipeline.yaml
@@ -9,6 +9,16 @@ spec:
     type: string
     description: Test targe name, used to group test results in JUNIT.
     default: manual-testing
+  - name: notebook-output
+    type: string
+    description: This should be the bucket that the rendered notebook will be written
+      to. This should be a GCS path that is accessible from the KF cluster where the
+      notebook runs. It will be copied to artifacts-gcs
+  - name: notebook-path
+    type: string
+    description: Path to the notebook to run. This should be the relative path relative
+      to the root of the repository where the notebook lives. Do not include a leading
+      "/"
   - name: artifacts-gcs
     type: string
     description: GCS bucket and directory artifacts will be uploaded to. Should be
@@ -24,33 +34,39 @@ spec:
   - name: testing-cluster-location
     type: string
     description: Location to search for test clusters.
-  - name: output-workspace
-    type: string
-    description: Directory to write outputs to in local FS.
   resources:
-  - name: examples-repo
+  - name: notebook-repo
     type: git
   - name: testing-repo
     type: git
+  - name: image
+    type: image
   tasks:
-  - name: mnist-gcp
+  # Build the docker image containing the source
+  - name: build-image
     resources:
       inputs:
-      - name: examples-repo
-        resource: examples-repo
-      - name: kf-testing-repo
-        resource: testing-repo
+      - name: notebook-repo
+        resource: notebook-repo
+      - name: image
+        resource: image
+    params:
+    - name: artifacts-gcs
+      value: $(params.artifacts-gcs)
+    taskRef:
+      name: notebook-test-builder
+  - name: run-notebook
+    runAfter:
+    - build-image
     taskRef:
       name: nb-tests
     params:
     - name: notebook-path
-      value: 'kubeflow/examples/mnist/mnist_gcp.ipynb'
-    - name: junit-path
-      value: $(params.output-workspace)/$(params.junit-path)/junit_mnist-gcp.xml
-    - name: test-target-name
+      value: $(params.notebook-path)
+    - name: test-target-name #- name: junit-path
       value: $(params.test-target-name)
-    - name: output-workspace
-      value: $(params.output-workspace)
+    - name: notebook-output
+      value: $(params.notebook-output)
     - name: artifacts-gcs
       value: $(params.artifacts-gcs)
     - name: testing-cluster-pattern

--- a/tekton/templates/tasks/cleanup-kubeflow-ci.yaml
+++ b/tekton/templates/tasks/cleanup-kubeflow-ci.yaml
@@ -36,7 +36,7 @@ spec:
       description: The GitHub repo containing kubeflow testing scripts
   steps:
   - name: create-context
-    image: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb"}]}}
+    image: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea"}]}}
     command:
     - python
     - -m

--- a/tekton/templates/tasks/deploy-gcp-blueprint.yaml
+++ b/tekton/templates/tasks/deploy-gcp-blueprint.yaml
@@ -41,7 +41,7 @@ spec:
     env:
     - name: KUBECONFIG
       value: /workspace/kubeconfig
-    image: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb"}]}}
+    image: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea"}]}}
   steps:
   - name: get-credential
     command:

--- a/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
+++ b/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
@@ -29,7 +29,7 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb"}]}}
+      default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea"}]}}
       description: The docker image to run the tests in
     # TODO(jlewi): Lets not use targetPath. Instead lets rely on Tekton checking repos
     # out to /workspace/$(resource.name)

--- a/tekton/templates/tasks/go-tests.yaml
+++ b/tekton/templates/tasks/go-tests.yaml
@@ -29,7 +29,7 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb"}]}}
+      default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea"}]}}
       description: The docker image to run the tests in
     resources:
     - name: source-repo

--- a/tekton/templates/tasks/kf-ready-task.yaml
+++ b/tekton/templates/tasks/kf-ready-task.yaml
@@ -29,7 +29,7 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:6f0d932-dirty@sha256:06ebe5412d638e3e51bdd792aecbafdc4ee1e7146ff367a7be346cd726738cbb"}]}}
+      default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea"}]}}
       description: The docker image to run the tests in. Should contain a version
         of kubeflow/testing/py in /srcCache that we want to use.
     resources:

--- a/tekton/templates/tasks/notebook-test-task.yaml
+++ b/tekton/templates/tasks/notebook-test-task.yaml
@@ -90,6 +90,9 @@ spec:
       #!/usr/bin/env bash
       set -x
       gsutil cp -r $(inputs.params.output)/ $(inputs.params.artifacts-gcs)
+      # Need the echo command to prevent a gsutil error from causing the task to fail
+      # which would prevent the copy-artifacts step from running
+      echo copy-buckets finished
   # This step is designed to be generic: given the output directory, it will try to
   # parse all the XML files with prefix of junit and error out if failures been found.
   - name: copy-artifacts

--- a/tekton/templates/tasks/notebook-test-task.yaml
+++ b/tekton/templates/tasks/notebook-test-task.yaml
@@ -14,7 +14,8 @@ spec:
     params:
     - name: notebook-path
       type: string
-      description: Testing notebook location. Should be in the form of {REPO_OWNER}/{REPO}/path/to/notebook.ipynb
+      description: Path to the notebook to run. This should be the relative path relative
+        to the root of the repository where the notebook lives.
     - name: testing-cluster-pattern
       type: string
       description: Cluster pattern to run the notebook test. Default to be from master
@@ -22,40 +23,33 @@ spec:
     - name: testing-cluster-location
       type: string
       description: Location to search for test clusters e.g. us-central1 or us-central1-f
+    - name: notebook-output
+      type: string
+      description: This should be the bucket that the rendered notebook will be written
+        to. This should be a GCS path that is accessible from the KF cluster where
+        the notebook runs. It will be copied to artifacts-gcs
     - name: artifacts-gcs
       type: string
       description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
-    - name: junit-path
-      type: string
-      description: Relative path to the GCS artifacts will be uploaded to. Base path
-        is artifacts-gcs so the actual GCS blob will be artifacts-gcs/junit-path
     - name: test-target-name
       type: string
       description: Test targe name, used to group test results in JUNIT.
       default: manual-testing
-    - name: output-workspace
-      type: string
-      description: Directory to write outputs to in local FS.
     - name: nb-namespace
       type: string
       description: The namespace to run the notebook in
       # The default corresponds to the name of the default profile created by blueprints
       default: default-profile
-    # TODO(jlewi): Lets not use targetPath. Instead lets rely on Tekton checking repos
-    # out to /workspace/$(resource.name)
-    resources:
-    - name: examples-repo
-      type: git
-      targetPath: src/kubeflow/examples
-    - name: kf-testing-repo
-      type: git
-      targetPath: src/kubeflow/testing
+    - name: test-image
+      type: string
+      default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea"}]}}
+      description: The docker image to run the tests in
   steps:
   - name: get-credential
-    image: gcr.io/kubeflow-ci/test-worker:latest
+    image: $(inputs.params.test-image)
     command:
-    - python3
+    - python
     args:
     - -m
     - kubeflow.testing.get_kf_testing_cluster
@@ -64,61 +58,125 @@ spec:
     - get-credentials
     env:
     - name: PYTHONPATH
-      value: /workspace/src/kubeflow/examples/py:/workspace/src/kubeflow/testing/py
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /secret/gcp-credentials/key.json
-    volumeMounts:
-    - name: gcp-credentials
-      readOnly: true
-      mountPath: /secret/gcp-credentials
+      value: /srcCache/kubeflow/testing/py
   - name: run-notebook
-    image: gcr.io/kubeflow-ci/test-worker:latest
+    image: $(inputs.params.test-image)
     # Need to use script as workaround not to error out in tests.
     # If any of the steps returns non-zero codes, subsequent steps will not be run.
     script: |
       #!/usr/bin/env bash
+      set -x
+      mkdir -p /workspace/artifacts
       pytest run_notebook_test.py \
         --log-cli-level=info \
         --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
         --timeout=1800 \
-        --junitxml=$(inputs.params.junit-path) \
-        --notebook_path=$(inputs.params.notebook-path) \
+        --junitxml=/workspace/artifacts/junit_notebook.xml \
+        --notebook_path=/src/notebook-repo/$(inputs.params.notebook-path) \
         --test-target-name=$(inputs.params.test-target-name) \
-        --artifacts-gcs=$(inputs.params.artifacts-gcs) \
+        --artifacts-gcs=$(inputs.params.notebook-output) \
+        --image_file=$(inputs.params.artifacts-gcs)/image.yaml
         --namespace=$(inputs.params.nb-namespace)
-      || echo test finished.
-    workingDir: /workspace/src/kubeflow/examples/py/kubeflow/examples/notebook_tests
+      echo test finished
+    workingDir: /srcCache/kubeflow/testing/py/kubeflow/testing/notebook_tests
     env:
     - name: PYTHONPATH
-      value: /workspace/src/kubeflow/examples/py:/workspace/src/kubeflow/testing/py
-    - name: GOOGLE_APPLICATION_CREDENTIALS # TODO(jlewi): Can we use Workload Identity?
-      value: /secret/gcp-credentials/key.json
-    volumeMounts:
-    - name: gcp-credentials
-      readOnly: true
-      mountPath: /secret/gcp-credentials
+      value: /srcCache/kubeflow/testing/py
+  # TODO(jlewi): We need to copy the GCS artifacts from the bucket that the notebook wrote to 
+  # to the bucket uset for test artifacts.
+  - name: copy-buckets
+    image: $(inputs.params.test-image)
+    script: |
+      #!/usr/bin/env bash
+      set -x
+      gsutil cp -r $(inputs.params.output)/ $(inputs.params.artifacts-gcs)
   # This step is designed to be generic: given the output directory, it will try to
   # parse all the XML files with prefix of junit and error out if failures been found.
   - name: copy-artifacts
-    image: gcr.io/kubeflow-ci/test-worker:latest
+    image: $(inputs.params.test-image)
     command:
     - python
     args:
     - -m
     - kubeflow.testing.tekton_client
     - junit_parse_and_upload
-    - --artifacts_dir=$(inputs.params.output-workspace)
+    - --artifacts_dir=/workspace/artifacts
     - --output_gcs=$(inputs.params.artifacts-gcs)
     env:
     - name: PYTHONPATH
-      value: /workspace/src/kubeflow/examples/py:/workspace/src/kubeflow/testing/py
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /secret/gcp-credentials/key.json
-    volumeMounts:
-    - name: gcp-credentials
-      readOnly: true
-      mountPath: /secret/gcp-credentials
-  volumes:
-  - name: gcp-credentials
-    secret:
-      secretName: gcp-credentials
+      value: /src/kubeflow/testing/py
+---
+# This task builds a docker image to run notebooks in.
+# It takes as a base image a notebook image and adds
+# the source code for the notebook to it.
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: notebook-test-builder
+  annotations:
+    # This gets passed down to the individual pods
+    sidecar.istio.io/inject: "false"
+spec:
+  inputs:
+    params:
+    - name: test-image
+      type: string
+      default: gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:3780b5d-dirty@sha256:4a766d6f5cc6cbcb00dbc96205f7a5b2816bc5f2b6d516fd67124d4a3e6508ea"}]}}
+      description: The docker image to run the tests in
+    - name: artifacts-gcs
+      type: string
+      description: GCS bucket and directory artifacts will be uploaded to. Should
+        be in the form of 'gs://'
+    resources:
+    # Repo containing the notebook code 
+    - name: notebook-repo
+      type: git
+    - name: image
+      type: image
+  steps:
+  # We need to setup the directory where we will build the docker image
+  - name: setup
+    image: $(inputs.params.test-image)
+    # Need to use script as workaround not to error out in tests.
+    # If any of the steps returns non-zero codes, subsequent steps will not be run.
+    script: |
+      #!/usr/bin/env bash
+      set -x
+      mkdir -p /workspace/build
+      cd /workspace/build
+      # Copy the source code
+      cp -r /workspace/$(inputs.resources.notebook-repo.name) .
+      cp -r /srcCache/kubeflow/testing/notebook_testing/Dockerfile.notebook_runner ./Dockerfile.notebook_runner
+      mkdir -p kubeflow/
+      # Copy over the kubeflow/testing directory because we need it to run the
+      # notebooks; note that the copy is coming from the worker test image.
+      cp -r /srcCache/kubeflow/testing ./kubeflow/testing
+      # Create the artifacts directory
+      mkdir -p /workspace/artifacts
+  - name: build-push
+    image: gcr.io/kaniko-project/executor:v0.23.0
+    command:
+    - /kaniko/executor
+    - --dockerfile=/workspace/build/Dockerfile.notebook_runner
+    #- --target=$(inputs.params.docker_target)
+    - --destination=$(inputs.resources.image.url)
+    - --context=/workspace/build
+    - --digest-file=/workspace/artifacts/image-digest
+    resources:
+      requests:
+        cpu: 7
+        memory: 16Gi
+  - name: create-image-file
+    image: $(inputs.params.test-image)
+    command:
+    - python
+    args:
+    - -m
+    - kubeflow.testing.tekton_client
+    - create-image-file
+    - --image-name=$(inputs.resources.image.url)
+    - --digest-file=/workspace/artifacts/image-digest
+    - --output=$(inputs.params.artifacts-gcs)/image.yaml
+    env:
+    - name: PYTHONPATH # N.B. This uses the version cached in the docker image.
+      value: /srcCache/kubeflow/testing/py


### PR DESCRIPTION
Notebook tests should build a docker image to run the notebook in.

* kubeflow/testing#613 currently the way we run notebook tests is
  by firing off a K8s job on the KF cluster which runs the notebook.

  * The K8s job uses init containers to pull in source code and install
    dependencies like papermill.

  * This is a bit brittle.

* To fix this we will instead use Tekton to build a docker image that
  takes the notebook image and then adds the notebook code to it.

  * Dockerfile.notebook_runner dockerfile to build the test image.

The pipeline to run the notebook consists of two tasks

  1. A Tekton Task to build a docker image to run the notebook in

  1. A tekton task that fires off a K8s job to run the notebook on the Kubeflow cluster.

Here's a list of changes to make this work

* tekton_client should provide methods to upload artifacts but not parse
  junits

* Add a tekton_client method to construct the full image URL based on
  the digest returned from kaniko

* Copy over the code for running the notebook tests from kubeflow/examples
and start modifying it.

* Create a simple CLI to wait for nomos to sync resources to the cluster
  * This is used in some syntactic sugar make rules to aid the dev-test loop

The mnist test isn't completing successfully yet because kubeflow/gcp-blueprints#61 means the KF
deployments don't have proper GSA's to write to GCS.

Related to: #613