### PR TITLE
chore: add cla yes and no labels for googlebot

### DIFF
--- a/label_sync/kubeflow_label.yml
+++ b/label_sync/kubeflow_label.yml
@@ -182,3 +182,7 @@ default:
     name: area/kfserving/crd
   - color: d4c5f9
     name: area/kfserving/doc
+  - color: aefcc0
+    name: 'cla: yes'
+  - color: f42e4c
+    name: 'cla: no'


### PR DESCRIPTION
Part of https://github.com/kubeflow/pipelines/issues/1653

Googlebot needs "cla: yes" and "cla: no" labels in a repo before it can add/delete these labels.
We can then configure PR protection rule that targets "cla: yes" label.