### PR TITLE
Add kubeflow/kubeflow to prow's presubmits

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  config.yaml: |-
+  config.yaml: |
     prowjob_namespace: prow
     pod_namespace: test-pods
     in_repo_config:
@@ -107,6 +107,20 @@ data:
 
       kubeflow/kfserving:
       - name: kubeflow-kfserving-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+        branches:
+        - master
+        decorate: false
+        labels:
+          preset-aws-cred: "true"
+        always_run: true
+        spec:
+          containers:
+          - image: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest
+            imagePullPolicy: Always
+            command: ["/usr/local/bin/run_workflows.sh"]
+
+      kubeflow/kubeflow:
+      - name: kubeflow-kubeflow-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
         - master
         decorate: false

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -116,6 +116,20 @@ presubmits:
         imagePullPolicy: Always
         command: ["/usr/local/bin/run_workflows.sh"]
 
+  kubeflow/kubeflow:
+  - name: kubeflow-kubeflow-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+    branches:
+    - master
+    decorate: false
+    labels:
+      preset-aws-cred: "true"
+    always_run: true
+    spec:
+      containers:
+      - image: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest
+        imagePullPolicy: Always
+        command: ["/usr/local/bin/run_workflows.sh"]
+
   kubeflow/manifests:
   - name: kubeflow-manifests-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #897 

**Description of your changes:**
It adds a section in the AWS Prow's config for running presubmit jobs for `kubeflow/kubeflow`

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes have been generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
 
I wasn't actually able to run the proposed commands, since I don't have a Prow cluster set up.

/cc @PatrickXYS 
/assign @kimwnasptd 