### PR TITLE
KFP: Remove status from kfp-standalone-1 manifest

### DIFF
--- a/acm-repos/kfp-standalone-1/kfp-all.yaml
+++ b/acm-repos/kfp-standalone-1/kfp-all.yaml
@@ -11,7 +11,6 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/application/pull/2
     controller-gen.kubebuilder.io/version: v0.4.0
-  creationTimestamp: null
   labels:
     application-crd-id: kubeflow-pipelines
     controller-tools.k8s.io: "1.0"
@@ -531,12 +530,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
@@ -31,6 +31,7 @@ namespace: kubeflow
 patchesStrategicMerge:
 - proxy-agent-patch.yaml
 - workflow-controller-configmap-patch.yaml
+- status-deletion.yaml
 
 #### Customization ###
 # 1. Change values in params.env file

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/status-deletion.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/status-deletion.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.app.k8s.io
+status:
+  $patch: delete


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
After running `nomos status`, I got this result:

```

*gke_kfp-ci_us-central1_kfp-standalone-1
  --------------------
  <root>   https://github.com/kubeflow/testing.git/acm-repos/kfp-standalone-1@master
  ERROR    de705d1a
  Error:   KNV1045: Configs with "status" specified are not allowed. To fix, either remove the config or remove the "status" field in the config:

source: /repo/root/rev-ad4d250e41daf07bfcf28eee86e0b7bee46a10d2/acm-repos/kfp-standalone-1/kfp-all.yaml
metadata.name: applications.app.k8s.io
group: apiextensions.k8s.io
version:
kind: CustomResourceDefinition

For more information, see https://g.co/cloud/acm-errors#knv1045
```

We should unblock the configsync issue by removing the status field.

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
