### PR TITLE
kfp: Set memory limit only for mysql

### DIFF
--- a/acm-repos/kfp-standalone-1/kfp-all.yaml
+++ b/acm-repos/kfp-standalone-1/kfp-all.yaml
@@ -2914,6 +2914,8 @@ spec:
         - containerPort: 3306
           name: mysql
         resources:
+          limits:
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 800Mi

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
@@ -31,6 +31,7 @@ namespace: kubeflow
 patchesStrategicMerge:
 - proxy-agent-patch.yaml
 - workflow-controller-configmap-patch.yaml
+- mysql-patch.yaml
 
 #### Customization ###
 # 1. Change values in params.env file

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/mysql-patch.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/mysql-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  template:
+    spec:
+      containers:
+      - name: mysql
+        resources:
+          limits:
+            memory: 1Gi


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

Based on discussion in https://github.com/kubeflow/testing/pull/980, I am applying memory limit only to mysql.

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
