### PR TITLE
Update py unittest

### DIFF
--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_pipeline_py-unittests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_pipeline_py-unittests.yaml
@@ -9,6 +9,17 @@ spec:
       in the form of 'gs://'
     name: artifacts-gcs
     type: string
+  - default: ""
+    description: It is the location of the directory to run lint over. If we set it
+      "", then it finds all the *.py files in the repository and test lint over them.
+    name: lint-src-dir
+    type: string
+  - default: ""
+    description: It is the location of the test directory which contains all the unit
+      tests. If we set it "", then it finds all the *_test.py files in the repository
+      and run unit test over them.
+    name: test-src-dir
+    type: string
   resources:
   - name: testing-repo
     type: git
@@ -17,6 +28,8 @@ spec:
     params:
     - name: artifacts-gcs
       value: $(params.artifacts-gcs)
+    - name: lint-src-dir
+      value: $(params.lint-src-dir)
     resources:
       inputs:
       - name: testing-repo
@@ -27,6 +40,8 @@ spec:
     params:
     - name: artifacts-gcs
       value: $(params.artifacts-gcs)
+    - name: test-src-dir
+      value: $(params.test-src-dir)
     resources:
       inputs:
       - name: testing-repo

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_py-lint.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_py-lint.yaml
@@ -6,17 +6,22 @@ metadata:
 spec:
   inputs:
     params:
-    - default: py-lint
-      description: Name to give the test results file.
-      name: test-name
-      type: string
     - description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker:latest
-      description: The docker image to run the tests in
+    - default: ""
+      description: It is the location of the directory to run lint over. If we set
+        it "", then it finds all the *.py files in the repository and test lint over
+        them.
+      name: lint-src-dir
+      type: string
+    - default: gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3
       name: test-image
+      type: string
+    - default: py-lint
+      description: Name to give the test results file.
+      name: test-name
       type: string
     resources:
     - description: The GitHub repo containing code to test
@@ -25,7 +30,7 @@ spec:
   steps:
   - env:
     - name: PYTHONPATH
-      value: /workspace/$(inputs.resources.testing-repo.name)/py
+      value: /srcCache/kubeflow/testing/py
     image: $(inputs.params.test-image)
     name: py-lint
     script: |
@@ -33,9 +38,10 @@ spec:
       set -x
       mkdir -p /workspace/artifacts
       echo Current Directory: $(pwd)
-      cd /workspace/$(inputs.resources.testing-repo.name)/py/kubeflow/testing/
+      cd /srcCache/kubeflow/testing/py/kubeflow/testing/
       pytest py_lint_test.py -s \
        --rcfile=/workspace/$(inputs.resources.testing-repo.name)/.pylintrc \
+       --src_dir=/workspace/$(inputs.resources.testing-repo.name)/$(inputs.params.lint-src-dir) \
        --timeout=500 \
        --junitxml=/workspace/artifacts/junit_$(inputs.params.test-name).xml
       echo Test results:

--- a/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_py-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/auto-deploy/tekton.dev_v1alpha1_task_py-test.yaml
@@ -6,39 +6,40 @@ metadata:
 spec:
   inputs:
     params:
-    - default: py-unit
-      description: Name to give the test results file.
-      name: test-name
-      type: string
     - description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker:latest
-      description: The docker image to run the tests in
+    - default: ""
+      description: It is the location of the test directory which contains all the
+        unit tests. If we set it "", then it finds all the *_test.py files in the
+        repository and run unit test over them.
+      name: test-src-dir
+      type: string
+    - default: gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3
       name: test-image
+      type: string
+    - default: py-unit
+      description: Name to give the test results file.
+      name: test-name
       type: string
     resources:
     - description: The GitHub repo containing code to test
       name: testing-repo
       type: git
   steps:
-  - env:
+  - args:
+    - -m
+    - kubeflow.testing.test_py_checks
+    - --artifacts_dir=/workspace/artifacts/junit_$(inputs.params.test-name)
+    - --src_dir=/workspace/$(inputs.resources.testing-repo.name)/$(inputs.params.test-src-dir)
+    command:
+    - python
+    env:
     - name: PYTHONPATH
-      value: /workspace/$(inputs.resources.testing-repo.name)/py
+      value: /srcCache/kubeflow/testing/py
     image: $(inputs.params.test-image)
     name: unit-test
