### PR TITLE
pipelines: Increase default memroy limit for Mysql instance

### DIFF
--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/limit-range.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/limit-range.yaml
@@ -9,7 +9,7 @@ spec:
   # The values are empirical.
   limits:
   - default:
-      memory: 0.5Gi
+      memory: 1Gi # Default limit is set to 1Gi because mysql request 800Mi.
       cpu: '1'
     defaultRequest:
       cpu: '0.5'


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

This is because the 1.8.0-rc.0 introduced the memory request for mysql instance: https://github.com/kubeflow/testing/blob/8644d09d122105eb6835fcab7b0ea29f6a84b3a4/test-infra/kfp/kfp-standalone-1/kustomize/upstream/third-party/mysql/base/mysql-deployment.yaml#L40. But there is no default limit, which falls back to the LimitRange file in this PR.


**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
