### PR TITLE
Create v1.2.0 config

### DIFF
--- a/apps-cd/applications.yaml
+++ b/apps-cd/applications.yaml
@@ -265,3 +265,24 @@ versions:
               value: v1.1-branch
             - name: url
               value: git@github.com:kubeflow/tf-operator.git
+  # Define a v1-2 release
+  - name: v1-2
+    # A tag to prefix image names with
+    tag: "v1.2.0"
+    repos:
+      - name: kubeflow
+        resourceSpec:
+          type: git
+          params:
+            - name: revision
+              value: v1.2-branch
+            - name: url
+              value: git@github.com:kubeflow/kubeflow.git
+      - name: manifests
+        resourceSpec:
+          type: git
+          params:
+            - name: revision
+              value: v1.2-branch
+            - name: url
+              value: git@github.com:kubeflow/manifests.git


### PR DESCRIPTION
I think this is the configuration for CD. I cut v1.2-branch in following repos. Once it's added, they should build images with v1.2 tag and update kubeflow/manifest repo. It also helps on cherry-picks against v1.2-branch. 


/cc @PatrickXYS @jlewi @Bobgy @pingsutw 