### PR TITLE
Add myself into OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 approvers:
 - bobgy
 - jlewi
+- PatrickXYS
 reviewers:
 - Jeffwan
 - pingsutw


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Adding myself into OWNERS can avoid the bahavior:

I created a new folder in root directory, got lgtm from others, but can't approve myself to move fast and I don't want to manually merge every time. Since kubeflow/testing active contributors are of 2-3, this PR can help improve efficiency.

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
