### PR TITLE
Enable tf-operator tests in all-in-one-operator branch

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -182,6 +182,7 @@ data:
       - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
         - master
+        - all-in-one-operator
         decorate: false
         labels:
           preset-aws-cred: "true"
@@ -212,6 +213,7 @@ data:
       - name: kubeflow-tf-operator-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
         - master
+        - all-in-one-operator
         decorate: false
         labels:
           preset-aws-cred: "true"

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -179,6 +179,7 @@ presubmits:
   - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
     - master
+    - all-in-one-operator
     decorate: false
     labels:
       preset-aws-cred: "true"
@@ -209,6 +210,7 @@ postsubmits:
   - name: kubeflow-tf-operator-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
     - master
+    - all-in-one-operator
     decorate: false
     labels:
       preset-aws-cred: "true"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #https://github.com/kubeflow/tf-operator/issues/1291

**Description of your changes:**
Enable prow test for tf-operator `all-in-one-operator` branch

/assign @PatrickXYS @theofpa 
/cc @zw0610 

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
