### PR TITLE
Use repo-level trigger plugins

### DIFF
--- a/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/plugins.yaml
+++ b/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/plugins.yaml
@@ -1,13 +1,34 @@
 apiVersion: v1
 data:
-  plugins.yaml: |
+  plugins.yaml: |-
     triggers:
     - repos:
       - kubeflow
       join_org_url: "https://github.com/kubeflow/kubeflow/blob/master/CONTRIBUTING.md"
       only_org_members: true
     plugins:
-      kubeflow:
+      kubeflow/katib:
+      - trigger
+
+      kubeflow/kfctl:
+      - trigger
+
+      kubeflow/kfserving:
+      - trigger
+
+      kubeflow/kubeflow:
+      - trigger
+
+      kubeflow/manifests:
+      - trigger
+
+      kubeflow/pytorch-operator:
+      - trigger
+
+      kubeflow/tf-operator:
+      - trigger
+
+      kubeflow/xgboost-operator:
       - trigger
 kind: ConfigMap
 metadata:

--- a/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/plugins.yaml
+++ b/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/plugins.yaml
@@ -4,5 +4,26 @@ triggers:
   join_org_url: "https://github.com/kubeflow/kubeflow/blob/master/CONTRIBUTING.md"
   only_org_members: true
 plugins:
-  kubeflow:
+  kubeflow/katib:
+  - trigger
+
+  kubeflow/kfctl:
+  - trigger
+
+  kubeflow/kfserving:
+  - trigger
+
+  kubeflow/kubeflow:
+  - trigger
+
+  kubeflow/manifests:
+  - trigger
+
+  kubeflow/pytorch-operator:
+  - trigger
+
+  kubeflow/tf-operator:
+  - trigger
+
+  kubeflow/xgboost-operator:
   - trigger


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/internal-acls/issues/354

**Description of your changes:**
Use repo-level trigger plugins to avoid aws-kf-ci-bot screaming in other repos.

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
