### PR TITLE
Migrate xgboost-operator repo

### DIFF
--- a/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/plugins.yaml
+++ b/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/plugins.yaml
@@ -9,11 +9,7 @@ data:
     plugins:
       kubeflow/kfserving:
       - trigger
-
       kubeflow/tf-operator:
-      - trigger
-
-      kubeflow/xgboost-operator:
       - trigger
 kind: ConfigMap
 metadata:

--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -76,16 +76,6 @@ data:
     decorate_all_jobs: true
 
     presubmits:
-      PatrickXYS-testing/flux-testing:
-      - name: flux-echo-test
-        branches:
-        - master
-        always_run: true
-        spec:
-          containers:
-          - image: alpine
-            command: ["/bin/date"]
-
       kubeflow/katib:
       - name: kubeflow-katib-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:

--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 data:
   plugins.yaml: |-
     plugins:
-      PatrickXYS-testing:
-      - trigger
       kubeflow/katib:
       - trigger
       kubeflow/kfctl:
@@ -13,6 +11,8 @@ data:
       kubeflow/manifests:
       - trigger
       kubeflow/pytorch-operator:
+      - trigger
+      kubeflow/xgboost-operator:
       - trigger
 kind: ConfigMap
 metadata:

--- a/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/plugins.yaml
+++ b/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/plugins.yaml
@@ -6,9 +6,5 @@ triggers:
 plugins:
   kubeflow/kfserving:
   - trigger
-
   kubeflow/tf-operator:
-  - trigger
-
-  kubeflow/xgboost-operator:
   - trigger

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -73,16 +73,6 @@ presets:
 decorate_all_jobs: true
 
 presubmits:
-  PatrickXYS-testing/flux-testing:
-  - name: flux-echo-test
-    branches:
-    - master
-    always_run: true
-    spec:
-      containers:
-      - image: alpine
-        command: ["/bin/date"]
-
   kubeflow/katib:
   - name: kubeflow-katib-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
@@ -1,6 +1,4 @@
 plugins:
-  PatrickXYS-testing:
-  - trigger
   kubeflow/katib:
   - trigger
   kubeflow/kfctl:
@@ -10,4 +8,6 @@ plugins:
   kubeflow/manifests:
   - trigger
   kubeflow/pytorch-operator:
+  - trigger
+  kubeflow/xgboost-operator:
   - trigger


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Helps #861 

**Description of your changes:**
Migrate xgboost-operator to new test-infra

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
