### PR TITLE
Allow test on Katib release branches

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -82,6 +82,7 @@ data:
         - master
         - release-0.11
         - release-0.12
+        - release-0.13
         decorate: false
         labels:
           preset-aws-cred: "true"

--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -79,10 +79,7 @@ data:
       kubeflow/katib:
       - name: kubeflow-katib-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
-        - master
-        - release-0.11
-        - release-0.12
-        - release-0.13
+        - ^master|release-.+$
         decorate: false
         labels:
           preset-aws-cred: "true"

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -76,10 +76,7 @@ presubmits:
   kubeflow/katib:
   - name: kubeflow-katib-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
-    - master
-    - release-0.11
-    - release-0.12
-    - release-0.13
+    - ^master|release-.+$
     decorate: false
     labels:
       preset-aws-cred: "true"

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -79,6 +79,7 @@ presubmits:
     - master
     - release-0.11
     - release-0.12
+    - release-0.13
     decorate: false
     labels:
       preset-aws-cred: "true"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related: https://github.com/kubeflow/katib/issues/1774.

**Description of your changes:**
This PR allows tests on Katib release-0.13 branch

/assign @capri-xiyue @zijianjoy
/cc @gaocegege @johnugeorge

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
