### PR TITLE
test(gcp): set up GSA workload identity for test pods in kf-ci-v1 cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,14 @@ hydrate:
 	rm -f $(REPO_DIRS)/kf-ci-v1/namespaces/auto-deploy/tekton*
 	find $(REPO_DIRS)/kf-ci-v1/namespaces/kf-ci -type f -not -name namespace.yaml -o -name service-account-kf-ci.yaml -exec rm {} ";"
 	find $(REPO_DIRS)/kf-ci-management/namespaces/kfp-ci -type f -not -name namespace.yaml -exec rm {} ";"
+	rm -rf $(REPO_DIRS)/kf-ci-v1/namespaces/test-pods
+	mkdir -p $(REPO_DIRS)/kf-ci-v1/namespaces/test-pods
 
 	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/auto-deploy $(TEKTON_INSTALLS)/auto-deploy
 	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/auto-deploy test-infra/auto-deploy/manifest
 	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/kf-ci $(TEKTON_INSTALLS)/kf-ci
+	kustomize build -o $(REPO_DIRS)/kf-ci-v1/namespaces/test-pods test-infra/kf-ci-v1/test-pods
+	cp test-infra/kf-ci-v1/test-pods/namespace.yaml $(REPO_DIRS)/kf-ci-v1/namespaces/test-pods/
 	cd test-infra/cleanup && $(MAKE) hydrate
 	cd test-infra/kfp && make all
 

--- a/acm-repos/kf-ci-v1/namespaces/test-pods/namespace.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/test-pods/namespace.yaml
@@ -1,0 +1,5 @@
+# Namespace to run prow test pods.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-pods

--- a/acm-repos/kf-ci-v1/namespaces/test-pods/v1_serviceaccount_default.yaml
+++ b/acm-repos/kf-ci-v1/namespaces/test-pods/v1_serviceaccount_default.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: kf-ci-v1-prow@kubeflow-ci.iam.gserviceaccount.com
+  name: default
+  namespace: test-pods

--- a/test-infra/kf-ci-v1/gcp_config/Makefile
+++ b/test-infra/kf-ci-v1/gcp_config/Makefile
@@ -1,0 +1,24 @@
+DEPLOYMENT=kf-ci-v1
+PROJECT_ARG=--project kubeflow-ci
+
+# Refer to documentation:
+# https://cloud.google.com/deployment-manager/docs/deployments/updating-deployments
+
+.PHONY: list apply
+
+list:
+	gcloud deployment-manager deployments list $(PROJECT_ARG)
+
+get:
+	gcloud deployment-manager deployments describe $(DEPLOYMENT) $(PROJECT_ARG)
+
+preview:
+	gcloud deployment-manager deployments update $(DEPLOYMENT) $(PROJECT_ARG) \
+		--config cluster-kubeflow.yaml \
+		--preview
+
+apply:
+	gcloud deployment-manager deployments update $(DEPLOYMENT) $(PROJECT_ARG)
+
+cancel:
+	gcloud deployment-manager deployments cancel-preview $(DEPLOYMENT) $(PROJECT_ARG)

--- a/test-infra/kf-ci-v1/gcp_config/cluster.jinja
+++ b/test-infra/kf-ci-v1/gcp_config/cluster.jinja
@@ -28,6 +28,7 @@ limitations under the License.
 {% set KF_ADMIN_NAME = NAME_PREFIX + '-admin' %}
 {% set KF_USER_NAME = NAME_PREFIX + '-user' %}
 {% set KF_VM_SA_NAME = NAME_PREFIX + '-vm' %}
+{% set PROW_SA_NAME = NAME_PREFIX + '-prow' %}
 
 resources:
 - name: {{ KF_ADMIN_NAME }}
@@ -47,6 +48,18 @@ resources:
   properties:
     accountId: {{ KF_VM_SA_NAME }}
     displayName: GCP Service Account to use as VM Service Account for Kubeflow Cluster VMs
+
+- name: {{ PROW_SA_NAME }}
+  type: iam.v1.serviceAccount
+  properties:
+    accountId: {{ PROW_SA_NAME }}
+    displayName: GCP Service Account for Kubeflow prow test infra.
+  accessControl:
+    gcpIamPolicy:
+      bindings:
+      - role: roles/iam.workloadIdentityUser
+        members:
+        - serviceAccount:{{ env['project'] }}.svc.id.goog[test-pods/default]
 
 - name: {{ CLUSTER_NAME }}
   {% if properties['gkeApiVersion'] == 'v1beta1' %}
@@ -99,7 +112,7 @@ resources:
         autoprovisioningNodePoolDefaults:
           oauthScopes: {{ VM_OAUTH_SCOPES }}
           serviceAccount: {{ KF_VM_SA_NAME }}@{{ env['project'] }}.iam.gserviceaccount.com
-          
+
         resourceLimits:
         - resourceType: 'cpu'
           maximum: {{ properties['autoprovisioning-config']['max-cpu'] }}

--- a/test-infra/kf-ci-v1/test-pods/kustomization.yaml
+++ b/test-infra/kf-ci-v1/test-pods/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: test-pods
+resources:
+- service-account.yaml

--- a/test-infra/kf-ci-v1/test-pods/namespace.yaml
+++ b/test-infra/kf-ci-v1/test-pods/namespace.yaml
@@ -1,0 +1,5 @@
+# Namespace to run prow test pods.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-pods

--- a/test-infra/kf-ci-v1/test-pods/service-account.yaml
+++ b/test-infra/kf-ci-v1/test-pods/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  annotations:
+    iam.gke.io/gcp-service-account: kf-ci-v1-prow@kubeflow-ci.iam.gserviceaccount.com


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubernetes/test-infra/issues/14343

**Description of your changes:**


**Checklist:**
If PR related to **Optional-Test-Infra**,

- [ ] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
