### PR TITLE
Add tide config for Kserve

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -73,6 +73,22 @@ data:
       - name: ARTIFACTS_S3_BUCKET
         value: aws-kubeflow-jenkins
 
+    tide:
+      merge_method:
+        kserve/kserve: squash
+      queries:
+      - labels:
+        - lgtm
+        - approved
+        missingLabels:
+        - needs-rebase
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - do-not-merge/invalid-owners-file
+        orgs:
+        - kserve
+      target_url: # TODO: update tide link to https://$(prow-ingress)/tide
+
     decorate_all_jobs: true
 
     presubmits:

--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
@@ -10,6 +10,14 @@ data:
       - trigger
       kserve/kserve:
       - trigger
+      - approve
+      - assign
+      - blunderbuss
+      - hold
+      - label
+      - lgtm
+      - verify-owners
+      - wip
       kubeflow/kubeflow:
       - trigger
       kubeflow/manifests:

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -70,6 +70,22 @@ presets:
   - name: ARTIFACTS_S3_BUCKET
     value: aws-kubeflow-jenkins
 
+tide:
+  merge_method:
+    kserve/kserve: squash
+  queries:
+  - labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - needs-rebase
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - do-not-merge/invalid-owners-file
+    orgs:
+    - kserve
+  target_url: # TODO: update tide link to https://$(prow-ingress)/tide
+
 decorate_all_jobs: true
 
 presubmits:

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
@@ -7,6 +7,14 @@ plugins:
   - trigger
   kserve/kserve:
   - trigger
+  - approve
+  - assign
+  - blunderbuss
+  - hold
+  - label
+  - lgtm
+  - verify-owners
+  - wip
   kubeflow/kubeflow:
   - trigger
   kubeflow/manifests:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
This is the basic config to enable Tide for the Kserve repo. However, we probably need to deploy Tide on the AWS infra and update the `target_url` to the Tide endpoint in order to make it work.


**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
