### PR TITLE
Add a workload identity binding for the emojichat namespace

### DIFF
--- a/acm-repos/kf-ci-management/namespaces/issue-label-bot-dev/iam.cnrm.cloud.google.com_v1beta1_iampolicymember_code-intelligence-emojichat-wi.yaml
+++ b/acm-repos/kf-ci-management/namespaces/issue-label-bot-dev/iam.cnrm.cloud.google.com_v1beta1_iampolicymember_code-intelligence-emojichat-wi.yaml
@@ -1,0 +1,14 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  labels:
+    kf-name: code-intelligence
+  name: code-intelligence-emojichat-wi
+  namespace: issue-label-bot-dev
+spec:
+  member: serviceAccount:issue-label-bot-dev.svc.id.goog[emojichat/default-editor]
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: code-intelligence-user
+  role: roles/iam.workloadIdentityUser


### PR DESCRIPTION
* Needed in order to download models from GCS.