### PR TITLE
Migrate kubeflow/testing to optional-test-infra

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -162,6 +162,20 @@ data:
                 imagePullPolicy: Always
                 command: ["/usr/local/bin/run_workflows.sh"]
 
+      kubeflow/testing:
+      - name: kubeflow-testing-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+        branches:
+        - master
+        decorate: false
+        labels:
+          preset-aws-cred: "true"
+        always_run: true
+        spec:
+          containers:
+          - image: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest
+            imagePullPolicy: Always
+            command: ["/usr/local/bin/run_workflows.sh"]
+
       kubeflow/tf-operator:
       - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:

--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  plugins.yaml: |-
+  plugins.yaml: |
     plugins:
       kubeflow/katib:
       - trigger
@@ -17,6 +17,8 @@ data:
       kubeflow/tf-operator:
       - trigger
       kubeflow/xgboost-operator:
+      - trigger
+      kubeflow/testing:
       - trigger
 kind: ConfigMap
 metadata:

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -159,6 +159,20 @@ presubmits:
             imagePullPolicy: Always
             command: ["/usr/local/bin/run_workflows.sh"]
 
+  kubeflow/testing:
+  - name: kubeflow-testing-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+    branches:
+    - master
+    decorate: false
+    labels:
+      preset-aws-cred: "true"
+    always_run: true
+    spec:
+      containers:
+      - image: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest
+        imagePullPolicy: Always
+        command: ["/usr/local/bin/run_workflows.sh"]
+
   kubeflow/tf-operator:
   - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
@@ -15,3 +15,5 @@ plugins:
   - trigger
   kubeflow/xgboost-operator:
   - trigger
+  kubeflow/testing:
+  - trigger

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -1,20 +1,20 @@
 # This file configures the workflows to trigger in our Prow jobs.
 # see kubeflow/testing/py/run_e2e_workflow.py
-workflows:
+workflows: {}
   # Verifies the workflow is skipped because the test would fail since it
   # doesn't exist
-  - app_dir: kubeflow/kubeflow/testing/lmnop
-    component: click_deploy_test
-    name: skipmeplease
-    job_types:
-    - presubmit
-    include_dirs:
-    - xyz/*
-    params:
-      workflowName: skipmeplease
-  
-  - tekton_run: kubeflow/testing/tekton/runs/go-test-run.yaml  
-    name: go-unittests
+#  - app_dir: kubeflow/kubeflow/testing/lmnop
+#    component: click_deploy_test
+#    name: skipmeplease
+#    job_types:
+#    - presubmit
+#    include_dirs:
+#    - xyz/*
+#    params:
+#      workflowName: skipmeplease
+#
+#  - tekton_run: kubeflow/testing/tekton/runs/go-test-run.yaml
+#    name: go-unittests
 
   # - tekton_run: kubeflow/testing/tekton/runs/py-test-run.yaml
   #   name: py-unittests


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Help #919

**Description of your changes:**
Migrate kubeflow/testing to optional-test-infra. 

Let's do it step by step, first migrate to optional-test-infra, then check if functionality works fine.

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
