### PR TITLE
Update the testing branches for kubeflow and manifests

### DIFF
--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -136,9 +136,7 @@ data:
       kubeflow/kubeflow:
       - name: kubeflow-kubeflow-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
-        - master
-        - v1.3-branch
-        - v1.4-branch
+        - ^master|v.+$
         decorate: false
         labels:
           preset-aws-cred: "true"
@@ -152,8 +150,7 @@ data:
       kubeflow/manifests:
       - name: kubeflow-manifests-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
-        - master
-        - v1.2-branch
+        - ^master|v.+$
         decorate: false
         labels:
           preset-aws-cred: "true"
@@ -212,9 +209,7 @@ data:
       kubeflow/kubeflow:
       - name: kubeflow-kubeflow-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
-        - master
-        - v1.3-branch
-        - v1.4-branch
+        - ^master|v.+$
         decorate: false
         labels:
           preset-aws-cred: "true"

--- a/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
+++ b/aws/GitOps/clusters/optional-test-infra-prow/namespaces/prow/config.yaml
@@ -136,7 +136,7 @@ data:
       kubeflow/kubeflow:
       - name: kubeflow-kubeflow-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
-        - ^master|v.+$
+        ^master|v.+-branch$
         decorate: false
         labels:
           preset-aws-cred: "true"
@@ -150,7 +150,7 @@ data:
       kubeflow/manifests:
       - name: kubeflow-manifests-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
-        - ^master|v.+$
+        ^master|v.+-branch$
         decorate: false
         labels:
           preset-aws-cred: "true"
@@ -209,7 +209,7 @@ data:
       kubeflow/kubeflow:
       - name: kubeflow-kubeflow-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
         branches:
-        - ^master|v.+$
+        ^master|v.+-branch$
         decorate: false
         labels:
           preset-aws-cred: "true"

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -133,7 +133,7 @@ presubmits:
   kubeflow/kubeflow:
   - name: kubeflow-kubeflow-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
-    - ^master|v.+$
+    ^master|v.+-branch$
     decorate: false
     labels:
       preset-aws-cred: "true"
@@ -147,7 +147,7 @@ presubmits:
   kubeflow/manifests:
   - name: kubeflow-manifests-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
-    - ^master|v.+$
+    ^master|v.+-branch$
     decorate: false
     labels:
       preset-aws-cred: "true"
@@ -206,7 +206,7 @@ postsubmits:
   kubeflow/kubeflow:
   - name: kubeflow-kubeflow-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
-    - ^master|v.+$
+    ^master|v.+-branch$
     decorate: false
     labels:
       preset-aws-cred: "true"

--- a/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
+++ b/aws/User/clusters/optional-test-infra-prow/namespaces/prow/configmap/config.yaml
@@ -133,9 +133,7 @@ presubmits:
   kubeflow/kubeflow:
   - name: kubeflow-kubeflow-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
-    - master
-    - v1.3-branch
-    - v1.4-branch
+    - ^master|v.+$
     decorate: false
     labels:
       preset-aws-cred: "true"
@@ -149,8 +147,7 @@ presubmits:
   kubeflow/manifests:
   - name: kubeflow-manifests-presubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
-    - master
-    - v1.2-branch
+    - ^master|v.+$
     decorate: false
     labels:
       preset-aws-cred: "true"
@@ -209,9 +206,7 @@ postsubmits:
   kubeflow/kubeflow:
   - name: kubeflow-kubeflow-postsubmit  # convention: (job type)-(repo name)-(suite name)-(test type)
     branches:
-    - master
-    - v1.3-branch
-    - v1.4-branch
+    - ^master|v.+$
     decorate: false
     labels:
       preset-aws-cred: "true"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Refs https://github.com/kubeflow/manifests/issues/2109 

**Description of your changes:**
Updated prow to run the jobs on all release branches. Inspired by https://github.com/kubeflow/testing/pull/978, but since we use `v1.5-branch` naming I think that the regex might not be as specific as for Katib. But it's a start.

/assign @zijianjoy 

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [x] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
