### PR TITLE
Bug fixes and improvements to prctl

### DIFF
--- a/go/Dockerfile.prctl
+++ b/go/Dockerfile.prctl
@@ -32,7 +32,16 @@ RUN apt-get update -y && \
 RUN cd /tmp && \
     curl -LO  https://github.com/github/hub/releases/download/v2.11.2/hub-linux-amd64-2.11.2.tgz && \
     tar -xvf hub-linux-amd64-2.11.2.tgz && \
-    cp hub-linux-amd64-2.11.2/bin/hub /usr/local/hub 
+    cp hub-linux-amd64-2.11.2/bin/hub /usr/local/hub
+
+# Add Kustomize so we can hydrate manifests
+#
+# TODO(jlewi): Should we create a separate image for Kustomize?
+RUN cd /tmp && \
+    curl -LO  https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.6.1/kustomize_v3.6.1_linux_amd64.tar.gz && \
+    tar -xvf kustomize_v3.6.1_linux_amd64.tar.gz && \
+    cp kustomize /usr/local/bin/kustomize && \
+    chmod a+x /usr/local/bin/kustomize
 
 # TODO(jlewi): We would really like to use a distroless images but we need to shell out to
 # git. I tried running git on a base-debian10 distrolless but that was missing some of the
@@ -45,23 +54,19 @@ FROM alpine:3.11
 
 WORKDIR /
 
-# Without ca-certificates we will get SSL errors with git
+# Without openssh we will get SSL errors with git.
+# Include make because we often wrap commands in make.
+# bash is needed so we can run tekton scripts
 RUN set -ex \
-    && apt-get update -yqq \
-    && apt-get install -yqq --no-install-recommends \
-    git \
-    ca-certificates \
-    && apt-get clean \
-    && rm -rf \
-    /var/lib/apt/lists/* \
-    /tmp/* \
-    /var/tmp/* \
-    /usr/share/man \
-    /usr/share/doc \
-    /usr/share/doc-base
+    && apk update \
+    && apk upgrade \
+    && apk add --no-cache git bash openssh make \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm /var/cache/apk/* 
 
 # Install the hub CLI for git
 COPY --from=hub_builder /usr/local/hub /usr/local/bin/
+COPY --from=hub_builder /usr/local/bin/kustomize /usr/local/bin/
 COPY --from=builder /workspace/prctl /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/prctl"]

--- a/go/cmd/prctl/main_test.go
+++ b/go/cmd/prctl/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+func TestErrorRegexes(t *testing.T) {
+	type testCase struct {
+		errorRes map[string][]string
+		text string
+		expected string
+	}
+
+	cases := []testCase {
+		{
+			errorRes: gitErrorRegexes,
+			text: `On branch update-0703
+Your branch is ahead of 'origin/master' by 1 commit.
+  (use "git push" to publish your local commits)
+
+nothing to commit, working tree clean`,
+			expected:NothingToCommit,
+		},
+	}
+
+	for _, c := range cases {
+		m, err := matchRePatterns(c.errorRes, c.text)
+
+		if err != nil {
+			t.Errorf("Unexpected error; %v", err)
+			continue
+		}
+
+		if m != c.expected {
+			t.Errorf("Got %v; Want %v", m, c.expected)
+		}
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,8 +3,8 @@ module github.com/kubeflow/testing/go
 go 1.13
 
 require (
-	github.com/onrik/logrus v0.6.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/sirupsen/logrus v1.6.0 // indirect
-	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/onrik/logrus v0.6.0
+	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.6.0
+	github.com/spf13/cobra v1.0.0
 )

--- a/go/prctl_latest_image.json
+++ b/go/prctl_latest_image.json
@@ -1,1 +1,1 @@
-{"builds":[{"imageName":"gcr.io/kubeflow-images-public/prctl","tag":"gcr.io/kubeflow-images-public/prctl:1788ef8-dirty@sha256:c3f1b726fa87342606bad010ad77bbecb729119f2f6fd3c450e99074fa140dc9"}]}
+{"builds":[{"imageName":"gcr.io/kubeflow-images-public/prctl","tag":"gcr.io/kubeflow-images-public/prctl:7939a1d-dirty@sha256:50ddf9dc0871f12037bb787abce6a2c43ee62793daae0f8e8622cad2675f9ec2"}]}


### PR DESCRIPTION
* Fix the docker image; I switched the base image to alpine but
didn't update the pkg commands from apt to apk.

* Refactor the code to make it easier to write a unittest for the error
  regexes.

  * Use a global map for the regexes
  * Use named constants for the particular error types

* We should be using CombinedOutput in order to get stdout and stderr
  when shelling out.

* Mark required flags
* Use working directory as default directory
* Change flag name for push to refspec

* Add an option to format logs as json
  * This is needed when running in cluster and using stackdriver so
    that multi line entries and metadata fields like level and filename
    are recorded as structured entries.

* Add kustomize to the prctl image

  * This is a quick fix so we can use the prctl image to run hydration
    of manifests