### PR TITLE
Fix the service account for emoji chat

### DIFF
--- a/acm-repos/kf-ci-management/namespaces/issue-label-bot-dev/iam.cnrm.cloud.google.com_v1beta1_iampolicymember_code-intelligence-emojichat-wi.yaml
+++ b/acm-repos/kf-ci-management/namespaces/issue-label-bot-dev/iam.cnrm.cloud.google.com_v1beta1_iampolicymember_code-intelligence-emojichat-wi.yaml
@@ -3,12 +3,12 @@ kind: IAMPolicyMember
 metadata:
   labels:
     kf-name: code-intelligence
-  name: code-intelligence-emojichat-wi
+  name: code-intelligence-emojichat-user-wi
   namespace: issue-label-bot-dev
 spec:
   member: serviceAccount:issue-label-bot-dev.svc.id.goog[emojichat/default-editor]
   resourceRef:
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
-    name: code-intelligence-user
+    name: issue-label-bot-user
   role: roles/iam.workloadIdentityUser


### PR DESCRIPTION
* We should be using the issue-label-bot-user GCP SA as that's the cluster where
  its running.