### PR TITLE
Fix copy-artifacts step in mnist notebook tests.

### DIFF
--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -94,6 +94,6 @@ spec:
     - python
     env:
     - name: PYTHONPATH
-      value: /src/kubeflow/testing/py
+      value: /srcCache/kubeflow/testing/py
     image: $(inputs.params.test-image)
     name: copy-artifacts

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -94,6 +94,6 @@ spec:
     - python
     env:
     - name: PYTHONPATH
-      value: /src/kubeflow/testing/py
+      value: /srcCache/kubeflow/testing/py
     image: $(inputs.params.test-image)
     name: copy-artifacts

--- a/docs/tekton.md
+++ b/docs/tekton.md
@@ -118,6 +118,19 @@ To update the hydrated manifests
 make hydrate
 ```
 
+## Debugging 
+
+### TaskRun Logs
+
+If the logs aren't available in the Tekton UI you can fetch them with a query like the one below.
+
+```
+resource.type="k8s_container"
+resource.labels.cluster_name="kf-ci-v1"
+labels."k8s-pod/tekton_dev/taskRun" = "mnist-wc6fq-run-notebook-d9q7w"
+resource.labels.container_name = "step-copy-artifacts"
+```
+
 ## Running on your own Tekton cluster
 
 You should be able to run the KF Tekton pipelines on your own Tekton cluster provided you install

--- a/tekton/templates/tasks/notebook-test-task.yaml
+++ b/tekton/templates/tasks/notebook-test-task.yaml
@@ -107,7 +107,7 @@ spec:
     - --output_gcs=$(inputs.params.artifacts-gcs)
     env:
     - name: PYTHONPATH
-      value: /src/kubeflow/testing/py
+      value: /srcCache/kubeflow/testing/py
 ---
 # This task builds a docker image to run notebooks in.
 # It takes as a base image a notebook image and adds


### PR DESCRIPTION
* Python path should be /srcCache not /src

* Related to kubeflow/gcp-blueprints#65