### PR TITLE
Disable manifests

### DIFF
--- a/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/config.yaml
@@ -136,7 +136,6 @@ data:
       kubeflow/kfctl:
       - name: kubeflow-kfctl-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
-        - master
         - v1.2-branch
         decorate: false
         labels:

--- a/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/config.yaml
@@ -165,7 +165,6 @@ data:
       kubeflow/manifests:
       - name: kubeflow-manifests-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
-        - master
         - v1.2-branch
         decorate: false
         labels:

--- a/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/config.yaml
@@ -133,7 +133,6 @@ presubmits:
   kubeflow/kfctl:
   - name: kubeflow-kfctl-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
-    - master
     - v1.2-branch
     decorate: false
     labels:

--- a/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/config.yaml
@@ -162,7 +162,6 @@ presubmits:
   kubeflow/manifests:
   - name: kubeflow-manifests-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
-    - master
     - v1.2-branch
     decorate: false
     labels:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Helps https://github.com/kubeflow/manifests/pull/1719

**Description of your changes:**
Disable until we finish upgrading manifests file. 

The reason to disable kfctl test is it has dependencies on master-branch manifests repo.

**Checklist:**
If PR related to **Optional-Test-Infra**,

- [x] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
