### PR TITLE
Fix AssumeRole error by changing root to user

### DIFF
--- a/aws/Access/assume-role-access/infra-viewer/trust-policy.json
+++ b/aws/Access/assume-role-access/infra-viewer/trust-policy.json
@@ -6,7 +6,7 @@
       "Principal": {
         "AWS": "arn:aws:iam::068661676837:root",
         "AWS": "arn:aws:iam::678801486373:root",
-        "AWS": "arn:aws:iam::692867976397:root"
+        "AWS": "arn:aws:iam::692867976397:user/kubeflow-testing-infra"
       },
       "Action": "sts:AssumeRole",
       "Condition": {}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

```
aws sts get-caller-identity
{
    "Account": "692867976397",
    "UserId": "692867976397",
    "Arn": "arn:aws:iam::692867976397:root"
}
```


```
 aws sts assume-role --role-arn arn:aws:iam::809251082950:role/infra-viewer --role-session-name hehe

An error occurred (AccessDenied) when calling the AssumeRole operation: Roles may not be assumed by root accounts.
```

Seems root account is not allowed to assume roles?  https://stackoverflow.com/a/37334769


**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
