### PR TITLE
Kubeflow kubeflow 1.4 jobs

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -139,6 +139,7 @@ data:
         branches:
         - master
         - v1.3-branch
+        - v1.4-branch
         decorate: false
         labels:
           preset-aws-cred: "true"
@@ -213,6 +214,7 @@ data:
         branches:
         - master
         - v1.3-branch
+        - v1.4-branch
         decorate: false
         labels:
           preset-aws-cred: "true"

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -136,6 +136,7 @@ presubmits:
     branches:
     - master
     - v1.3-branch
+    - v1.4-branch
     decorate: false
     labels:
       preset-aws-cred: "true"
@@ -210,6 +211,7 @@ postsubmits:
     branches:
     - master
     - v1.3-branch
+    - v1.4-branch
     decorate: false
     labels:
       preset-aws-cred: "true"


### PR DESCRIPTION
Extends the prow cluster to also run the jobs on the 1.4 branch of kubeflow/kubeflow

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`

/cc @PatrickXYS 