### PR TITLE
Add universal training image to private ECR

### DIFF
--- a/aws/IaC/CDK/test-infra/config/static_config/ECR_Resources.py
+++ b/aws/IaC/CDK/test-infra/config/static_config/ECR_Resources.py
@@ -31,4 +31,6 @@ ECR_Private_Registry_List = {
     "katib-trial-enas-cnn-cifar10-gpu": "katib/v1beta1/trial-enas-cnn-cifar10-gpu",
     "katib-trial-enas-cnn-cifar10-cpu": "katib/v1beta1/trial-enas-cnn-cifar10-cpu",
     "katib-trial-darts-cnn-cifar10": "katib/v1beta1/trial-darts-cnn-cifar10",
+    # Training operator
+    "training-operator": "training-operator",
 }


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/tf-operator/issues/1326

**Description of your changes:**
Add universal training image to private ECR

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
