### PR TITLE
test(gcp): add storage object admin permission to kfp-standalone-1-vm GSA

### DIFF
--- a/acm-repos/kf-ci-management/namespaces/kfp-ci/iam.cnrm.cloud.google.com_v1beta1_iampolicymember_vm-cloud-storage-object-admin.yaml
+++ b/acm-repos/kf-ci-management/namespaces/kfp-ci/iam.cnrm.cloud.google.com_v1beta1_iampolicymember_vm-cloud-storage-object-admin.yaml
@@ -1,0 +1,15 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  labels:
+    app: kubeflow-pipelines
+    instance: kfp-standalone-1
+  name: vm-cloud-storage-object-admin
+  namespace: kfp-ci
+spec:
+  member: serviceAccount:kfp-standalone-1-vm@kfp-ci.iam.gserviceaccount.com
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    external: projects/kfp-ci
+    kind: Project
+  role: roles/storage.objectAdmin

--- a/test-infra/kfp/kfp-standalone-1/instance/iam.yaml
+++ b/test-infra/kfp/kfp-standalone-1/instance/iam.yaml
@@ -1,0 +1,14 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: vm-cloud-storage-object-admin
+spec:
+  member: serviceAccount:kfp-standalone-1-vm@kfp-ci.iam.gserviceaccount.com # {"$kpt-set":"vm-sa-ref"}
+  # This allows tests to:
+  # * get/put cloud storage objects
+  # * pull/push cloud container registry images
+  role: roles/storage.objectAdmin
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: projects/kfp-ci # {"$kpt-set":"project-ref"}

--- a/test-infra/kfp/kfp-standalone-1/instance/kustomization.yaml
+++ b/test-infra/kfp/kfp-standalone-1/instance/kustomization.yaml
@@ -6,6 +6,7 @@ commonLabels:
   instance: kfp-standalone-1 # {"$kpt-set":"name"}
 resources:
 - ../upstream
+- iam.yaml
 patchesStrategicMerge:
 - cluster-patch.yaml
 - nodepool-patch.yaml


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Prepare for permission needed in https://github.com/kubeflow/pipelines/pull/5337

**Description of your changes:**


**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
