### PR TITLE
Add OWNERS files for Shared Assets

### DIFF
--- a/images/OWNERS
+++ b/images/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- bobgy
+- jlewi
+- PatrickXYS

--- a/py/kubeflow/testing/OWNERS
+++ b/py/kubeflow/testing/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- bobgy
+- jlewi
+- PatrickXYS


### PR DESCRIPTION
Add OWNERS for shared assets, this should unblock us from development on kubeflow/testing