### PR TITLE
Add access related resources

### DIFF
--- a/aws/Access/README.md
+++ b/aws/Access/README.md
@@ -1,0 +1,1 @@
+[TODO] PatrickXYS: add instructions for adding team member with infra permission

--- a/aws/Access/assume-role-access/infra-editor/trust-policy.json
+++ b/aws/Access/assume-role-access/infra-editor/trust-policy.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": {
+        "Effect": "Allow",
+        "Principal": {"AWS": [
+            "arn:aws:iam::068661676837:root"
+        ]},
+        "Action": "sts:AssumeRole"
+    }
+}

--- a/aws/GitOps/clusters/optional-test-infra-daily-worker/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-daily-worker/namespaces/prow/config.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    prowjob_namespace: prow
+    pod_namespace: test-pods
+
+    in_repo_config:
+      enabled:
+        "*": true
+
+    deck:
+     spyglass:
+       lenses:
+       - lens:
+           name: metadata
+         required_files:
+         - started.json|finished.json
+       - lens:
+           config:
+           name: buildlog
+         required_files:
+         - build-log.txt
+       - lens:
+           name: junit
+         required_files:
+         - .*/junit.*\.xml
+       - lens:
+           name: podinfo
+         required_files:
+         - podinfo.json
+
+    plank:
+      job_url_prefix_config:
+        "*": http://worker.kubeflow-testing.com/view/
+      job_url_template: 'http://worker.kubeflow-testing.com/view/s3/aws-kubeflow-worker/pr-logs/pull/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}'
+      report_templates:
+        '*': >-
+            [Full PR test history](http://worker.kubeflow-testing.com/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+            [Your PR dashboard](https://worker.kubeflow-testing.com/pr?query=is:pr+state:open+author:{{with
+            index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
+      default_decoration_configs:
+        "*":
+          gcs_configuration:
+            bucket: s3://aws-kubeflow-worker
+            path_strategy: explicit
+          s3_credentials_secret: s3-credentials
+          utility_images:
+            clonerefs: gcr.io/k8s-prow/clonerefs:v20210128-721ee668fd
+            entrypoint: gcr.io/k8s-prow/entrypoint:v20210128-721ee668fd
+            initupload: gcr.io/k8s-prow/initupload:v20210128-721ee668fd
+            sidecar: gcr.io/k8s-prow/sidecar:v20210128-721ee668fd
+
+
+    decorate_all_jobs: true
+    periodics:
+    - interval: 1m
+      agent: kubernetes
+      name: echo-test
+      spec:
+        containers:
+        - image: alpine
+          command: ["/bin/date"]
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: config
+  namespace: prow

--- a/aws/Makefile
+++ b/aws/Makefile
@@ -10,6 +10,7 @@ optional-generate:
 	make optional-generate-optional-test-infra-prow
 	make optional-generate-optional-test-infra-argo
 	make optional-generate-optional-test-infra-tekton
+	make optional-generate-optional-test-infra-daily-worker
 
 # Validate if optional-generate runs
 optional-test:
@@ -93,3 +94,14 @@ optional-generate-optional-test-infra-tekton:
 	cp -r ./User/clusters/optional-test-infra-tekton/namespaces/kubeflow-test-infra/task/ \
     ${OPTIONAL_TEST_INFRA_GITOPS_DIRS}/clusters/optional-test-infra-tekton/namespaces/kubeflow-test-infra/
 	echo "Finish generating yaml files for optional-test-infra-tekton cluster"
+
+optional-generate-optional-test-infra-daily-worker:
+	echo ${OPTIONAL_TEST_INFRA_GITOPS_DIRS}
+	echo "Start generating yaml files for optional-test-infra-daily-worker cluster"
+	rm -rf ${OPTIONAL_TEST_INFRA_GITOPS_DIRS}/clusters/optional-test-infra-daily-worker/namespaces/prow/*
+	mkdir -p ${OPTIONAL_TEST_INFRA_GITOPS_DIRS}/clusters/optional-test-infra-daily-worker/namespaces/prow/
+	kubectl -n prow --kubeconfig=./testing/fake-kubeconfig/config.yaml create configmap config \
+	--from-file=config.yaml=./User/clusters/optional-test-infra-daily-worker/namespaces/prow/configmap/config.yaml \
+	--dry-run=client -o yaml > \
+	${OPTIONAL_TEST_INFRA_GITOPS_DIRS}/clusters/optional-test-infra-daily-worker/namespaces/prow/config.yaml
+	echo "Finish generating yaml files for optional-test-infra-daily-worker cluster"

--- a/aws/README.md
+++ b/aws/README.md
@@ -10,3 +10,4 @@ Each sub-folder refer to different functionality for Optional-Test-Infra
 * **Doc**: documentations for optional-test-infra
 * **Picture**: pictures embedded in the documentations
 * **testing**: testing artifacts storage
+* **Access**: Infra Access Control for Kubeflow Community

--- a/aws/User/clusters/optional-test-infra-daily-worker/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-daily-worker/namespaces/prow/configmap/config.yaml
@@ -1,0 +1,59 @@
+prowjob_namespace: prow
+pod_namespace: test-pods
+
+in_repo_config:
+  enabled:
+    "*": true
+
+deck:
+ spyglass:
+   lenses:
+   - lens:
+       name: metadata
+     required_files:
+     - started.json|finished.json
+   - lens:
+       config:
+       name: buildlog
+     required_files:
+     - build-log.txt
+   - lens:
+       name: junit
+     required_files:
+     - .*/junit.*\.xml
+   - lens:
+       name: podinfo
+     required_files:
+     - podinfo.json
+
+plank:
+  job_url_prefix_config:
+    "*": http://worker.kubeflow-testing.com/view/
+  job_url_template: 'http://worker.kubeflow-testing.com/view/s3/aws-kubeflow-worker/pr-logs/pull/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}'
+  report_templates:
+    '*': >-
+        [Full PR test history](http://worker.kubeflow-testing.com/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+        [Your PR dashboard](https://worker.kubeflow-testing.com/pr?query=is:pr+state:open+author:{{with
+        index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
+  default_decoration_configs:
+    "*":
+      gcs_configuration:
+        bucket: s3://aws-kubeflow-worker
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20210128-721ee668fd
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20210128-721ee668fd
+        initupload: gcr.io/k8s-prow/initupload:v20210128-721ee668fd
+        sidecar: gcr.io/k8s-prow/sidecar:v20210128-721ee668fd
+
+
+decorate_all_jobs: true
+periodics:
+- interval: 1m
+  agent: kubernetes
+  name: echo-test
+  spec:
+    containers:
+    - image: alpine
+      command: ["/bin/date"]


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Helps #848 

**Description of your changes:**
1. Create one EKS cluster (optional-test-infra-daily-worker), installed with Prow, only use for Periodic Job
2. Experiment with AWS role related to test-infra access, will set up periodic job to sync between upstream to AWS IAM

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
