### PR TITLE
prctl should support using urls for the flag --repo

### DIFF
--- a/go/cmd/prctl/main.go
+++ b/go/cmd/prctl/main.go
@@ -147,7 +147,7 @@ func init() {
 	pushCmd.MarkFlagRequired("forkName")
 	pushCmd.MarkFlagRequired("messagePath")
 
-	prCmd.Flags().StringVarP(&options.repo, "repo", "", "", "The repo to create the PR in in the form OWNER/REPO")
+	prCmd.Flags().StringVarP(&options.repo, "repo", "", "", "The repo to create the PR can be in the form OWNER/REPO, git@github.com:OWNER/REPO.git or https://github.com/OWNER/REPO.git")
 	prCmd.Flags().StringVarP(&options.baseBranch, "baseBranch", "", "master", "Name of the branch to merge your changes into")
 	prCmd.Flags().StringVarP(&options.forkRef, "forkRef", "", "", "Reference to the branch to create the PR from; typically ${user}:${branch}")
 	prCmd.Flags().StringVarP(&options.messagePath, "messagePath", "", "", "Path to a file containing the message to use for the commit")
@@ -414,7 +414,7 @@ func pr(repo string, baseBranch, forkRef, messagePath string) error {
 		return errors.WithStack(errors.Errorf("Could not convert appId %v to integer; error: %v", options.appId, err))
 	}
 
-	baseRepo, err := ghrepo.FromFullName(repo)
+	baseRepo, err := ghrepo.FromUrlOrName(repo)
 
 	if err != nil {
 		return errors.WithStack(errors.Wrapf(err, "There was a problem getting the base repo."))

--- a/go/pkg/ghrepo/repo_test.go
+++ b/go/pkg/ghrepo/repo_test.go
@@ -1,0 +1,45 @@
+package ghrepo
+
+import "testing"
+
+func Test_FromUrlOrName(t *testing.T) {
+	type testCase struct {
+		in string
+		expectedOwner string
+		expectedName string
+	}
+
+	cases := []testCase{
+		{
+			in: "kubeflow/code",
+			expectedOwner: "kubeflow",
+			expectedName: "code",
+		},
+		{
+			in: "git@github.com:kubeflow/code.git",
+			expectedOwner: "kubeflow",
+			expectedName: "code",
+		},
+		{
+			in: "https://github.com/kubeflow/code.git",
+			expectedOwner: "kubeflow",
+			expectedName: "code",
+		},
+	}
+
+	for _, c := range cases {
+		r, err := FromUrlOrName(c.in)
+
+		if err != nil {
+			t.Errorf("in: %v; Got error: %v", c.in, err)
+			continue
+		}
+
+		if r.RepoOwner() != c.expectedOwner {
+			t.Errorf("in %v; Got %v want %v", c.in, r.RepoOwner(), c.expectedOwner)
+		}
+		if r.RepoName() != c.expectedName {
+			t.Errorf("in %v; Got %v want %v", c.in, r.RepoName(), c.expectedName)
+		}
+	}
+}

--- a/go/prctl_latest_image.json
+++ b/go/prctl_latest_image.json
@@ -1,1 +1,1 @@
-{"builds":[{"imageName":"gcr.io/kubeflow-images-public/prctl","tag":"gcr.io/kubeflow-images-public/prctl:f386858-dirty@sha256:afe3fe6ca81c2c78116df6e0a1860d86a4d4e878d95f5ca55cc1acbe5cd1bac5"}]}
+{"builds":[{"imageName":"gcr.io/kubeflow-images-public/prctl","tag":"gcr.io/kubeflow-images-public/prctl:a1a488e@sha256:53b4e6ff048adf8a4f9afc623e533456c7ace944f9bf03c527f07e597c86ae8c"}]}


### PR DESCRIPTION
* In tekton tasks we can get the URL of the repo directly from
  the git resource so being able to parse OWNER/REPO from a URL
  avoids having to expose an additional parameter.