-    script: |
-      #!/usr/bin/env bash
-      set -x
-      mkdir -p /workspace/artifacts
-      echo Current Directory: $(pwd)
-      python -m kubeflow.testing.test_py_checks \
-       --artifacts_dir=/workspace/artifacts/junit_$(inputs.params.test-name).xml \
-       --src_dir=/workspace/$(inputs.resources.testing-repo.name)/py/kubeflow/tests
-      echo Test results:
-      cat /workspace/artifacts/junit_$(inputs.params.test-name).xml
-      echo Test finished.
   - args:
     - -m
     - kubeflow.testing.tekton_client

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_pipeline_py-unittests.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_pipeline_py-unittests.yaml
@@ -9,6 +9,17 @@ spec:
       in the form of 'gs://'
     name: artifacts-gcs
     type: string
+  - default: ""
+    description: It is the location of the directory to run lint over. If we set it
+      "", then it finds all the *.py files in the repository and test lint over them.
+    name: lint-src-dir
+    type: string
+  - default: ""
+    description: It is the location of the test directory which contains all the unit
+      tests. If we set it "", then it finds all the *_test.py files in the repository
+      and run unit test over them.
+    name: test-src-dir
+    type: string
   resources:
   - name: testing-repo
     type: git
@@ -17,6 +28,8 @@ spec:
     params:
     - name: artifacts-gcs
       value: $(params.artifacts-gcs)
+    - name: lint-src-dir
+      value: $(params.lint-src-dir)
     resources:
       inputs:
       - name: testing-repo
@@ -27,6 +40,8 @@ spec:
     params:
     - name: artifacts-gcs
       value: $(params.artifacts-gcs)
+    - name: test-src-dir
+      value: $(params.test-src-dir)
     resources:
       inputs:
       - name: testing-repo

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_py-lint.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_py-lint.yaml
@@ -6,17 +6,22 @@ metadata:
 spec:
   inputs:
     params:
-    - default: py-lint
-      description: Name to give the test results file.
-      name: test-name
-      type: string
     - description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker:latest
-      description: The docker image to run the tests in
+    - default: ""
+      description: It is the location of the directory to run lint over. If we set
+        it "", then it finds all the *.py files in the repository and test lint over
+        them.
+      name: lint-src-dir
+      type: string
+    - default: gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3
       name: test-image
+      type: string
+    - default: py-lint
+      description: Name to give the test results file.
+      name: test-name
       type: string
     resources:
     - description: The GitHub repo containing code to test
@@ -25,7 +30,7 @@ spec:
   steps:
   - env:
     - name: PYTHONPATH
-      value: /workspace/$(inputs.resources.testing-repo.name)/py
+      value: /srcCache/kubeflow/testing/py
     image: $(inputs.params.test-image)
     name: py-lint
     script: |
@@ -33,9 +38,10 @@ spec:
       set -x
       mkdir -p /workspace/artifacts
       echo Current Directory: $(pwd)
-      cd /workspace/$(inputs.resources.testing-repo.name)/py/kubeflow/testing/
+      cd /srcCache/kubeflow/testing/py/kubeflow/testing/
       pytest py_lint_test.py -s \
        --rcfile=/workspace/$(inputs.resources.testing-repo.name)/.pylintrc \
+       --src_dir=/workspace/$(inputs.resources.testing-repo.name)/$(inputs.params.lint-src-dir) \
        --timeout=500 \
        --junitxml=/workspace/artifacts/junit_$(inputs.params.test-name).xml
       echo Test results:

--- a/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_py-test.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/kf-ci/tekton.dev_v1alpha1_task_py-test.yaml
@@ -6,39 +6,40 @@ metadata:
 spec:
   inputs:
     params:
-    - default: py-unit
-      description: Name to give the test results file.
-      name: test-name
-      type: string
     - description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
       name: artifacts-gcs
       type: string
-    - default: gcr.io/kubeflow-ci/test-worker:latest
-      description: The docker image to run the tests in
+    - default: ""
+      description: It is the location of the test directory which contains all the
+        unit tests. If we set it "", then it finds all the *_test.py files in the
+        repository and run unit test over them.
+      name: test-src-dir
+      type: string
+    - default: gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3
       name: test-image
+      type: string
+    - default: py-unit
+      description: Name to give the test results file.
+      name: test-name
       type: string
     resources:
     - description: The GitHub repo containing code to test
       name: testing-repo
       type: git
   steps:
-  - env:
+  - args:
+    - -m
+    - kubeflow.testing.test_py_checks
+    - --artifacts_dir=/workspace/artifacts/junit_$(inputs.params.test-name)
+    - --src_dir=/workspace/$(inputs.resources.testing-repo.name)/$(inputs.params.test-src-dir)
+    command:
+    - python
+    env:
     - name: PYTHONPATH
-      value: /workspace/$(inputs.resources.testing-repo.name)/py
+      value: /srcCache/kubeflow/testing/py
     image: $(inputs.params.test-image)
     name: unit-test
