### PR TITLE
Fix typo

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
@@ -5,7 +5,7 @@ data:
       PatrickXYS-testing:
       - trigger
       kubeflow/pytorch-operator:
-      - trigeer
+      - trigger
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
@@ -2,4 +2,4 @@ plugins:
   PatrickXYS-testing:
   - trigger
   kubeflow/pytorch-operator:
-  - trigeer
+  - trigger


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/testing/issues/861

**Description of your changes:**
Start from migrating pytorch-operator first

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
