### PR TITLE
Disable pytorch in old test-infra

### DIFF
--- a/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/config.yaml
@@ -177,20 +177,6 @@ data:
             imagePullPolicy: Always
             command: ["/usr/local/bin/run_workflows.sh"]
 
-      kubeflow/pytorch-operator:
-      - name: kubeflow-pytorch-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
-        branches:
-        - master
-        decorate: false
-        labels:
-          preset-aws-cred: "true"
-        always_run: true
-        spec:
-          containers:
-          - image: 527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:latest
-            imagePullPolicy: Always
-            command: ["/usr/local/bin/run_workflows.sh"]
-
       kubeflow/tf-operator:
       - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:

--- a/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/plugins.yaml
+++ b/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/plugins.yaml
@@ -22,9 +22,6 @@ data:
       kubeflow/manifests:
       - trigger
 
-      kubeflow/pytorch-operator:
-      - trigger
-
       kubeflow/tf-operator:
       - trigger
 

--- a/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/config.yaml
@@ -174,20 +174,6 @@ presubmits:
         imagePullPolicy: Always
         command: ["/usr/local/bin/run_workflows.sh"]
 
-  kubeflow/pytorch-operator:
-  - name: kubeflow-pytorch-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
-    branches:
-    - master
-    decorate: false
-    labels:
-      preset-aws-cred: "true"
-    always_run: true
-    spec:
-      containers:
-      - image: 527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-        command: ["/usr/local/bin/run_workflows.sh"]
-
   kubeflow/tf-operator:
   - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:

--- a/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/plugins.yaml
+++ b/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/plugins.yaml
@@ -19,9 +19,6 @@ plugins:
   kubeflow/manifests:
   - trigger
 
-  kubeflow/pytorch-operator:
-  - trigger
-
   kubeflow/tf-operator:
   - trigger
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/testing/issues/861

**Description of your changes:**
Start from migrating pytorch-operator first

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