-    script: |
-      #!/usr/bin/env bash
-      set -x
-      mkdir -p /workspace/artifacts
-      echo Current Directory: $(pwd)
-      python -m kubeflow.testing.test_py_checks \
-       --artifacts_dir=/workspace/artifacts/junit_$(inputs.params.test-name).xml \
-       --src_dir=/workspace/$(inputs.resources.testing-repo.name)/py/kubeflow/tests
-      echo Test results:
-      cat /workspace/artifacts/junit_$(inputs.params.test-name).xml
-      echo Test finished.
   - args:
     - -m
     - kubeflow.testing.tekton_client

--- a/tekton/runs/py-test-run.yaml
+++ b/tekton/runs/py-test-run.yaml
@@ -1,7 +1,8 @@
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineRun
 metadata:
-  generateName: py-test-
+  # generateName: py-test-
+  name: py-test-123
   namespace: kf-ci
   labels:
     pipeline: py-test
@@ -9,7 +10,7 @@ metadata:
 spec:
   params:
   - name: artifacts-gcs
-    value: "gs://kubeflow-ci-deployment/py-test"
+    value: "gs://subodh101-experiments/testing-123"
   serviceAccountName: kf-ci
   resources:
   - name: testing-repo

--- a/tekton/runs/py-test-run.yaml
+++ b/tekton/runs/py-test-run.yaml
@@ -1,8 +1,7 @@
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineRun
 metadata:
-  # generateName: py-test-
-  name: py-test-123
+  generateName: py-test-
   namespace: kf-ci
   labels:
     pipeline: py-test
@@ -10,7 +9,11 @@ metadata:
 spec:
   params:
   - name: artifacts-gcs
-    value: "gs://subodh101-experiments/testing-123"
+    value: "gs://kubeflow-ci-deployment/py-test"
+  - name: lint-src-dir
+    value: "py"
+  - name: test-src-dir
+    value: "py/kubeflow/tests"
   serviceAccountName: kf-ci
   resources:
   - name: testing-repo

--- a/tekton/templates/pipelines/py-unittests-pipeline.yaml
+++ b/tekton/templates/pipelines/py-unittests-pipeline.yaml
@@ -8,6 +8,16 @@ spec:
     type: string
     description: GCS bucket and directory artifacts will be uploaded to. Should be
       in the form of 'gs://'
+  - name: lint-src-dir
+    type: string
+    default: ""
+    description: It is the location of the directory to run lint over.
+      If we set it "", then it finds all the *.py files in the repository and test lint over them.
+  - name: test-src-dir
+    type: string
+    default: ""
+    description: It is the location of the test directory which contains all the unit tests.
+      If we set it "", then it finds all the *_test.py files in the repository and run unit test over them.
   resources:
   - name: testing-repo
     type: git
@@ -16,6 +26,8 @@ spec:
     params:
     - name: artifacts-gcs
       value: "$(params.artifacts-gcs)"
+    - name: lint-src-dir
+      value: "$(params.lint-src-dir)"
     resources:
       inputs:
       - name: testing-repo
@@ -26,6 +38,8 @@ spec:
     params:
     - name: artifacts-gcs
       value: "$(params.artifacts-gcs)"
+    - name: test-src-dir
+      value: "$(params.test-src-dir)"
     resources:
       inputs:
       - name: testing-repo

--- a/tekton/templates/tasks/py-lint.yaml
+++ b/tekton/templates/tasks/py-lint.yaml
@@ -9,6 +9,11 @@ spec:
       type: string
       description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
+    - name: lint-src-dir
+      type: string
+      default: ""
+      description: It is the location of the directory to run lint over.
+        If we set it "", then it finds all the *.py files in the repository and test lint over them.
     - name: test-image
       type: string
       default: gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}      description: The docker image to run the tests in
@@ -28,9 +33,10 @@ spec:
       set -x
       mkdir -p /workspace/artifacts
       echo Current Directory: $(pwd)
-      cd /workspace/$(inputs.resources.testing-repo.name)/py/kubeflow/testing/
+      cd /srcCache/kubeflow/testing/py/kubeflow/testing/
       pytest py_lint_test.py -s \
        --rcfile=/workspace/$(inputs.resources.testing-repo.name)/.pylintrc \
+       --src_dir=/workspace/$(inputs.resources.testing-repo.name)/$(inputs.params.lint-src-dir) \
        --timeout=500 \
        --junitxml=/workspace/artifacts/junit_$(inputs.params.test-name).xml
       echo Test results:

--- a/tekton/templates/tasks/py-lint.yaml
+++ b/tekton/templates/tasks/py-lint.yaml
@@ -5,18 +5,17 @@ metadata:
 spec:
   inputs:
     params:
