### PR TITLE
Allow test on Katib release-0.11 branch

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -80,6 +80,7 @@ data:
       - name: kubeflow-katib-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
         - master
+        - release-0.11
         decorate: false
         labels:
           preset-aws-cred: "true"

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -77,6 +77,7 @@ presubmits:
   - name: kubeflow-katib-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
     - master
+    - release-0.11
     decorate: false
     labels:
       preset-aws-cred: "true"


### PR DESCRIPTION
**Description of your changes:**
We should enable CI test on Katib 0.11 release branch.

/assign @PatrickXYS 
/cc @yanniszark @gaocegege @johnugeorge 

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
