### PR TITLE
Enable training-operator tests in v1.3-branch 

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -198,7 +198,6 @@ data:
       - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
         - master
-        - all-in-one-operator
         - v1.2-branch
         - v1.3-branch
         decorate: false
@@ -232,7 +231,6 @@ data:
       - name: kubeflow-tf-operator-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
         - master
-        - all-in-one-operator
         - v1.2-branch
         - v1.3-branch
         decorate: false

--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -200,6 +200,7 @@ data:
         - master
         - all-in-one-operator
         - v1.2-branch
+        - v1.3-branch
         decorate: false
         labels:
           preset-aws-cred: "true"
@@ -233,6 +234,7 @@ data:
         - master
         - all-in-one-operator
         - v1.2-branch
+        - v1.3-branch
         decorate: false
         labels:
           preset-aws-cred: "true"

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -197,6 +197,7 @@ presubmits:
     - master
     - all-in-one-operator
     - v1.2-branch
+    - v1.3-branch
     decorate: false
     labels:
       preset-aws-cred: "true"
@@ -230,6 +231,7 @@ postsubmits:
     - master
     - all-in-one-operator
     - v1.2-branch
+    - v1.3-branch
     decorate: false
     labels:
       preset-aws-cred: "true"

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -195,7 +195,6 @@ presubmits:
   - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
     - master
-    - all-in-one-operator
     - v1.2-branch
     - v1.3-branch
     decorate: false
@@ -229,7 +228,6 @@ postsubmits:
   - name: kubeflow-tf-operator-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
     - master
-    - all-in-one-operator
     - v1.2-branch
     - v1.3-branch
     decorate: false


### PR DESCRIPTION
adding testing for new release branch v1.3-branch
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
