### PR TITLE
Add Katib images to private ECR

### DIFF
--- a/aws/IaC/CDK/test-infra/config/static_config/ECR_Resources.py
+++ b/aws/IaC/CDK/test-infra/config/static_config/ECR_Resources.py
@@ -11,4 +11,30 @@ ECR_Private_Registry_List = {
     # "kfserving/agent": "cdk-poc/kfserving/agent",
     # "pytorch-operator": "cdk-poc/pytorch-operator",
     # "tf-operator": "cdk-poc/tf-operator",
+
+    # Katib images.
+    # Katib main components.
+    "katib-controller": "/katib/v1beta1/katib-controller",
+    "katib-db-manager": "/katib/v1beta1/katib-db-manager",
+    "katib-ui": "/katib/v1beta1/katib-ui",
+    "katib-cert-generator": "/katib/v1beta1/cert-generator",
+    # Katib Metric Collector list.
+    "katib-file-metrics-collector": "/katib/v1beta1/file-metrics-collector",
+    "katib-tfevent-metrics-collector": "/katib/v1beta1/tfevent-metrics-collector",
+    # Katib Suggestion list.
+    "katib-suggestion-hyperopt": "/katib/v1beta1/suggestion-hyperopt",
+    "katib-suggestion-chocolate": "/katib/v1beta1/suggestion-chocolate",
+    "katib-suggestion-skopt": "/katib/v1beta1/suggestion-skopt",
+    "katib-suggestion-hyperband": "/katib/v1beta1/suggestion-hyperband",
+    "katib-suggestion-goptuna": "/katib/v1beta1/suggestion-goptuna",
+    "katib-suggestion-enas": "/katib/v1beta1/suggestion-enas",
+    "katib-suggestion-darts": "/katib/v1beta1/suggestion-darts",
+    # Katib Early Stopping list.
+    "katib-earlystopping-medianstop": "/katib/v1beta1/earlystopping-medianstop",
+    # Katib Trial list.
+    "katib-trial-mxnet-mnist": "/katib/v1beta1/trial-mxnet-mnist",
+    "katib-trial-pytorch-mnist": "/katib/v1beta1/trial-pytorch-mnist",
+    "katib-trial-enas-cnn-cifar10-gpu": "/katib/v1beta1/trial-enas-cnn-cifar10-gpu",
+    "katib-trial-enas-cnn-cifar10-cpu": "/katib/v1beta1/trial-enas-cnn-cifar10-cpu",
+    "katib-trial-darts-cnn-cifar10": "/katib/v1beta1/trial-darts-cnn-cifar10",
 }


### PR DESCRIPTION
Related to: https://github.com/kubeflow/testing/issues/922.

I added list of Katib images to the `ECR_Private_Registry_List`.
We should delete current images in ECR for Katib and this script should re-create them.
We currently use this private ECR: `809251082950.dkr.ecr.us-west-2.amazonaws.com`.

/assign @PatrickXYS @gaocegege @johnugeorge 

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
