### PR TITLE
kfp: increase memory limit for workflow-controller

### DIFF
--- a/acm-repos/kfp-standalone-1/kfp-all.yaml
+++ b/acm-repos/kfp-standalone-1/kfp-all.yaml
@@ -2955,6 +2955,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app: workflow-controller
     application-crd-id: kubeflow-pipelines
   name: workflow-controller
   namespace: kubeflow
@@ -2999,6 +3000,8 @@ spec:
           name: metrics
         - containerPort: 6060
         resources:
+          limits:
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 500Mi

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
@@ -33,6 +33,7 @@ patchesStrategicMerge:
 - workflow-controller-configmap-patch.yaml
 - status-deletion.yaml
 - mysql-patch.yaml
+- workflow-controller-patch.yaml
 
 #### Customization ###
 # 1. Change values in params.env file

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/workflow-controller-patch.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/workflow-controller-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflow-controller
+  labels:
+    app: workflow-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: workflow-controller
+        resources:
+          limits:
+            memory: 1Gi


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
workflow-controller pod often gets OOMKilled when there were lots of test runs.

**Description of your changes:**
Increase memory limit for workflow-controller from 0.5G to 1G.

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
