### PR TITLE
kfp: Increase memory limits for metadata writer to 1Gi

### DIFF
--- a/acm-repos/kfp-standalone-1/kfp-all.yaml
+++ b/acm-repos/kfp-standalone-1/kfp-all.yaml
@@ -2917,6 +2917,9 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/ml-pipeline/metadata-writer:2.0.0-alpha.4
         name: main
+        resources:
+          limits:
+            memory: 1Gi
       serviceAccountName: kubeflow-pipelines-metadata-writer
 ---
 apiVersion: apps/v1

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/kustomization.yaml
@@ -36,6 +36,7 @@ patchesStrategicMerge:
 - workflow-controller-patch.yaml
 - metadata-grpc-deployment-patch.yaml
 - persistent-agent-deployment-patch.yaml
+- metadata-writer-patch.yaml
 
 #### Customization ###
 # 1. Change values in params.env file

--- a/test-infra/kfp/kfp-standalone-1/kustomize/instance/metadata-writer-patch.yaml
+++ b/test-infra/kfp/kfp-standalone-1/kustomize/instance/metadata-writer-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metadata-writer
+spec:
+  template:
+    spec:
+      containers:
+      - name: main
+        resources:
+          limits:
+            memory: 1Gi


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
Metadata-writer was in a crash-loop due to OOMKIlled.
```
Name:             metadata-writer-546cc4bbb4-fl2ww
Namespace:        kubeflow
Priority:         0
Service Account:  kubeflow-pipelines-metadata-writer
Node:             gke-kfp-standalone-1-kfp-standalone-1-60baa0a0-bg42/10.128.0.45
Start Time:       Thu, 01 Sep 2022 22:16:32 +0000
Labels:           app=metadata-writer
                  application-crd-id=kubeflow-pipelines
                  pod-template-hash=546cc4bbb4
Annotations:      kubectl.kubernetes.io/restartedAt: 2022-07-06T13:40:37-06:00
                  kubernetes.io/limit-ranger: LimitRanger plugin set: cpu, memory request for container main; cpu, memory limit for container main
Status:           Running
IP:               10.44.33.228
IPs:
  IP:           10.44.33.228
Controlled By:  ReplicaSet/metadata-writer-546cc4bbb4
Containers:
  main:
    Container ID:   docker://232cf30bed0894dc79e3ca04abafeb518430ae2541ec405ced3ccfeaa0c6a132
    Image:          gcr.io/ml-pipeline/metadata-writer:2.0.0-alpha.4
    Image ID:       docker-pullable://gcr.io/ml-pipeline/metadata-writer@sha256:2fe55a9df6d562188bd9fdf6f2de666767f24fd5f126361d699010b650f4f636
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Tue, 06 Sep 2022 16:38:00 +0000
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Tue, 06 Sep 2022 16:32:57 +0000
      Finished:     Tue, 06 Sep 2022 16:36:35 +0000
    Ready:          True
    Restart Count:  82
    Limits:
      cpu:     1
      memory:  512Mi
```
**Description of your changes:**


**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
