### PR TITLE
Directory for junit file for notebooks is incorrect

### DIFF
--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_pipeline_notebook-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_pipeline_notebook-test.yaml
@@ -61,7 +61,7 @@ spec:
     - name: notebook-output
       value: $(params.notebook-output)
     - name: artifacts-gcs
-      value: $(params.artifacts-gcs)
+      value: $(params.artifacts-gcs)/artifacts/junit_$(params.test-target-name)
     - name: testing-cluster-pattern
       value: $(params.testing-cluster-pattern)
     - name: testing-cluster-location

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_pipeline_notebook-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_pipeline_notebook-test.yaml
@@ -61,7 +61,7 @@ spec:
     - name: notebook-output
       value: $(params.notebook-output)
     - name: artifacts-gcs
-      value: $(params.artifacts-gcs)
+      value: $(params.artifacts-gcs)/artifacts/junit_$(params.test-target-name)
     - name: testing-cluster-pattern
       value: $(params.testing-cluster-pattern)
     - name: testing-cluster-location

--- a/tekton/templates/pipelines/notebook-test-pipeline.yaml
+++ b/tekton/templates/pipelines/notebook-test-pipeline.yaml
@@ -66,7 +66,7 @@ spec:
     - name: notebook-output
       value: $(params.notebook-output)
     - name: artifacts-gcs
-      value: $(params.artifacts-gcs)
+      value: $(params.artifacts-gcs)/artifacts/junit_$(params.test-target-name)
     - name: testing-cluster-pattern
       value: $(params.testing-cluster-pattern)
     - name: testing-cluster-location


### PR DESCRIPTION
* We need to upload the junits to the artifacts/junit_* directory

Related to kubeflow/gcp-blueprints#65