### PR TITLE
Swap TF with Training Operator

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -194,8 +194,8 @@ data:
             imagePullPolicy: Always
             command: ["/usr/local/bin/run_workflows.sh"]
 
-      kubeflow/tf-operator:
-      - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+      kubeflow/training-operator:
+      - name: kubeflow-training-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
         - master
         - v1.2-branch
@@ -227,8 +227,8 @@ data:
             imagePullPolicy: Always
             command: ["/usr/local/bin/run_workflows.sh"]
 
-      kubeflow/tf-operator:
-      - name: kubeflow-tf-operator-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+      kubeflow/training-operator:
+      - name: kubeflow-training-operator-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
         - master
         - v1.2-branch

--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/plugins.yaml
@@ -16,7 +16,7 @@ data:
       - trigger
       kubeflow/pytorch-operator:
       - trigger
-      kubeflow/tf-operator:
+      kubeflow/training-operator:
       - trigger
       kubeflow/xgboost-operator:
       - trigger

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -191,8 +191,8 @@ presubmits:
         imagePullPolicy: Always
         command: ["/usr/local/bin/run_workflows.sh"]
 
-  kubeflow/tf-operator:
-  - name: kubeflow-tf-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+  kubeflow/training-operator:
+  - name: kubeflow-training-operator-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
     - master
     - v1.2-branch
@@ -224,8 +224,8 @@ postsubmits:
         imagePullPolicy: Always
         command: ["/usr/local/bin/run_workflows.sh"]
 
-  kubeflow/tf-operator:
-  - name: kubeflow-tf-operator-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
+  kubeflow/training-operator:
+  - name: kubeflow-training-operator-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
     - master
     - v1.2-branch

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/plugins.yaml
@@ -13,7 +13,7 @@ plugins:
   - trigger
   kubeflow/pytorch-operator:
   - trigger
-  kubeflow/tf-operator:
+  kubeflow/training-operator:
   - trigger
   kubeflow/xgboost-operator:
   - trigger


### PR DESCRIPTION
Recently we renamed `tf-operator` to `training-operator`: https://github.com/kubeflow/training-operator/issues/1348.
We should make the appropriate changes in the prow settings.

/assign @kubeflow/wg-training-leads 

@PatrickXYS Do you know, does prow cluster automatically carry the new changes ?

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
