### PR TITLE
Add Optuna Suggestion to Katib ECR List

### DIFF
--- a/aws/IaC/CDK/test-infra/config/static_config/ECR_Resources.py
+++ b/aws/IaC/CDK/test-infra/config/static_config/ECR_Resources.py
@@ -21,6 +21,7 @@ ECR_Private_Registry_List = {
     "katib-suggestion-skopt": "katib/v1beta1/suggestion-skopt",
     "katib-suggestion-hyperband": "katib/v1beta1/suggestion-hyperband",
     "katib-suggestion-goptuna": "katib/v1beta1/suggestion-goptuna",
+    "katib-suggestion-optuna": "katib/v1beta1/suggestion-optuna",
     "katib-suggestion-enas": "katib/v1beta1/suggestion-enas",
     "katib-suggestion-darts": "katib/v1beta1/suggestion-darts",
     # Katib Early Stopping list.


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related: https://github.com/kubeflow/katib/pull/1613

**Description of your changes:**

We will use this image to test Optuna Suggestion on AWS cluster.
Do we need to manually run some scripts to add this image to ECR ?

/assign @PatrickXYS 

/cc @kubeflow/wg-automl-leads @g-votte @c-bata 

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
