### PR TITLE
chore: rm obsolete OWNERS

### DIFF
--- a/images/OWNERS
+++ b/images/OWNERS
@@ -1,3 +1,0 @@
-approvers:
-- bobgy
-- PatrickXYS

--- a/py/kubeflow/OWNERS
+++ b/py/kubeflow/OWNERS
@@ -1,3 +1,0 @@
-approvers:
-- bobgy
-- jlewi

--- a/py/kubeflow/testing/OWNERS
+++ b/py/kubeflow/testing/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- bobgy
-- jlewi
-- PatrickXYS


### PR DESCRIPTION
**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
