### PR TITLE
Update deploy script to work with Kptfile refactor.

### DIFF
--- a/py/kubeflow/testing/create_kf_from_gcp_blueprint.py
+++ b/py/kubeflow/testing/create_kf_from_gcp_blueprint.py
@@ -124,13 +124,30 @@ class BlueprintRunner:
       "gcloud.core.project": project,
       "gcloud.compute.zone": zone,
       "location": location,
+    }
+
+    def set_values(pairs, subdir):
+      for k, v in pairs.items():
+        util.run(["kpt", "cfg", "set", subdir, k, v],
+                 cwd=blueprint_dir)
+
+    set_values(values, "./upstream/manifests/gcp")
+
+    values = {
+      "name": name,
+      "gcloud.core.project": project,
+    }
+
+    set_values(values, "./upstream/manifests/stacks/gcp")
+
+    values = {
+      "name": name,
+      "gcloud.core.project": project,
+      "location": location,
       "email": email,
     }
 
-    for subdir in ["./upstream/manifests/gcp", "./upstream/manifests/stacks/gcp", "./instance"]:
-      for k, v in values.items():
-        util.run(["kpt", "cfg", "set", subdir, k, v],
-                 cwd=blueprint_dir)
+    set_values(values, "./instance")
 
     # TODO(jlewi): We should add an expiration time; either as a label
     # or as as an annotation.


### PR DESCRIPTION
* Now that we are using kptfiles; kpt will complain if we try to
  set a setter which doesn't exist.

related to kubeflow/gcp-blueprints#89