### PR TITLE
Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 REPO_DIRS=./acm-repos
 AUTO_DEPLOY_CONTEXT=kf-ci-v1
+KFCI_CONTEXT=kf-ci-v1
 
 #***************************************************************************************************
 
 TEKTON_INSTALLS=./tekton/templates/installs
+
 # Hydrate ACM repos
 .PHONY: hydrate
 hydrate:
@@ -13,6 +15,12 @@ hydrate:
 	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/auto-deploy $(TEKTON_INSTALLS)/auto-deploy
 	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/auto-deploy test-infra/auto-deploy/manifest
 	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/kf-ci $(TEKTON_INSTALLS)/kf-ci
+
+
+# This applies your local changes to tekton components to the kf-ci-dev namespace.
+# This allows you to test changes manually before your pipelines are submitted.
+apply-kf-ci-dev:
+	kustomize build $(TEKTON_INSTALLS)/kf-ci-dev | kubectl --context=$(KFCI_CONTEXT) apply -f -
 
 build-worker-image:
 	cd images && skaffold build -p testing --kube-context=kubeflow-testing -v info --file-output=latest_image.json

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/apps_v1_statefulset_test-pod.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/apps_v1_statefulset_test-pod.yaml
@@ -19,7 +19,7 @@ spec:
         - tail
         - -f
         - /dev/null
-        image: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+        image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
         name: worker
         ports:
         - containerPort: 80

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_cleanup-kubeflow-ci.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_cleanup-kubeflow-ci.yaml
@@ -48,7 +48,7 @@ spec:
       value: /workspace/kubeconfig
     - name: PYTHONPATH
       value: /workspace/$(inputs.resources.testing-repo.name)/py
-    image: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
     name: create-context
   - command:
     - python

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_deploy-gcp-blueprint.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_deploy-gcp-blueprint.yaml
@@ -39,7 +39,7 @@ spec:
     env:
     - name: KUBECONFIG
       value: /workspace/kubeconfig
-    image: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
   steps:
   - command:
     - /workspace/$(inputs.resources.blueprint-repo.name)/kubeflow/hack/create_context.sh

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_golang-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_golang-test.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    - default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_iap-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_iap-ready.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    - default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_kf-ready.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    - default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
       description: The docker image to run the tests in. Should contain a version
         of kubeflow/testing/py in /srcCache that we want to use.
       name: test-image

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -21,7 +21,7 @@ spec:
       type: string
     - description: This should be the bucket that the rendered notebook will be written
         to. This should be a GCS path that is accessible from the KF cluster where
-        the notebook runs. It will be copied to artifacts-gcs
+        the notebook runs. It will be copied to artifacts-gcs. This should be a directory.
       name: notebook-output
       type: string
     - description: GCS bucket and directory artifacts will be uploaded to. Should
@@ -36,7 +36,7 @@ spec:
       description: The namespace to run the notebook in
       name: nb-namespace
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    - default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_notebook-test-builder.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_notebook-test-builder.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   inputs:
     params:
-    - default: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    - default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/apps_v1_statefulset_test-pod.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/apps_v1_statefulset_test-pod.yaml
@@ -19,7 +19,7 @@ spec:
         - tail
         - -f
         - /dev/null
-        image: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+        image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
         name: worker
         ports:
         - containerPort: 80

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_cleanup-kubeflow-ci.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_cleanup-kubeflow-ci.yaml
@@ -48,7 +48,7 @@ spec:
       value: /workspace/kubeconfig
     - name: PYTHONPATH
       value: /workspace/$(inputs.resources.testing-repo.name)/py
-    image: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
     name: create-context
   - command:
     - python

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_deploy-gcp-blueprint.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_deploy-gcp-blueprint.yaml
@@ -39,7 +39,7 @@ spec:
     env:
     - name: KUBECONFIG
       value: /workspace/kubeconfig
-    image: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
   steps:
   - command:
     - /workspace/$(inputs.resources.blueprint-repo.name)/kubeflow/hack/create_context.sh

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_golang-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_golang-test.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    - default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_iap-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_iap-ready.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    - default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_kf-ready.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_kf-ready.yaml
@@ -23,7 +23,7 @@ spec:
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    - default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
       description: The docker image to run the tests in. Should contain a version
         of kubeflow/testing/py in /srcCache that we want to use.
       name: test-image

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_nb-tests.yaml
@@ -21,7 +21,7 @@ spec:
       type: string
     - description: This should be the bucket that the rendered notebook will be written
         to. This should be a GCS path that is accessible from the KF cluster where
