### PR TITLE
Fix get-credentials; To support debugging of the test worker image deploy a stateful set that is in sync with the worker image

### DIFF
--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/apps_v1_statefulset_test-pod.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/apps_v1_statefulset_test-pod.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-pod
+  namespace: auto-deploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-pod
+  serviceName: test-pod
+  template:
+    metadata:
+      labels:
+        app: test-pod
+    spec:
+      containers:
+      - command:
+        - tail
+        - -f
+        - /dev/null
+        image: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+        name: worker
+        ports:
+        - containerPort: 80
+          name: web
+      serviceAccount: kf-ci
+      terminationGracePeriodSeconds: 10

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -47,7 +47,7 @@ spec:
     - get-credentials
     - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
-    - get-credentials
+    - --output=/workspace/cluster.info.yaml
     command:
     - python
     env:

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/~g_v1_service_test-pod.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/~g_v1_service_test-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-pod
+  name: test-pod
+  namespace: auto-deploy
+spec:
+  clusterIP: None
+  ports:
+  - name: web
+    port: 80
+  selector:
+    app: test-pod

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/apps_v1_statefulset_test-pod.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/apps_v1_statefulset_test-pod.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-pod
+  namespace: kf-ci
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-pod
+  serviceName: test-pod
+  template:
+    metadata:
+      labels:
+        app: test-pod
+    spec:
+      containers:
+      - command:
+        - tail
+        - -f
+        - /dev/null
+        image: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+        name: worker
+        ports:
+        - containerPort: 80
+          name: web
+      serviceAccount: kf-ci
+      terminationGracePeriodSeconds: 10

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -47,7 +47,7 @@ spec:
     - get-credentials
     - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
-    - get-credentials
+    - --output=/workspace/cluster.info.yaml
     command:
     - python
     env:

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/~g_v1_service_test-pod.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/~g_v1_service_test-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-pod
+  name: test-pod
+  namespace: kf-ci
+spec:
+  clusterIP: None
+  ports:
+  - name: web
+    port: 80
+  selector:
+    app: test-pod

--- a/tekton/templates/pipelines/kustomization.yaml
+++ b/tekton/templates/pipelines/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - gcp-kf-ready.yaml
 - go-test-pipeline.yaml
 - notebook-test-pipeline.yaml
+- test-pod.yaml

--- a/tekton/templates/pipelines/test-pod.yaml
+++ b/tekton/templates/pipelines/test-pod.yaml
@@ -1,0 +1,45 @@
+# This is a bit of a hack
+# This is a stateful set that starts a pod using the worker image.
+# It is primarily useful for inspecting what's in the image
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-pod
+  labels:
+    app: test-pod
+spec:
+  ports:
+  - port: 80
+    name: web
+  clusterIP: None
+  selector:
+    app: test-pod
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-pod
+spec:
+  selector:
+    matchLabels:
+      app: test-pod # has to match .spec.template.metadata.labels
+  serviceName: "test-pod"
+  replicas: 1 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: test-pod # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: worker
+        image: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac"}]}}
+        command:
+        - tail
+        - -f
+        - /dev/null
+        ports:
+        - containerPort: 80
+          name: web
+      # Bind to a service account with workload identity
+      serviceAccount: kf-ci

--- a/tekton/templates/tasks/notebook-test-task.yaml
+++ b/tekton/templates/tasks/notebook-test-task.yaml
@@ -56,7 +56,7 @@ spec:
     - get-credentials
     - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
-    - get-credentials
+    - --output=/workspace/cluster.info.yaml
     env:
     - name: PYTHONPATH
       value: /srcCache/kubeflow/testing/py


### PR DESCRIPTION
  Fix get-credentials in notebook tasks
    
    * Related to kubeflow/gcp-blueprints#65
