### PR TITLE
Fix bug in notebook task

### DIFF
--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -72,7 +72,7 @@ spec:
         --notebook_path=/src/notebook-repo/$(inputs.params.notebook-path) \
         --test-target-name=$(inputs.params.test-target-name) \
         --artifacts-gcs=$(inputs.params.notebook-output) \
-        --image_file=$(inputs.params.artifacts-gcs)/image.yaml
+        --image_file=$(inputs.params.artifacts-gcs)/image.yaml \
         --namespace=$(inputs.params.nb-namespace)
       echo test finished
     workingDir: /srcCache/kubeflow/testing/py/kubeflow/testing/notebook_tests

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -72,7 +72,7 @@ spec:
         --notebook_path=/src/notebook-repo/$(inputs.params.notebook-path) \
         --test-target-name=$(inputs.params.test-target-name) \
         --artifacts-gcs=$(inputs.params.notebook-output) \
-        --image_file=$(inputs.params.artifacts-gcs)/image.yaml
+        --image_file=$(inputs.params.artifacts-gcs)/image.yaml \
         --namespace=$(inputs.params.nb-namespace)
       echo test finished
     workingDir: /srcCache/kubeflow/testing/py/kubeflow/testing/notebook_tests

--- a/tekton/templates/tasks/notebook-test-task.yaml
+++ b/tekton/templates/tasks/notebook-test-task.yaml
@@ -76,7 +76,7 @@ spec:
         --notebook_path=/src/notebook-repo/$(inputs.params.notebook-path) \
         --test-target-name=$(inputs.params.test-target-name) \
         --artifacts-gcs=$(inputs.params.notebook-output) \
-        --image_file=$(inputs.params.artifacts-gcs)/image.yaml
+        --image_file=$(inputs.params.artifacts-gcs)/image.yaml \
         --namespace=$(inputs.params.nb-namespace)
       echo test finished
     workingDir: /srcCache/kubeflow/testing/py/kubeflow/testing/notebook_tests


### PR DESCRIPTION
* The script to run a notebook is missing a trailing slash to indicate
  a continued command.

* Related to kubeflow/gcp-blueprints#78