-        the notebook runs. It will be copied to artifacts-gcs
+        the notebook runs. It will be copied to artifacts-gcs. This should be a directory.
       name: notebook-output
       type: string
     - description: GCS bucket and directory artifacts will be uploaded to. Should
@@ -36,7 +36,7 @@ spec:
       description: The namespace to run the notebook in
       name: nb-namespace
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    - default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_notebook-test-builder.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_notebook-test-builder.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   inputs:
     params:
-    - default: gcr.io/kubeflow-ci/test-worker-py3:fb970ef@sha256:804c6cc8a73face69d79c60bcd85b93fa04218db9ee31127fb529b41fcab43ac
+    - default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a
       description: The docker image to run the tests in
       name: test-image
       type: string

--- a/docs/tekton.md
+++ b/docs/tekton.md
@@ -118,6 +118,20 @@ To update the hydrated manifests
 make hydrate
 ```
 
+## Developing/Testing your tasks
+
+The namespace `kf-ci-dev` in the `kf-ci-v1` cluster is intended for manually applying any testing any changes to tasks or pipelines
+you made. This allows you to test changes to test without having to first merge your changes and have them get sync'd via acm-repos.
+
+To apply your local changes
+
+```
+KFCI_CONTEXT=<Context for kf-ci-v1 cluster> make apply-kf-ci-dev
+```
+
+TODO(jlewi): This isn't a very scalable solution since if multiple developers are working simultaneously they will likely be overridding each other's changes.
+
+
 ## Debugging 
 
 ### TaskRun Logs

--- a/images/Dockerfile.py3
+++ b/images/Dockerfile.py3
@@ -80,6 +80,7 @@ RUN ln -sf /usr/local/go/bin/go /usr/local/bin && \
 RUN go get github.com/kelseyhightower/kube-rsa
 
 COPY ./images/checkout_repos.sh /usr/local/bin
+COPY ./images/checkout.sh /usr/local/bin
 COPY ./images/setup_ssh.sh /usr/local/bin
 RUN chmod a+x /usr/local/bin/checkout* /usr/local/bin/setup_ssh.sh
 

--- a/images/Dockerfile.py3
+++ b/images/Dockerfile.py3
@@ -1,3 +1,7 @@
+# Build the docker image used to run the scripts
+# to continuously update our docker files.
+#
+# The context for this docker file should be the root of the kubeflow/testing repository.
 FROM ubuntu:18.04
 
 RUN apt-get update -y && \
@@ -27,21 +31,13 @@ RUN cd /tmp && \
     wget -O /tmp/go.tar.gz https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz
 
-# Create go symlinks
-RUN ln -sf /usr/local/go/bin/go /usr/local/bin && \
-    ln -sf /usr/local/go/bin/gofmt /usr/local/bin && \
-    ln -sf /usr/local/go/bin/godoc /usr/local/bin
-
-# Install the new version of yq which is based on go
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
-
-RUN go get github.com/kelseyhightower/kube-rsa
-
-RUN go get -u github.com/jstemmer/go-junit-report
-
 # Install gcloud
 ENV PATH=/root/go/bin:/usr/local/go/bin:/google-cloud-sdk/bin:/workspace:${PATH} \
     CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+# Install the new version of yq which is based on go
+RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
+RUN go get github.com/kelseyhightower/kube-rsa 
 
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
     tar xzf google-cloud-sdk.tar.gz -C / && \
@@ -75,10 +71,23 @@ RUN export ASM_VERSION=1.4.7-asm.0 && \
     mv istio-${ASM_VERSION} /usr/local && \
     ln -sf /usr/local/istio-${ASM_VERSION}/bin/istioctl /usr/local/bin/istioctl
 
-COPY checkout_*.sh /usr/local/bin
-COPY setup_ssh.sh /usr/local/bin
-COPY run_*.sh /usr/local/bin
-RUN chmod a+x /usr/local/bin/checkout* /usr/local/bin/setup_ssh.sh /usr/local/bin/run_*.sh
+    
+# Create go symlinks
+RUN ln -sf /usr/local/go/bin/go /usr/local/bin && \
+    ln -sf /usr/local/go/bin/gofmt /usr/local/bin && \
+    ln -sf /usr/local/go/bin/godoc /usr/local/bin
+
+RUN go get github.com/kelseyhightower/kube-rsa
+
+COPY ./images/checkout_repos.sh /usr/local/bin
+COPY ./images/setup_ssh.sh /usr/local/bin
+RUN chmod a+x /usr/local/bin/checkout* /usr/local/bin/setup_ssh.sh
+
+COPY ./images/run_workflows.sh /usr/local/bin
+RUN chmod a+x /usr/local/bin/run_workflows.sh
+
+COPY ./images/run_release.sh /usr/local/bin
+RUN chmod a+x /usr/local/bin/run_release.sh
 
 # Install the hub CLI for git
 RUN cd /tmp && \
@@ -92,6 +101,8 @@ RUN cd /tmp && \
 RUN  curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl && \
     mv kubectl /usr/local/bin && \
     chmod a+x /usr/local/bin/kubectl
+
+RUN go get -u github.com/jstemmer/go-junit-report
 
 # Create a cached copy of the python test scripts so that we don't
 # need to clone the repo just to get access to them

--- a/images/latest_image.json
+++ b/images/latest_image.json
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-{"builds":[{"imageName":"gcr.io/kubeflow-ci/test-worker-py3","tag":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}
-=======
-{"builds":[{"imageName":"gcr.io/kubeflow-ci/test-worker-py3","tag":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}
->>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
+{"builds":[{"imageName":"gcr.io/kubeflow-ci/test-worker-py3","tag":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}

--- a/images/latest_image.json
+++ b/images/latest_image.json
@@ -1,1 +1,1 @@
-{"builds":[{"imageName":"gcr.io/kubeflow-ci/test-worker-py3","tag":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}
+{"builds":[{"imageName":"gcr.io/kubeflow-ci/test-worker-py3","tag":"gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}

--- a/images/latest_image.json
+++ b/images/latest_image.json
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 {"builds":[{"imageName":"gcr.io/kubeflow-ci/test-worker-py3","tag":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}
+=======
+{"builds":[{"imageName":"gcr.io/kubeflow-ci/test-worker-py3","tag":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}
+>>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.

--- a/tekton/templates/installs/kf-ci-dev/kustomization.yaml
+++ b/tekton/templates/installs/kf-ci-dev/kustomization.yaml
@@ -1,0 +1,9 @@
+# Configure the tekton tasks for the auto-deploy namespace
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The kf-ci-dev is for manual testing of tekton tasks before committing them.
+namespace: kf-ci-dev
+resources:
+- ../../tasks
+- ../../pipelines
+- service-account-kf-ci.yaml

--- a/tekton/templates/installs/kf-ci-dev/service-account-kf-ci.yaml
+++ b/tekton/templates/installs/kf-ci-dev/service-account-kf-ci.yaml
@@ -1,0 +1,7 @@
+# Service account to use to run the tests
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kf-ci
+  annotations:
+    iam.gke.io/gcp-service-account: kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com

--- a/tekton/templates/pipelines/test-pod.yaml
+++ b/tekton/templates/pipelines/test-pod.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: worker
-        image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
+        image: gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}
         command:
         - tail
         - -f

--- a/tekton/templates/pipelines/test-pod.yaml
+++ b/tekton/templates/pipelines/test-pod.yaml
@@ -33,11 +33,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: worker
-<<<<<<< HEAD
-        image: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
-=======
-        image: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
->>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
+        image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
         command:
         - tail
         - -f

--- a/tekton/templates/pipelines/test-pod.yaml
+++ b/tekton/templates/pipelines/test-pod.yaml
@@ -33,7 +33,11 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: worker
+<<<<<<< HEAD
         image: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
+=======
+        image: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
+>>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
         command:
         - tail
         - -f

--- a/tekton/templates/tasks/cleanup-kubeflow-ci.yaml
+++ b/tekton/templates/tasks/cleanup-kubeflow-ci.yaml
@@ -36,7 +36,7 @@ spec:
       description: The GitHub repo containing kubeflow testing scripts
   steps:
   - name: create-context
-    image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
+    image: gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}
     command:
     - python
     - -m

--- a/tekton/templates/tasks/cleanup-kubeflow-ci.yaml
+++ b/tekton/templates/tasks/cleanup-kubeflow-ci.yaml
@@ -36,11 +36,7 @@ spec:
       description: The GitHub repo containing kubeflow testing scripts
   steps:
   - name: create-context
-<<<<<<< HEAD
-    image: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
-=======
-    image: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
->>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
+    image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
     command:
     - python
     - -m

--- a/tekton/templates/tasks/cleanup-kubeflow-ci.yaml
+++ b/tekton/templates/tasks/cleanup-kubeflow-ci.yaml
@@ -36,7 +36,11 @@ spec:
       description: The GitHub repo containing kubeflow testing scripts
   steps:
   - name: create-context
+<<<<<<< HEAD
     image: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
+=======
+    image: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
+>>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
     command:
     - python
     - -m

--- a/tekton/templates/tasks/deploy-gcp-blueprint.yaml
+++ b/tekton/templates/tasks/deploy-gcp-blueprint.yaml
@@ -41,11 +41,7 @@ spec:
     env:
     - name: KUBECONFIG
       value: /workspace/kubeconfig
-<<<<<<< HEAD
-    image: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
-=======
-    image: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
->>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
+    image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
   steps:
   - name: get-credential
     command:

--- a/tekton/templates/tasks/deploy-gcp-blueprint.yaml
+++ b/tekton/templates/tasks/deploy-gcp-blueprint.yaml
@@ -41,7 +41,11 @@ spec:
     env:
     - name: KUBECONFIG
       value: /workspace/kubeconfig
+<<<<<<< HEAD
     image: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
+=======
+    image: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
+>>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
   steps:
   - name: get-credential
     command:

--- a/tekton/templates/tasks/deploy-gcp-blueprint.yaml
+++ b/tekton/templates/tasks/deploy-gcp-blueprint.yaml
@@ -41,7 +41,7 @@ spec:
     env:
     - name: KUBECONFIG
       value: /workspace/kubeconfig
-    image: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
+    image: gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}
   steps:
   - name: get-credential
     command:

--- a/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
+++ b/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
@@ -29,11 +29,7 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
-<<<<<<< HEAD
-      default: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
-=======
-      default: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
->>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
+      default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
       description: The docker image to run the tests in
     # TODO(jlewi): Lets not use targetPath. Instead lets rely on Tekton checking repos
     # out to /workspace/$(resource.name)

--- a/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
+++ b/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
@@ -29,7 +29,7 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
+      default: gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}
       description: The docker image to run the tests in
     # TODO(jlewi): Lets not use targetPath. Instead lets rely on Tekton checking repos
     # out to /workspace/$(resource.name)

--- a/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
+++ b/tekton/templates/tasks/gcp-iap-endpoint-ready-task.yaml
@@ -29,7 +29,11 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
+<<<<<<< HEAD
       default: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
+=======
+      default: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
+>>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
       description: The docker image to run the tests in
     # TODO(jlewi): Lets not use targetPath. Instead lets rely on Tekton checking repos
     # out to /workspace/$(resource.name)

--- a/tekton/templates/tasks/go-tests.yaml
+++ b/tekton/templates/tasks/go-tests.yaml
@@ -29,7 +29,7 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
+      default: gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}
       description: The docker image to run the tests in
     resources:
     - name: source-repo

--- a/tekton/templates/tasks/go-tests.yaml
+++ b/tekton/templates/tasks/go-tests.yaml
@@ -29,11 +29,7 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
-<<<<<<< HEAD
-      default: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
-=======
-      default: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
->>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
+      default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
       description: The docker image to run the tests in
     resources:
     - name: source-repo

--- a/tekton/templates/tasks/go-tests.yaml
+++ b/tekton/templates/tasks/go-tests.yaml
@@ -29,7 +29,11 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
+<<<<<<< HEAD
       default: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
+=======
+      default: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
+>>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
       description: The docker image to run the tests in
     resources:
     - name: source-repo

--- a/tekton/templates/tasks/kf-ready-task.yaml
+++ b/tekton/templates/tasks/kf-ready-task.yaml
@@ -29,7 +29,11 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
+<<<<<<< HEAD
       default: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
+=======
+      default: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
+>>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
       description: The docker image to run the tests in. Should contain a version
         of kubeflow/testing/py in /srcCache that we want to use.
     resources:

--- a/tekton/templates/tasks/kf-ready-task.yaml
+++ b/tekton/templates/tasks/kf-ready-task.yaml
@@ -76,7 +76,7 @@ spec:
         --log-cli-level=info \
         --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
         --junitxml=/workspace/artifacts/junit_kf-ready.xml \
-        --app_name=$(KFNAME) \
+        --app_name=${KFNAME} \
         --timeout=180 \
         -o junit_suite_name=test_kf_ready_blueprint
       echo test finished.

--- a/tekton/templates/tasks/kf-ready-task.yaml
+++ b/tekton/templates/tasks/kf-ready-task.yaml
@@ -29,11 +29,7 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
-<<<<<<< HEAD
-      default: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
-=======
-      default: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
->>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
+      default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
       description: The docker image to run the tests in. Should contain a version
         of kubeflow/testing/py in /srcCache that we want to use.
     resources:
@@ -76,7 +72,7 @@ spec:
         --log-cli-level=info \
         --log-cli-format='%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s' \
         --junitxml=/workspace/artifacts/junit_kf-ready.xml \
-        --app_name=${KFNAME} \
+        --app_name=$(KFNAME) \
         --timeout=180 \
         -o junit_suite_name=test_kf_ready_blueprint
       echo test finished.

--- a/tekton/templates/tasks/kf-ready-task.yaml
+++ b/tekton/templates/tasks/kf-ready-task.yaml
@@ -29,7 +29,7 @@ spec:
         be in the form of 'gs://'
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
+      default: gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}
       description: The docker image to run the tests in. Should contain a version
         of kubeflow/testing/py in /srcCache that we want to use.
     resources:

--- a/tekton/templates/tasks/notebook-test-task.yaml
+++ b/tekton/templates/tasks/notebook-test-task.yaml
@@ -43,7 +43,11 @@ spec:
       default: default-profile
     - name: test-image
       type: string
+<<<<<<< HEAD
       default: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
+=======
+      default: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
+>>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
       description: The docker image to run the tests in
   steps:
   - name: get-credential
@@ -125,7 +129,11 @@ spec:
     params:
     - name: test-image
       type: string
+<<<<<<< HEAD
       default: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
+=======
+      default: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
+>>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
       description: The docker image to run the tests in
     - name: artifacts-gcs
       type: string

--- a/tekton/templates/tasks/notebook-test-task.yaml
+++ b/tekton/templates/tasks/notebook-test-task.yaml
@@ -43,7 +43,7 @@ spec:
       default: default-profile
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
+      default: gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}
       description: The docker image to run the tests in
   steps:
   - name: get-credential
@@ -125,7 +125,7 @@ spec:
     params:
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
+      default: gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:b23b63b-dirty@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}
       description: The docker image to run the tests in
     - name: artifacts-gcs
       type: string

--- a/tekton/templates/tasks/notebook-test-task.yaml
+++ b/tekton/templates/tasks/notebook-test-task.yaml
@@ -43,11 +43,7 @@ spec:
       default: default-profile
     - name: test-image
       type: string
-<<<<<<< HEAD
-      default: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
-=======
-      default: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
->>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
+      default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
       description: The docker image to run the tests in
   steps:
   - name: get-credential
@@ -129,11 +125,7 @@ spec:
     params:
     - name: test-image
       type: string
-<<<<<<< HEAD
-      default: gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:59b3b5d-dirty@sha256:58701d52b9fba37e7082c8e530b05fd533fb9a5ada5055c5f1443c0c4b9c8c43"}]}}
-=======
-      default: gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:4a56d44-dirty@sha256:cf45693453e331e89d0540ed8c2436528eec4db63f9ce4967591bb023b166417"}]}}
->>>>>>> 11a620e... Setup a kf-ci-dev namespace for manual sync'ing of Tekton pipelines.
+      default: gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3:d67009b@sha256:e96d069db00159c03b95ed1064569bcd0a78acdc691f42b5025050370949007a"}]}}
       description: The docker image to run the tests in
     - name: artifacts-gcs
       type: string


### PR DESCRIPTION
* This namespace is intended to allow for testing of changes to the pipelines
  without having to first check in the changes.

Revert "Update Dockerfile.py3 (#729)"
  This commit doesn't build.
This reverts commit 0de57331b32bfd7defe3a0b30fc5b8bf9abd4adf.

* Fix the entrypoint in Dockerfile.py3 for kubeflow/testing#684
* Rebuild the test worker image