### PR TITLE
test(gcp): expand kfp-ci oauth2 scope to cloud-platform

### DIFF
--- a/acm-repos/kf-ci-management/namespaces/kfp-ci/container.cnrm.cloud.google.com_v1beta1_containernodepool_kfp-standalone-1-nodepool-v2.yaml
+++ b/acm-repos/kf-ci-management/namespaces/kfp-ci/container.cnrm.cloud.google.com_v1beta1_containernodepool_kfp-standalone-1-nodepool-v2.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: kubeflow-pipelines
     instance: kfp-standalone-1
-  name: kfp-standalone-1-nodepool
+  name: kfp-standalone-1-nodepool-v2
   namespace: kfp-ci
 spec:
   autoscaling:
@@ -29,3 +29,5 @@ spec:
   nodeLocations:
   - us-central1-a
   - us-central1-b
+  oauthScopes:
+  - https://www.googleapis.com/auth/cloud-platform

--- a/test-infra/kfp/kfp-standalone-1/.krmignore
+++ b/test-infra/kfp/kfp-standalone-1/.krmignore
@@ -1,0 +1,1 @@
+kustomize/upstream

--- a/test-infra/kfp/kfp-standalone-1/Kptfile
+++ b/test-infra/kfp/kfp-standalone-1/Kptfile
@@ -26,14 +26,6 @@ openAPI:
           isSet: true
           name: name
           value: kfp-standalone-1
-    io.k8s.cli.substitutions.name-nodepool:
-      x-k8s-cli:
-        substitution:
-          name: name-nodepool
-          pattern: ${name}-nodepool
-          values:
-          - marker: ${name}
-            ref: '#/definitions/io.k8s.cli.setters.name'
     io.k8s.cli.substitutions.name-prefix:
       x-k8s-cli:
         substitution:
@@ -68,3 +60,9 @@ openAPI:
             ref: '#/definitions/io.k8s.cli.substitutions.name-sa'
           - marker: ${gcloud.core.project}
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+    io.k8s.cli.setters.name-nodepool:
+      x-k8s-cli:
+        setter:
+          name: name-nodepool
+          value: kfp-standalone-1-nodepool-v2
+          isSet: true

--- a/test-infra/kfp/kfp-standalone-1/configsync/config-management-operator.yaml
+++ b/test-infra/kfp/kfp-standalone-1/configsync/config-management-operator.yaml
@@ -243,9 +243,9 @@ metadata:
     k8s-app: config-management-operator
   name: config-management-operator
 rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
 ---
 # ----- k8s/operators/addons_rolebinding_rbac.yaml -----
 apiVersion: rbac.authorization.k8s.io/v1

--- a/test-infra/kfp/kfp-standalone-1/instance/nodepool-patch.yaml
+++ b/test-infra/kfp/kfp-standalone-1/instance/nodepool-patch.yaml
@@ -3,24 +3,27 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
-  name: kfp-standalone-1-nodepool # {"$kpt-set":"name-nodepool"}
+  name: kfp-standalone-1-nodepool-v2 # {"$kpt-set":"name-nodepool"}
 spec:
   location: us-central1
   nodeLocations: # We only need two nodes.
   - us-central1-a
   - us-central1-b
-  # Uncomment fields you care about to override.
-  # initialNodeCount: 1
-  # autoscaling:
-  #   minNodeCount: 1
-  #   maxNodeCount: 3
-  # nodeConfig:
-  #   diskSizeGb: 100
-  #   diskType: pd-standard
-  #   machineType: e2-standard-8
-  #   preemptible: false
-  #   metadata:
-  #     disable-legacy-endpoints: "true"
-  # management:
-  #   autoRepair: true
-  #   autoUpgrade: true
+  oauthScopes: # Allow entire cloud platform scope, use IAM to control access.
+  - https://www.googleapis.com/auth/cloud-platform
+
+# Uncomment fields you care about to override.
+# initialNodeCount: 1
+# autoscaling:
+#   minNodeCount: 1
+#   maxNodeCount: 3
+# nodeConfig:
+#   diskSizeGb: 100
+#   diskType: pd-standard
+#   machineType: e2-standard-8
+#   preemptible: false
+#   metadata:
+#     disable-legacy-endpoints: "true"
+# management:
+#   autoRepair: true
+#   autoUpgrade: true

--- a/test-infra/kfp/kfp-standalone-1/upstream/Kptfile
+++ b/test-infra/kfp/kfp-standalone-1/upstream/Kptfile
@@ -43,14 +43,6 @@ openAPI:
           values:
           - marker: ${gcloud.core.project}
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
-    io.k8s.cli.substitutions.name-nodepool:
-      x-k8s-cli:
-        substitution:
-          name: name-nodepool
-          pattern: ${name}-nodepool
-          values:
-          - marker: ${name}
-            ref: '#/definitions/io.k8s.cli.setters.name'
     io.k8s.cli.substitutions.vm-sa-ref:
       x-k8s-cli:
         substitution:
@@ -61,3 +53,9 @@ openAPI:
             ref: '#/definitions/io.k8s.cli.substitutions.name-sa'
           - marker: ${gcloud.core.project}
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+    io.k8s.cli.setters.name-nodepool:
+      x-k8s-cli:
+        setter:
+          name: name-nodepool
+          value: kfp-standalone-1-nodepool-v2
+          isSet: true

--- a/test-infra/kfp/kfp-standalone-1/upstream/cluster.yaml
+++ b/test-infra/kfp/kfp-standalone-1/upstream/cluster.yaml
@@ -15,7 +15,7 @@ spec:
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
-  name: kfp-standalone-1-nodepool # {"$kpt-set":"name-nodepool"}
+  name: kfp-standalone-1-nodepool-v2 # {"$kpt-set":"name-nodepool"}
 spec:
   location: us-central1
   initialNodeCount: 1


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/pipelines/pull/5337

**Description of your changes:**
Add oauth2 scope to a new nodepool and remove the existing one, because it's an immutable field.

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