-    - name: test-name
-      type: string
-      default: py-lint
-      description: Name to give the test results file.
     - name: artifacts-gcs
       type: string
       description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker:latest
-      description: The docker image to run the tests in
+      default: gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}      description: The docker image to run the tests in
+    - name: test-name
+      type: string
+      default: py-lint
+      description: Name to give the test results file.
     resources:
     - name: testing-repo
       type: git
@@ -39,7 +38,7 @@ spec:
       echo Test finished.
     env:
     - name: PYTHONPATH
-      value: /workspace/$(inputs.resources.testing-repo.name)/py
+      value: /srcCache/kubeflow/testing/py
   # This step is designed to be generic: given the output directory, it will try to
   # parse all the XML files with prefix of junit and error out if failures been found.
   - name: copy-artifacts

--- a/tekton/templates/tasks/py-test.yaml
+++ b/tekton/templates/tasks/py-test.yaml
@@ -5,18 +5,17 @@ metadata:
 spec:
   inputs:
     params:
-    - name: test-name
-      type: string
-      default: py-unit
-      description: Name to give the test results file.
     - name: artifacts-gcs
       type: string
       description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
     - name: test-image
       type: string
-      default: gcr.io/kubeflow-ci/test-worker:latest
-      description: The docker image to run the tests in
+      default: gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}      description: The docker image to run the tests in
+    - name: test-name
+      type: string
+      default: py-unit
+      description: Name to give the test results file.
     resources:
     - name: testing-repo
       type: git
@@ -24,20 +23,16 @@ spec:
   steps:
   - name: unit-test
     image: $(inputs.params.test-image)
-    script: |
-      #!/usr/bin/env bash
-      set -x
-      mkdir -p /workspace/artifacts
-      echo Current Directory: $(pwd)
-      python -m kubeflow.testing.test_py_checks \
-       --artifacts_dir=/workspace/artifacts/junit_$(inputs.params.test-name).xml \
-       --src_dir=/workspace/$(inputs.resources.testing-repo.name)/py/kubeflow/tests
-      echo Test results:
-      cat /workspace/artifacts/junit_$(inputs.params.test-name).xml
-      echo Test finished.
+    command:
+    - python
+    args:
+    - -m
+    - kubeflow.testing.test_py_checks
+    - --artifacts_dir=/workspace/artifacts/junit_$(inputs.params.test-name)
+    - --src_dir=/workspace/$(inputs.resources.testing-repo.name)/py/kubeflow/tests
     env:
     - name: PYTHONPATH
-      value: /workspace/$(inputs.resources.testing-repo.name)/py
+      value: /srcCache/kubeflow/testing/py
   # This step is designed to be generic: given the output directory, it will try to
   # parse all the XML files with prefix of junit and error out if failures been found.
   - name: copy-artifacts

--- a/tekton/templates/tasks/py-test.yaml
+++ b/tekton/templates/tasks/py-test.yaml
@@ -9,6 +9,11 @@ spec:
       type: string
       description: GCS bucket and directory artifacts will be uploaded to. Should
         be in the form of 'gs://'
+    - name: test-src-dir
+      type: string
+      default: ""
+      description: It is the location of the test directory which contains all the unit tests.
+        If we set it "", then it finds all the *_test.py files in the repository and run unit test over them.
     - name: test-image
       type: string
       default: gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"test-image","value":"gcr.io/kubeflow-ci/test-worker-py3@sha256:a749d7fa4d77466c892a206d3adf0909e86717da898dbd12378e6cbed59ffbd3"}]}}      description: The docker image to run the tests in
@@ -29,7 +34,7 @@ spec:
     - -m
     - kubeflow.testing.test_py_checks
     - --artifacts_dir=/workspace/artifacts/junit_$(inputs.params.test-name)
-    - --src_dir=/workspace/$(inputs.resources.testing-repo.name)/py/kubeflow/tests
+    - --src_dir=/workspace/$(inputs.resources.testing-repo.name)/$(inputs.params.test-src-dir)
     env:
     - name: PYTHONPATH
       value: /srcCache/kubeflow/testing/py


### PR DESCRIPTION
What?
- add source path for lint and unit test.
- Update to py docker image.
- Fix python path for all the steps.

Usage:
- path for the lint and unit test directory is to be set at the pipelinerun based on the locations in any repository.
For eg. in case of kubeflow/testing repo:

```
  - name: lint-src-dir
    value: "py"
  - name: test-src-dir
    value: "py/kubeflow/tests"
``` 
- .pylintrc file should be present at the toplevel of any repository using it.

Ref: https://github.com/kubeflow/testing/issues/769