### PR TITLE
feat: add reusable verify-boilerplate composite action

### DIFF
--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -57,7 +57,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -14,9 +14,16 @@
 
 name: Verify Boilerplate Headers
 description: >
-  Verify that every source file carries the required Apache 2.0 copyright
-  header. Wraps hack/boilerplate/boilerplate.py from kubeflow/testing so
-  callers never need to vendor the script.
+  Verify Apache 2.0 copyright headers across a repository. Every source file
+  must match the boilerplate template once the copyright year is normalized
+  out; files added relative to the base branch must additionally use the
+  year-less header. Runs hack/boilerplate/boilerplate.py from the checkout of
+  kubeflow/testing that GitHub creates for this action, so the script version
+  always matches the reference the action is pinned to and callers never
+  vendor a copy.
+
+  The caller must check out its own repository before this action runs, using
+  fetch-depth: 0 so the base branch can be resolved.
 
 inputs:
   base-ref:

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -41,12 +41,12 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Checkout kubeflow/testing
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@v4
       with:
         repository: kubeflow/testing
         path: .kubeflow-testing

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -42,7 +42,7 @@ inputs:
     required: false
     default: ""
   python-version:
-    description: Python version to use.
+    description: Python version used to run the checker.
     required: false
     default: "3.12"
 

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -35,10 +35,17 @@ inputs:
       added files; all files are checked for header match regardless.
     required: false
     default: ""
-  boilerplate-dir:
+  boilerplate-directory:
     description: >
-      Directory containing boilerplate template files (boilerplate.*.txt).
-      Leave empty to use the templates shipped with kubeflow/testing.
+      Directory containing the boilerplate template files (boilerplate.*.txt).
+      Leave empty to use the templates shipped alongside the script in
+      kubeflow/testing.
+    required: false
+    default: ""
+  root-directory:
+    description: >
+      Directory to scan. Leave empty to use the workspace root. Set this when
+      the caller checks its repository out into a subdirectory.
     required: false
     default: ""
   python-version:

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -26,11 +26,13 @@ description: >
   fetch-depth: 0 so the base branch can be resolved.
 
 inputs:
-  base-ref:
+  base-reference:
     description: >
-      Base branch for new-file detection. Defaults to the pull-request base
-      branch (github.base_ref) so only changed/new files are flagged for
-      year-less header enforcement.
+      Base branch used for new-file detection. Defaults to the pull-request
+      base branch, then to the repository default branch, so the action works
+      on both pull_request and push events without per-repository
+      configuration. Note that this governs only the year-less rule for newly
+      added files; all files are checked for header match regardless.
     required: false
     default: ""
   boilerplate-dir:

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -45,13 +45,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Checkout kubeflow/testing
-      uses: actions/checkout@v4
-      with:
-        repository: kubeflow/testing
-        path: .kubeflow-testing
-        sparse-checkout: hack/boilerplate
-
     - name: Run boilerplate check
       shell: bash
       env:

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -1,0 +1,74 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Verify Boilerplate Headers
+description: >
+  Verify that every source file carries the required Apache 2.0 copyright
+  header. Wraps hack/boilerplate/boilerplate.py from kubeflow/testing so
+  callers never need to vendor the script.
+
+inputs:
+  base-ref:
+    description: >
+      Base branch for new-file detection. Defaults to the pull-request base
+      branch (github.base_ref) so only changed/new files are flagged for
+      year-less header enforcement.
+    required: false
+    default: ""
+  boilerplate-dir:
+    description: >
+      Directory containing boilerplate template files (boilerplate.*.txt).
+      Leave empty to use the templates shipped with kubeflow/testing.
+    required: false
+    default: ""
+  python-version:
+    description: Python version to use.
+    required: false
+    default: "3.12"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Checkout kubeflow/testing
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: kubeflow/testing
+        path: .kubeflow-testing
+        sparse-checkout: hack/boilerplate
+
+    - name: Run boilerplate check
+      shell: bash
+      env:
+        BASE_REF: ${{ inputs.base-ref || github.base_ref || 'master' }}
+        BOILERPLATE_DIR: ${{ inputs.boilerplate-dir }}
+      run: |
+        ARGS=("--base-ref" "${BASE_REF}")
+
+        if [[ -n "${BOILERPLATE_DIR}" ]]; then
+          ARGS+=("--boilerplate-dir" "${BOILERPLATE_DIR}")
+        else
+          ARGS+=("--boilerplate-dir" ".kubeflow-testing/hack/boilerplate")
+        fi
+
+        python .kubeflow-testing/hack/boilerplate/boilerplate.py "${ARGS[@]}"
+
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: rm -rf .kubeflow-testing

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -59,7 +59,3 @@ runs:
 
         python "${GITHUB_ACTION_PATH}/../../../hack/boilerplate/boilerplate.py" "${ARGS[@]}"
 
-    - name: Cleanup
-      if: always()
-      shell: bash
-      run: rm -rf .kubeflow-testing

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -55,18 +55,16 @@ runs:
     - name: Run boilerplate check
       shell: bash
       env:
-        BASE_REF: ${{ inputs.base-ref || github.base_ref || 'master' }}
+        BASE_REF: ${{ inputs.base-ref || github.base_ref || github.event.repository.default_branch || 'master' }}
         BOILERPLATE_DIR: ${{ inputs.boilerplate-dir }}
       run: |
         ARGS=("--base-ref" "${BASE_REF}")
 
         if [[ -n "${BOILERPLATE_DIR}" ]]; then
           ARGS+=("--boilerplate-dir" "${BOILERPLATE_DIR}")
