### PR TITLE
Remove environment variable logs

### DIFF
--- a/py/kubeflow/testing/util.py
+++ b/py/kubeflow/testing/util.py
@@ -54,7 +54,6 @@ def run(command,
     lines = []
     for k in keys:
       lines.append("{0}={1}".format(k, env[k]))
-    logging.info("Running: Environment:\n%s", "\n".join(lines))
 
   process = subprocess.Popen(
     command, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Disable environment variable logging to avoid security issue, has no effect in test-infra.

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
