### PR TITLE
let kpt set value in upstream/manifests/stacks/gcp

### DIFF
--- a/py/kubeflow/testing/create_kf_from_gcp_blueprint.py
+++ b/py/kubeflow/testing/create_kf_from_gcp_blueprint.py
@@ -127,7 +127,7 @@ class BlueprintRunner:
       "email": email,
     }
 
-    for subdir in ["./upstream/manifests/gcp", "./instance"]:
+    for subdir in ["./upstream/manifests/gcp", "./upstream/manifests/stacks/gcp", "./instance"]:
       for k, v in values.items():
         util.run(["kpt", "cfg", "set", subdir, k, v],
                  cwd=blueprint_dir)


### PR DESCRIPTION
Part of https://github.com/kubeflow/gcp-blueprints/issues/61

Some values in upstream/manifests/stacks/gcp contain kpt setters to support default workload identity bindings