-        else
-          ARGS+=("--boilerplate-dir" ".kubeflow-testing/hack/boilerplate")
         fi
 
-        python .kubeflow-testing/hack/boilerplate/boilerplate.py "${ARGS[@]}"
+        python "${GITHUB_ACTION_PATH}/../../../hack/boilerplate/boilerplate.py" "${ARGS[@]}"
 
     - name: Cleanup
       if: always()

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -64,8 +64,12 @@ runs:
     - name: Run boilerplate check
       shell: bash
       env:
-        BASE_REF: ${{ inputs.base-ref || github.base_ref || github.event.repository.default_branch || 'master' }}
-        BOILERPLATE_DIR: ${{ inputs.boilerplate-dir }}
+        BASE_REFERENCE: >-
+          ${{ inputs.base-reference
+              || github.event.pull_request.base.ref
+              || github.event.repository.default_branch }}
+        BOILERPLATE_DIRECTORY: ${{ inputs.boilerplate-directory }}
+        ROOT_DIRECTORY: ${{ inputs.root-directory }}
       run: |
         set -euo pipefail
 

--- a/.github/actions/verify-boilerplate/action.yml
+++ b/.github/actions/verify-boilerplate/action.yml
@@ -67,11 +67,45 @@ runs:
         BASE_REF: ${{ inputs.base-ref || github.base_ref || github.event.repository.default_branch || 'master' }}
         BOILERPLATE_DIR: ${{ inputs.boilerplate-dir }}
       run: |
-        ARGS=("--base-ref" "${BASE_REF}")
+        set -euo pipefail
 
-        if [[ -n "${BOILERPLATE_DIR}" ]]; then
-          ARGS+=("--boilerplate-dir" "${BOILERPLATE_DIR}")
+        action_root="$(cd "${GITHUB_ACTION_PATH}/../../.." && pwd)"
+        script="${action_root}/hack/boilerplate/boilerplate.py"
+        if [[ ! -f "${script}" ]]; then
+          echo "::error::boilerplate.py not found at ${script}. The action" \
+               "expects to run from a checkout of kubeflow/testing."
+          exit 1
         fi
 
-        python "${GITHUB_ACTION_PATH}/../../../hack/boilerplate/boilerplate.py" "${ARGS[@]}"
+        base_reference="${BASE_REFERENCE#refs/heads/}"
+        if [[ -z "${base_reference}" ]]; then
+          echo "::error::No base branch could be determined. Pass the" \
+               "base-reference input explicitly."
+          exit 1
+        fi
+
+        root_directory="${ROOT_DIRECTORY:-${GITHUB_WORKSPACE}}"
+        if ! git -C "${root_directory}" rev-parse --git-dir >/dev/null 2>&1; then
+          echo "::error::${root_directory} is not a Git checkout. Run" \
+               "actions/checkout with fetch-depth: 0 before this action, or" \
+               "set the root-directory input."
+          exit 1
+        fi
+        root_directory="$(cd "${root_directory}" && pwd)"
+
+        if [[ -n "${BOILERPLATE_DIRECTORY}" ]]; then
+          if [[ ! -d "${BOILERPLATE_DIRECTORY}" ]]; then
+            echo "::error::boilerplate-directory ${BOILERPLATE_DIRECTORY}" \
+                 "does not exist."
+            exit 1
+          fi
+          boilerplate_directory="$(cd "${BOILERPLATE_DIRECTORY}" && pwd)"
+        else
+          boilerplate_directory="${action_root}/hack/boilerplate"
+        fi
+
+        python3 "${script}" \
+          --rootdir "${root_directory}" \
+          --boilerplate-dir "${boilerplate_directory}" \
+          --base-ref "${base_reference}"
 


### PR DESCRIPTION
Fixes #1069

## What this PR does

Adds a reusable composite GitHub Action at `.github/actions/verify-boilerplate/` that wraps the existing `hack/boilerplate/boilerplate.py` script, so Kubeflow subprojects can enforce Apache 2.0 copyright headers without vendoring the script.

## Requirements checklist

- [x] **Composite action wrapping `hack/boilerplate/boilerplate.py`** — script is sourced directly from `kubeflow/testing` via `actions/checkout` with sparse-checkout, so callers never vendor it.
- [x] **Input for base ref** — `base-ref` input defaults to the PR base branch (`github.base_ref`), so only changed/new files are flagged for year-less header enforcement.
- [x] **Input for boilerplate template directory** — `boilerplate-dir` input lets repos with custom templates point to their own directory. Defaults to `kubeflow/testing`'s templates.
- [x] **Sets up Python** — includes a `setup-python` step (default `3.12`) so callers don't need to add one.
- [x] **Non-zero exit on failure** — the script already exits non-zero with remediation output; the action inherits this behavior.

## Usage

Callers can use this action in their workflows like:

```yaml
steps:
  - uses: actions/checkout@v4
    with:
      fetch-depth: 0

  - uses: kubeflow/testing/.github/actions/verify-boilerplate@master
    with:
      base-ref: ${{ github.base_ref }}
```

## Context

- Tracking issue: #1069
- Related: kubeflow/sdk#765, kubeflow/sdk#566
