### PR TITLE
Add tf-mnist-with-summaries in katib ECR list

### DIFF
--- a/aws/IaC/CDK/test-infra/config/static_config/ECR_Resources.py
+++ b/aws/IaC/CDK/test-infra/config/static_config/ECR_Resources.py
@@ -29,6 +29,7 @@ ECR_Private_Registry_List = {
     # Katib Trial list.
     "katib-trial-mxnet-mnist": "katib/v1beta1/trial-mxnet-mnist",
     "katib-trial-pytorch-mnist": "katib/v1beta1/trial-pytorch-mnist",
+    "katib-trial-tf-mnist-with-summaries": "katib/v1beta1/trial-tf-mnist-with-summaries",
     "katib-trial-enas-cnn-cifar10-gpu": "katib/v1beta1/trial-enas-cnn-cifar10-gpu",
     "katib-trial-enas-cnn-cifar10-cpu": "katib/v1beta1/trial-enas-cnn-cifar10-cpu",
     "katib-trial-darts-cnn-cifar10": "katib/v1beta1/trial-darts-cnn-cifar10",


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related: https://github.com/kubeflow/katib/pull/1731

**Description of your changes:**
We will use tf-mnist-with-summaries to test tfevent-metrics-collctor on EKS.

/assign @theofpa 
/cc @kubeflow/wg-automl-leads

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
