### PR TITLE
kfp: Reduce persistent agent TTL_SECONDS_AFTER_WORKFLOW_FINISH to 8 hours

### DIFF
--- a/acm-repos/kfp-standalone-1/kfp-all.yaml
+++ b/acm-repos/kfp-standalone-1/kfp-all.yaml
@@ -3118,12 +3118,12 @@ spec:
     spec:
       containers:
       - env:
+        - name: TTL_SECONDS_AFTER_WORKFLOW_FINISH
+          value: "28800"
         - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: TTL_SECONDS_AFTER_WORKFLOW_FINISH
-          value: "86400"
         - name: NUM_WORKERS
           value: "2"
         image: gcr.io/ml-pipeline/persistenceagent:2.0.0-alpha.3

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
@@ -35,6 +35,7 @@ patchesStrategicMerge:
 - mysql-patch.yaml
 - workflow-controller-patch.yaml
 - metadata-grpc-deployment-patch.yaml
+- persistent-agent-deployment-patch.yaml
 
 #### Customization ###
 # 1. Change values in params.env file

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/persistent-agent-deployment-patch.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/persistent-agent-deployment-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-persistenceagent
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-persistenceagent
+        env:
+        - name: TTL_SECONDS_AFTER_WORKFLOW_FINISH
+          value: "28800"


### PR DESCRIPTION
Reduce persistent agent TTL_SECONDS_AFTER_WORKFLOW_FINISH from 24 hours to 8 hours.

`kubeflow-pipelines-samples-v2` are often flaky and deleting completed pods--usually a lot--seems to reduce the flakiness. We can probably reduce the default TTL to 8 hours as I expect most test debugging should happen within such time window.