### PR TITLE
kfp: increase memory limit for metadata-grpc-deployment

### DIFF
--- a/acm-repos/kfp-standalone-1/kfp-all.yaml
+++ b/acm-repos/kfp-standalone-1/kfp-all.yaml
@@ -2418,6 +2418,9 @@ spec:
           tcpSocket:
             port: grpc-api
           timeoutSeconds: 2
+        resources:
+          limits:
+            memory: 1Gi
       serviceAccountName: metadata-grpc-server
 ---
 apiVersion: apps/v1

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
@@ -34,6 +34,7 @@ patchesStrategicMerge:
 - status-deletion.yaml
 - mysql-patch.yaml
 - workflow-controller-patch.yaml
+- metadata-grpc-deployment-patch.yaml
 
 #### Customization ###
 # 1. Change values in params.env file

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/metadata-grpc-deployment-patch.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/metadata-grpc-deployment-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metadata-grpc-deployment
+  labels:
+    component: metadata-grpc-server
+spec:
+  template:
+    spec:
+      containers:
+      - name: container
+        resources:
+          limits:
+            memory: 1Gi


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
The pod restarted a lot due to OOMKilled:
```
    State:          Running
      Started:      Tue, 05 Apr 2022 07:01:02 +0000
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Tue, 05 Apr 2022 06:56:15 +0000
      Finished:     Tue, 05 Apr 2022 07:00:44 +0000
    Ready:          True
    Restart Count:  14
    Limits:
      cpu:     1
      memory:  512Mi
    Requests:
      cpu:      500m
      memory:   512Mi
    Liveness:   tcp-socket :grpc-api delay=3s timeout=2s period=5s #success=1 #failure=3
    Readiness:  tcp-socket :grpc-api delay=3s timeout=2s period=5s #success=1 #failure=3
```
**Description of your changes:**


**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
