### PR TITLE
Fix python3.8 and pip linking

### DIFF
--- a/images/Dockerfile.py3
+++ b/images/Dockerfile.py3
@@ -5,8 +5,11 @@
 FROM ubuntu:18.04
 
 RUN apt-get update -y && \
-    apt-get install -y curl git python3.8 python3-pip wget && \
-    ln -sf /usr/bin/python3.8 /usr/bin/python
+    apt-get install -y curl git python3.8 python3-distutils wget && \
+    ln -sf /usr/bin/python3.8 /usr/bin/python && \
+    ln -sf /usr/bin/python3.8 /usr/bin/python3
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py
 
 RUN python3.8 -m pip install \
     filelock \

--- a/images/Dockerfile.py3.aws
+++ b/images/Dockerfile.py3.aws
@@ -5,8 +5,11 @@
 FROM ubuntu:18.04
 
 RUN apt-get update -y && \
-    apt-get install -y curl git python3.8 python3-pip wget jq && \
-    ln -sf /usr/bin/python3.8 /usr/bin/python
+    apt-get install -y curl git python3.8 python3-distutils wget && \
+    ln -sf /usr/bin/python3.8 /usr/bin/python && \
+    ln -sf /usr/bin/python3.8 /usr/bin/python3
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py
 
 RUN python3.8 -m pip install \
     filelock \


### PR DESCRIPTION
resolve #760 

1. Delete `python3-pip` and python3.6 won't be installed
2. Link pip3/pip to python3.8
3. Link python3 to python3.8