### PR TITLE
update eks kubernetes version to 1.19

### DIFF
--- a/images/aws-scripts/create-eks-cluster.sh
+++ b/images/aws-scripts/create-eks-cluster.sh
@@ -26,6 +26,6 @@ EKS_CLUSTER_NAME="${CLUSTER_NAME}"
 # TODO (PatrickXYS): Need to determine which NG template we need
 eksctl create cluster \
 --name $EKS_CLUSTER_NAME \
---version ${EKS_CLUSTER_VERSION:-"1.18"} \
+--version ${EKS_CLUSTER_VERSION:-"1.19"} \
 --region ${AWS_REGION:-"us-west-2"} \
 --managed


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
training-operator e2e test fails as cluster setup error: https://github.com/kubeflow/training-operator/pull/1575

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
