### PR TITLE
Migrate KFServing to new test-infra

### DIFF
--- a/aws-images/daily-worker/Dockerfile
+++ b/aws-images/daily-worker/Dockerfile
@@ -1,0 +1,7 @@
+FROM amazon/aws-cli
+
+COPY ./update-iam-assume-role-policy.sh /usr/local/bin/
+
+RUN chmod a+x /usr/local/bin/*.sh
+
+ENTRYPOINT ["/usr/local/bin/update-iam-assume-role-policy.sh"]

--- a/aws-images/daily-worker/update-iam-assume-role-policy.sh
+++ b/aws-images/daily-worker/update-iam-assume-role-policy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This shell script is used to sync Assume-role Policy from upstream to AWS IAM
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Downloading Trust-policy.json"
+curl ${TRUST_POLICY} -o trust-policy.json
+echo "Update AWS IAM role ${ROLE_NAME} assume role policy"
+aws iam update-assume-role-policy --role-name ${ROLE_NAME} --policy-document file://trust-policy.json

--- a/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/config.yaml
@@ -119,21 +119,6 @@ data:
             value: v1.2-branch
 
     presubmits:
-
-      kubeflow/kfserving:
-      - name: kubeflow-kfserving-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
-        branches:
-        - master
-        decorate: false
-        labels:
-          preset-aws-cred: "true"
-        always_run: true
-        spec:
-          containers:
-          - image: 527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:v1.2-branch
-            imagePullPolicy: Always
-            command: ["/usr/local/bin/run_workflows.sh"]
-
       kubeflow/tf-operator:
       - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:

--- a/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/plugins.yaml
+++ b/aws/GitOps/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/plugins.yaml
@@ -7,8 +7,6 @@ data:
       join_org_url: "https://github.com/kubeflow/kubeflow/blob/master/CONTRIBUTING.md"
       only_org_members: true
     plugins:
-      kubeflow/kfserving:
-      - trigger
       kubeflow/tf-operator:
       - trigger
 kind: ConfigMap

--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -105,6 +105,20 @@ data:
             imagePullPolicy: Always
             command: ["/usr/local/bin/run_workflows.sh"]
 
+      kubeflow/kfserving:
+      - name: kubeflow-kfserving-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+        branches:
+        - master
+        decorate: false
+        labels:
+          preset-aws-cred: "true"
+        always_run: true
+        spec:
+          containers:
+          - image: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest
+            imagePullPolicy: Always
+            command: ["/usr/local/bin/run_workflows.sh"]
+
       kubeflow/manifests:
       - name: kubeflow-manifests-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:

--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
@@ -6,6 +6,8 @@ data:
       - trigger
       kubeflow/kfctl:
       - trigger
+      kubeflow/kfserving:
+      - trigger
       kubeflow/kubeflow:
       - trigger
       kubeflow/manifests:

--- a/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/config.yaml
@@ -116,21 +116,6 @@ periodics:
         value: v1.2-branch
 
 presubmits:
-
-  kubeflow/kfserving:
-  - name: kubeflow-kfserving-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
-    branches:
-    - master
-    decorate: false
-    labels:
-      preset-aws-cred: "true"
-    always_run: true
-    spec:
-      containers:
-      - image: 527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:v1.2-branch
-        imagePullPolicy: Always
-        command: ["/usr/local/bin/run_workflows.sh"]
-
   kubeflow/tf-operator:
   - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:

--- a/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/plugins.yaml
+++ b/aws/User/clusters/kubeflow-shared-test-infra-poc/namespaces/prow/configmap/plugins.yaml
@@ -4,7 +4,5 @@ triggers:
   join_org_url: "https://github.com/kubeflow/kubeflow/blob/master/CONTRIBUTING.md"
   only_org_members: true
 plugins:
-  kubeflow/kfserving:
-  - trigger
   kubeflow/tf-operator:
   - trigger

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -102,6 +102,20 @@ presubmits:
         imagePullPolicy: Always
         command: ["/usr/local/bin/run_workflows.sh"]
 
+  kubeflow/kfserving:
+  - name: kubeflow-kfserving-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+    branches:
+    - master
+    decorate: false
+    labels:
+      preset-aws-cred: "true"
+    always_run: true
+    spec:
+      containers:
+      - image: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest
+        imagePullPolicy: Always
+        command: ["/usr/local/bin/run_workflows.sh"]
+
   kubeflow/manifests:
   - name: kubeflow-manifests-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
@@ -3,6 +3,8 @@ plugins:
   - trigger
   kubeflow/kfctl:
   - trigger
+  kubeflow/kfserving:
+  - trigger
   kubeflow/kubeflow:
   - trigger
   kubeflow/manifests:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Helps #861 

**Description of your changes:**
Migrate kubeflow/kfserving repo to new test-infra

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
