### PR TITLE
update kaniko image to the official

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-tekton/namespaces/kubeflow-test-infra/kaniko.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-tekton/namespaces/kubeflow-test-infra/kaniko.yaml
@@ -29,8 +29,7 @@ spec:
     default: ""
   - name: BUILDER_IMAGE
     description: The image on which builds will run
-    # custom build while pending PRs awslabs/amazon-ecr-credential-helper#253, GoogleContainerTools/kaniko#1515 and #1543
-    default: docker.io/theofpa/executor@sha256:e968634a9c63f3a16c8ef331749115cb6cbcde4d1726c28e3e0b4e5eb79aa4aa
+    default: gcr.io/kaniko-project/executor:v1.5.0
   workspaces:
   - name: source
   - name: aws-credentials

--- a/aws/User/clusters/optional-test-infra-tekton/namespaces/kubeflow-test-infra/task/kaniko.yaml
+++ b/aws/User/clusters/optional-test-infra-tekton/namespaces/kubeflow-test-infra/task/kaniko.yaml
@@ -29,8 +29,7 @@ spec:
     default: ""
   - name: BUILDER_IMAGE
     description: The image on which builds will run
-    # custom build while pending PRs awslabs/amazon-ecr-credential-helper#253, GoogleContainerTools/kaniko#1515 and #1543
-    default: docker.io/theofpa/executor@sha256:e968634a9c63f3a16c8ef331749115cb6cbcde4d1726c28e3e0b4e5eb79aa4aa
+    default: gcr.io/kaniko-project/executor:v1.5.0
   workspaces:
   - name: source
   - name: aws-credentials


### PR DESCRIPTION
**Description of your changes:**

Update kaniko image to the latest official, `v1.5.0`

This closes a series of dependencies for us to have the official kaniko image with support for ecr-public and checkout from PR:
* awslabs/amazon-ecr-credential-helper#253 to get ecr-public support in credential-helper which is used by kaniko
* GoogleContainerTools/kaniko#1515 to get kaniko built with the new credential-helper
* GoogleContainerTools/kaniko#1543 to get kaniko support fetching a repo from the PR refspec

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
