### PR TITLE
Upgrade go version to 1.17.3

### DIFF
--- a/images/Dockerfile.py3.aws
+++ b/images/Dockerfile.py3.aws
@@ -30,7 +30,7 @@ RUN python3.8 -m pip install \
 
 # Install go
 RUN cd /tmp && \
-    wget -O /tmp/go.tar.gz https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz && \
+    wget -O /tmp/go.tar.gz https://dl.google.com/go/go1.17.3.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz
 
 # Install the hub CLI for git


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Looks most of kubeflow projects like `training-operator`, `katib` and `kserve` have migrated to go 1.17.3, so make sense to update in e2e testing worker image as well.

With go 1.14 we are getting errors like following:
```
/root/go/pkg/mod/k8s.io/client-go@v0.22.3/plugin/pkg/client/auth/exec/metrics.go:21:2: package io/fs is not in GOROOT (/usr/local/go/src/io/fs)
```

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
