### PR TITLE
Use zonal cluster for gcp blueprint

### DIFF
--- a/py/kubeflow/testing/create_kf_from_gcp_blueprint.py
+++ b/py/kubeflow/testing/create_kf_from_gcp_blueprint.py
@@ -66,7 +66,7 @@ class BlueprintRunner:
   @staticmethod
   def deploy(blueprint_dir, management_context, name="kf-vbp-{uid}",
              project="kubeflow-ci-deployment",
-             location="us-central1", zone="us-central1-f",
+             location="us-central1-c", zone="us-central1-c",
              labels_file=None,
              oauth_file=DEFAULT_OAUTH_FILE): # pylinet: disable=too-many-arguments
     """Deploy the blueprint:


### PR DESCRIPTION
/assign @jlewi 

Fixes https://github.com/kubeflow/gcp-blueprints/issues/59

Before we make gcp blueprint completely compliant to regional clusters, let's use regional clusters first to pass testing.