### PR TITLE
Fix bugs in GCP blueprint tests

### DIFF
--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_iap-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_iap-ready.yaml
@@ -35,7 +35,7 @@ spec:
     - -m
     - kubeflow.testing.get_kf_testing_cluster
     - get-credentials
-    - --base=$(inputs.params.testing-cluster-pattern)
+    - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
     - --output=/workspace/cluster.info.yaml
     command:

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_kf-ready.yaml
@@ -35,9 +35,9 @@ spec:
   - args:
     - -m
     - kubeflow.testing.get_kf_testing_cluster
-    - --base=$(inputs.params.testing-cluster-pattern)
-    - --location=$(inputs.params.testing-cluster-location)
     - get-credentials
+    - --pattern=$(inputs.params.testing-cluster-pattern)
+    - --location=$(inputs.params.testing-cluster-location)
     command:
     - python
     env:

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -44,7 +44,8 @@ spec:
   - args:
     - -m
     - kubeflow.testing.get_kf_testing_cluster
-    - --base=$(inputs.params.testing-cluster-pattern)
+    - get-credentials
+    - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
     - get-credentials
     command:
@@ -80,7 +81,7 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -x
-      gsutil cp -r $(inputs.params.output)/ $(inputs.params.artifacts-gcs)
+      gsutil cp -r $(inputs.params.notebook-output)/ $(inputs.params.artifacts-gcs)
       # Need the echo command to prevent a gsutil error from causing the task to fail
       # which would prevent the copy-artifacts step from running
       echo copy-buckets finished

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_iap-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_iap-ready.yaml
@@ -35,7 +35,7 @@ spec:
     - -m
     - kubeflow.testing.get_kf_testing_cluster
     - get-credentials
-    - --base=$(inputs.params.testing-cluster-pattern)
+    - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
     - --output=/workspace/cluster.info.yaml
     command:

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_kf-ready.yaml
@@ -35,9 +35,9 @@ spec:
   - args:
     - -m
     - kubeflow.testing.get_kf_testing_cluster
-    - --base=$(inputs.params.testing-cluster-pattern)
-    - --location=$(inputs.params.testing-cluster-location)
     - get-credentials
+    - --pattern=$(inputs.params.testing-cluster-pattern)
+    - --location=$(inputs.params.testing-cluster-location)
     command:
     - python
     env:

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -44,7 +44,8 @@ spec:
   - args:
     - -m
     - kubeflow.testing.get_kf_testing_cluster
-    - --base=$(inputs.params.testing-cluster-pattern)
+    - get-credentials
+    - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
     - get-credentials
     command:
@@ -80,7 +81,7 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -x
-      gsutil cp -r $(inputs.params.output)/ $(inputs.params.artifacts-gcs)
+      gsutil cp -r $(inputs.params.notebook-output)/ $(inputs.params.artifacts-gcs)
       # Need the echo command to prevent a gsutil error from causing the task to fail
       # which would prevent the copy-artifacts step from running
       echo copy-buckets finished

--- a/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
+++ b/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
@@ -45,7 +45,7 @@ spec:
     - -m
     - kubeflow.testing.get_kf_testing_cluster
     - get-credentials
-    - --base=$(inputs.params.testing-cluster-pattern)
+    - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
     - --output=/workspace/cluster.info.yaml
     env:

--- a/tekton/templates/tasks/kf-ready-task.yaml
+++ b/tekton/templates/tasks/kf-ready-task.yaml
@@ -43,9 +43,9 @@ spec:
     args:
     - -m
     - kubeflow.testing.get_kf_testing_cluster
-    - --base=$(inputs.params.testing-cluster-pattern)
-    - --location=$(inputs.params.testing-cluster-location)
     - get-credentials
+    - --pattern=$(inputs.params.testing-cluster-pattern)
+    - --location=$(inputs.params.testing-cluster-location)
     env:
     - name: PYTHONPATH
       value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py

--- a/tekton/templates/tasks/notebook-test-task.yaml
+++ b/tekton/templates/tasks/notebook-test-task.yaml
@@ -53,7 +53,8 @@ spec:
     args:
     - -m
     - kubeflow.testing.get_kf_testing_cluster
-    - --base=$(inputs.params.testing-cluster-pattern)
+    - get-credentials
+    - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
     - get-credentials
     env:
@@ -89,7 +90,7 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -x
-      gsutil cp -r $(inputs.params.output)/ $(inputs.params.artifacts-gcs)
+      gsutil cp -r $(inputs.params.notebook-output)/ $(inputs.params.artifacts-gcs)
       # Need the echo command to prevent a gsutil error from causing the task to fail
       # which would prevent the copy-artifacts step from running
       echo copy-buckets finished


### PR DESCRIPTION
* Related kubeflow/gcp-blueprints#51 get-credentials isn't finding any clusters
  because when using Fire the parameter should be --pattern not --location

* Related kubeflow/gcp-blueprints#65 When copying the bucket output
  in the notebook tests the parameter should be params.notebook-output
  not params.output