### PR TITLE
test: pin gcp blueprint auto deploy to v1.1 branch in testing repo

### DIFF
--- a/test-infra/auto-deploy/manifest/config/pipeline-run-deploy-blueprint-v1.1.yaml
+++ b/test-infra/auto-deploy/manifest/config/pipeline-run-deploy-blueprint-v1.1.yaml
@@ -28,7 +28,7 @@ spec:
       type: git
       params:
         - name: revision
-          value: master
+          value: v1.1-branch
         - name: url
           value: https://github.com/kubeflow/testing.git
   # Need to use a KSA with appropriate GSA


### PR DESCRIPTION
Part of https://github.com/kubeflow/gcp-blueprints/issues/150