### PR TITLE
Bug: NameError: global name 'FileNotFoundError' is not defined

### DIFF
--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -82,7 +82,7 @@ TEST_TARGET_ARG_NAME = "test_target_name"
 TEKTON_CLUSTER_NAME = "kf-ci-v1"
 TEKTON_CLUSTER_ZONE = "us-east1-d"
 
-if sys.version_info < (3):
+if sys.version_info < (3,0):
   FileNotFoundError = IOError
 
 

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -59,6 +59,7 @@ import importlib
 import logging
 import os
 import tempfile
+import six
 from kubernetes import client as k8s_client
 from kubeflow.testing import argo_client
 from kubeflow.testing import ks_util
@@ -82,7 +83,7 @@ TEST_TARGET_ARG_NAME = "test_target_name"
 TEKTON_CLUSTER_NAME = "kf-ci-v1"
 TEKTON_CLUSTER_ZONE = "us-east1-d"
 
-if sys.version_info < (3,0):
+if six.PY2:
   FileNotFoundError = IOError
 
 

--- a/py/kubeflow/testing/run_e2e_workflow.py
+++ b/py/kubeflow/testing/run_e2e_workflow.py
@@ -82,6 +82,10 @@ TEST_TARGET_ARG_NAME = "test_target_name"
 TEKTON_CLUSTER_NAME = "kf-ci-v1"
 TEKTON_CLUSTER_ZONE = "us-east1-d"
 
+if sys.version_info < (3):
+  FileNotFoundError = IOError
+
+
 # The namespace to launch the Argo workflow in.
 def get_namespace(args):
   if args.namespace:


### PR DESCRIPTION
Since python 2.7 is used `FileNotFoundError` is not available. I dont know if the best way it so overwritt it for python2 or replace it with IOError? 

Error message currently: 

```bash
INFO|2020-07-04T12:06:42|/src/kubeflow/testing/py/kubeflow/testing/tekton_client.py|187| Job is type presubmit; looking for url https://github.com/kubeflow/mpi-operator.git
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/src/kubeflow/testing/py/kubeflow/testing/run_e2e_workflow.py", line 621, in <module>
    final_result = main()
  File "/src/kubeflow/testing/py/kubeflow/testing/run_e2e_workflow.py", line 611, in main
    return run(args, file_handler)
  File "/src/kubeflow/testing/py/kubeflow/testing/run_e2e_workflow.py", line 385, in run
    except (FileNotFoundError, ValueError) as e:
NameError: global name 'FileNotFoundError' is not defined

```