### PR TITLE
changed from staging proxy to production proxy of proxy agent 

### DIFF
--- a/acm-repos/kfp-standalone-1/kfp-all.yaml
+++ b/acm-repos/kfp-standalone-1/kfp-all.yaml
@@ -2188,10 +2188,7 @@ spec:
         application-crd-id: kubeflow-pipelines
     spec:
       containers:
-      - env:
-        - name: PROXY_URL
-          value: https://datalab-staging.cloud.google.com/tun/m/4592f092208ecc84946b8f8f8016274df1b36a14
-        image: gcr.io/ml-pipeline/inverse-proxy-agent:1.1.1-beta.1
+      - image: gcr.io/ml-pipeline/inverse-proxy-agent:1.1.1-beta.1
         imagePullPolicy: IfNotPresent
         name: proxy-agent
       hostNetwork: true

--- a/test-infra/kfp/Makefile
+++ b/test-infra/kfp/Makefile
@@ -37,11 +37,11 @@ update-pkg-upstream: FORCE
 	cp -r $(REPO_ROOT)/gcp/packages/cluster-standard/upstream ./$(NAME)/
 	# Or use the following to fetch from remote
 	# kpt pkg get $(PACKAGE_UPSTEAM_URL) ./$(NAME)/upstream
-	$(MAKE) set-values
+	make set-values
 
 set-values: FORCE
 	kpt cfg set ./iam name "$(NAME)"
-	cd $(NAME) && $(MAKE) set-values
+	cd $(NAME) && make set-values
 
 apply-configsync: FORCE
 	kubectl apply -k $(NAME)/configsync

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/proxy-agent-patch.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/proxy-agent-patch.yaml
@@ -8,6 +8,7 @@ spec:
       containers:
       - name: proxy-agent
         # Use staging proxy endpoint for tests, so that we can discover problems earlier.
-        env:
-        - name: PROXY_URL
-          value: https://datalab-staging.cloud.google.com/tun/m/4592f092208ecc84946b8f8f8016274df1b36a14
+        # Uncomment the following to use staging proxy endpoint
+#        env:
+#        - name: PROXY_URL
+#          value: https://datalab-staging.cloud.google.com/tun/m/4592f092208ecc84946b8f8f8016274df1b36a14


### PR DESCRIPTION
changed from staging proxy to production proxy of proxy agent  to see whether it can temporarily fix https://github.com/kubeflow/pipelines/issues/5154.
Will change it back to staging proxy once the issues of staging proxy gets resolved.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
changed from staging proxy to production proxy of proxy agent 

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
