### PR TITLE
chore(kfp): update instructions for updating kfp deployment in the test cluster.

### DIFF
--- a/test-infra/kfp/README.md
+++ b/test-infra/kfp/README.md
@@ -2,6 +2,14 @@
 
 ## Upgrade KFP
 
+1. (Optionally) Run:
+
+    ```bash
+    make hydrate-kfp-manifests
+    ```
+    
+    To check the generated raw k8s resources in acm-repos folder based on local changes (without pulling manifests from kfp repo). 
+
 1. Edit `PIPELINES_VERSION=<new-version>` in Makefile.
 
 1. Run:

--- a/test-infra/kfp/README.md
+++ b/test-infra/kfp/README.md
@@ -10,12 +10,6 @@
     make kfp-update
     ```
 
-1. Run:
-
-    ```bash
-    make hydrate-kfp-manifests
-    ```
-
     It generates raw k8s resources in acm-repos folder which is source of truth for the cluster via gitops.
 
 1. Commit the changes and send a PR.


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
`hydrate-kfp-manifests` is already covered by `kfp-update`, so no need to run that separately again.

https://github.com/kubeflow/testing/blob/5a610d067789d63eb5771884946387702d497e57/test-infra/kfp/Makefile#L54

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
