### PR TITLE
Fix workload identity tests by passing in app name.

### DIFF
--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_kf-ready.yaml
@@ -38,6 +38,7 @@ spec:
     - get-credentials
     - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
+    - --output=/workspace/cluster.info.yaml
     command:
     - python
     env:
@@ -53,6 +54,8 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -x
+      # Get the name of the cluster
+      export KFNAME=$(yq r /workspace/cluster.info.yaml cluster.name)
       # I think -s mean stdout/stderr will print out to aid in debugging.
       # Failures still appear to be captured and stored in the junit file.
       # Test suite name needs to be unique based on parameters
@@ -61,6 +64,7 @@ spec:
         --log-cli-level=info \
         --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
         --junitxml=/workspace/artifacts/junit_kf-ready.xml \
+        --app_name=$(KFNAME) \
         --timeout=180 \
         -o junit_suite_name=test_kf_ready_blueprint
       echo test finished.

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_kf-ready.yaml
@@ -38,6 +38,7 @@ spec:
     - get-credentials
     - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
+    - --output=/workspace/cluster.info.yaml
     command:
     - python
     env:
@@ -53,6 +54,8 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -x
+      # Get the name of the cluster
+      export KFNAME=$(yq r /workspace/cluster.info.yaml cluster.name)
       # I think -s mean stdout/stderr will print out to aid in debugging.
       # Failures still appear to be captured and stored in the junit file.
       # Test suite name needs to be unique based on parameters
@@ -61,6 +64,7 @@ spec:
         --log-cli-level=info \
         --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
         --junitxml=/workspace/artifacts/junit_kf-ready.xml \
+        --app_name=$(KFNAME) \
         --timeout=180 \
         -o junit_suite_name=test_kf_ready_blueprint
       echo test finished.

--- a/tekton/templates/tasks/kf-ready-task.yaml
+++ b/tekton/templates/tasks/kf-ready-task.yaml
@@ -46,6 +46,7 @@ spec:
     - get-credentials
     - --pattern=$(inputs.params.testing-cluster-pattern)
     - --location=$(inputs.params.testing-cluster-location)
+    - --output=/workspace/cluster.info.yaml
     env:
     - name: PYTHONPATH
       value: /workspace/$(inputs.resources.kfctl-repo.name)/py:/srcCache/kubeflow/testing/py
@@ -61,6 +62,8 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -x
+      # Get the name of the cluster
+      export KFNAME=$(yq r /workspace/cluster.info.yaml cluster.name)
       # I think -s mean stdout/stderr will print out to aid in debugging.
       # Failures still appear to be captured and stored in the junit file.
       # Test suite name needs to be unique based on parameters
@@ -69,6 +72,7 @@ spec:
         --log-cli-level=info \
         --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
         --junitxml=/workspace/artifacts/junit_kf-ready.xml \
+        --app_name=$(KFNAME) \
         --timeout=180 \
         -o junit_suite_name=test_kf_ready_blueprint
       echo test finished.


### PR DESCRIPTION
* Related to kubeflow/gcp-blueprints#82 ; The workload identity tests
  are failing because we need to know the name of the Kubeflow application
  in order to know what service accounts to check.