### PR TITLE
Add tf operator presubmit to share test infra config

### DIFF
--- a/aws/GitOps/clusters/kubeflow-shared-test-infra-poc-tekton/namespaces/tekton-templates/tf-operator-repo.yaml
+++ b/aws/GitOps/clusters/kubeflow-shared-test-infra-poc-tekton/namespaces/tekton-templates/tf-operator-repo.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineResource
+metadata:
+  name: tf-operator-repo
+spec:
+  type: git
+  params:
+    - name: revision
+      value: master
+    - name: url
+      value: https://github.com/kubeflow/tf-operator

--- a/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/config.yaml
@@ -190,6 +190,20 @@ data:
           - image: 527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:latest
             imagePullPolicy: Always
             command: ["/usr/local/bin/run_workflows.sh"]
+
+      kubeflow/tf-operator:
+      - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+        branches:
+        - master
+        decorate: false
+        labels:
+          preset-aws-cred: "true"
+        always_run: true
+        spec:
+          containers:
+          - image: 527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:latest
+            imagePullPolicy: Always
+            command: ["/usr/local/bin/run_workflows.sh"]
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/aws/User/clusters/kubeflow-shared-test-infra-poc-tekton/namespaces/tekton-templates/pipelineresources/tf-operator-repo.yaml
+++ b/aws/User/clusters/kubeflow-shared-test-infra-poc-tekton/namespaces/tekton-templates/pipelineresources/tf-operator-repo.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineResource
+metadata:
+  name: tf-operator-repo
+spec:
+  type: git
+  params:
+    - name: revision
+      value: master
+    - name: url
+      value: https://github.com/kubeflow/tf-operator

--- a/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/config.yaml
@@ -187,3 +187,17 @@ presubmits:
       - image: 527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
         command: ["/usr/local/bin/run_workflows.sh"]
+
+  kubeflow/tf-operator:
+  - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+    branches:
+    - master
+    decorate: false
+    labels:
+      preset-aws-cred: "true"
+    always_run: true
+    spec:
+      containers:
+      - image: 527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+        command: ["/usr/local/bin/run_workflows.sh"]


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
[tf-operator#1193](https://github.com/kubeflow/tf-operator/issues/1193)

**Description of your changes:**
Move tf-operator presubmit jobs to AWS CI

**Checklist:**
<br> If PR related to **Optional-Test-Infra**,

- [x] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`