### PR TITLE
Update Dockerfile.py3 image

### DIFF
--- a/images/Dockerfile.py3
+++ b/images/Dockerfile.py3
@@ -31,13 +31,19 @@ RUN cd /tmp && \
     wget -O /tmp/go.tar.gz https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz
 
-# Install gcloud
-ENV PATH=/root/go/bin:/usr/local/go/bin:/google-cloud-sdk/bin:/workspace:${PATH} \
-    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+# Create go symlinks
+RUN ln -sf /usr/local/go/bin/go /usr/local/bin && \
+    ln -sf /usr/local/go/bin/gofmt /usr/local/bin && \
+    ln -sf /usr/local/go/bin/godoc /usr/local/bin
 
 # Install the new version of yq which is based on go
 RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
-RUN go get github.com/kelseyhightower/kube-rsa 
+RUN go get github.com/kelseyhightower/kube-rsa
+RUN go get -u github.com/jstemmer/go-junit-report
+
+# Install gcloud
+ENV PATH=/root/go/bin:/usr/local/go/bin:/google-cloud-sdk/bin:/workspace:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
     tar xzf google-cloud-sdk.tar.gz -C / && \
@@ -71,31 +77,13 @@ RUN export ASM_VERSION=1.4.7-asm.0 && \
     mv istio-${ASM_VERSION} /usr/local && \
     ln -sf /usr/local/istio-${ASM_VERSION}/bin/istioctl /usr/local/bin/istioctl
 
-    
-# Create go symlinks
-RUN ln -sf /usr/local/go/bin/go /usr/local/bin && \
-    ln -sf /usr/local/go/bin/gofmt /usr/local/bin && \
-    ln -sf /usr/local/go/bin/godoc /usr/local/bin
+COPY checkout_repos.sh /usr/local/bin/
+COPY checkout.sh /usr/local/bin/
+COPY setup_ssh.sh /usr/local/bin/
+COPY run_workflows.sh /usr/local/bin/
+COPY run_release.sh /usr/local/bin/
 
-RUN go get github.com/kelseyhightower/kube-rsa
-
-COPY ./images/checkout_repos.sh /usr/local/bin
-COPY ./images/checkout.sh /usr/local/bin
-COPY ./images/setup_ssh.sh /usr/local/bin
-RUN chmod a+x /usr/local/bin/checkout* /usr/local/bin/setup_ssh.sh
-
-COPY ./images/run_workflows.sh /usr/local/bin
-RUN chmod a+x /usr/local/bin/run_workflows.sh
-
-COPY ./images/run_release.sh /usr/local/bin
-RUN chmod a+x /usr/local/bin/run_release.sh
-
-# Install the hub CLI for git
-RUN cd /tmp && \
-    curl -LO  https://github.com/github/hub/releases/download/v2.11.2/hub-linux-amd64-2.11.2.tgz && \
-    tar -xvf hub-linux-amd64-2.11.2.tgz && \
-    mv hub-linux-amd64-2.11.2 /usr/local && \
-    ln -sf /usr/local/hub-linux-amd64-2.11.2/bin/hub /usr/local/bin/hub
+RUN chmod a+x /usr/local/bin/checkout* /usr/local/bin/setup_ssh.sh /usr/local/bin/run_*.sh
 
 # Install kubectl
 # We don't install via gcloud because we want 1.10 which is newer than what's in gcloud.
@@ -103,12 +91,6 @@ RUN  curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.0/
     mv kubectl /usr/local/bin && \
     chmod a+x /usr/local/bin/kubectl
 
-RUN go get -u github.com/jstemmer/go-junit-report
-
-# Create a cached copy of the python test scripts so that we don't
-# need to clone the repo just to get access to them
-RUN mkdir -p /srcCache/kubeflow/testing
-COPY py /srcCache/kubeflow/testing/py
-COPY notebook_testing /srcCache/kubeflow/testing/notebook_testing
+ENV PYTHONPATH /src/kubeflow/testing/py/
 
 ENTRYPOINT ["/usr/local/bin/run_workflows.sh"]


### PR DESCRIPTION
This change is to build a working Dockerfile for Python 3 (please reference: https://github.com/kubeflow/testing/issues/684). Fixes the following issues:

* .sh scripts (e.g., `checkout_repos.sh`) were not being referenced correctly causing build errors
* "py" and "notebook_testing" were being referenced although they are outside the Dockerfile directory
* hub CLI and github.com/kelseyhightower/kube-rsa were being installed twice

I was able to successfully build this Dockerfile from the "images" folder by running: `docker build -f Dockerfile.py3  .`